### PR TITLE
Adding some future use properties to settings.xml

### DIFF
--- a/TEdit/settings.xml
+++ b/TEdit/settings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Settings>
   <GlobalColors>
     <GlobalColor name="Sky" color="#FF9BD1FF" />
@@ -11,120 +11,120 @@
   <Tiles>
     <Tile num="0" name="Dirt" color="#ff916a4f" isSolid="true" />
     <Tile num="1" name="Stone" color="#ff808080" isSolid="true" />
-    <Tile num="2" name="Grass" color="#ff1cd85e" isSolid="true" />
-    <Tile num="3" name="Plants" color="#ff0d6524" isFramed="true" isSolid="true" />
-    <Tile num="4" name="Torches" color="#fffd3e03" isSolid="true" />
-    <Tile num="5" name="Trees" color="#ff634631" isFramed="true" isSolid="true" />
+    <Tile num="2" name="Grass" color="#ff1cd85e" isSolid="true" growsOn="0" />
+    <Tile num="3" name="Plants" color="#ff0d6524" isFramed="true" isSolid="true" growsOn="2" />
+    <Tile num="4" name="Torch" color="#fffd3e03" isSolid="true" lightBrightness="100%" isHouseItem="true" placement="wallFloor" />
+    <Tile num="5" name="Trees" color="#ff634631" isFramed="true" isSolid="true" growsOn="2" />
     <Tile num="6" name="Iron" color="#ff6b594e" isSolid="true" />
     <Tile num="7" name="Copper" color="#ffc6561d" isSolid="true" />
     <Tile num="8" name="Gold" color="#ffb9a417" isSolid="true" />
     <Tile num="9" name="Silver" color="#ffd9dfdf" isSolid="true" />
-    <Tile num="10" name="Door Closed" color="#ff00fff2" isFramed="true" isSolid="true" />
-    <Tile num="11" name="Door Open" color="#ff00fff2" isFramed="true" isSolid="true" />
-    <Tile num="12" name="HeartStone" color="#ffff0000" isFramed="true" />
-    <Tile num="13" name="Bottle" color="#ff00fff2" isFramed="true" />
-    <Tile num="14" name="Table" color="#ff00fff2" isFramed="true" isSolidTop="true" />
-    <Tile num="15" name="Chair" color="#ff00fff2" isFramed="true" />
-    <Tile num="16" name="Anvil" color="#ff00fff2" isFramed="true" isSolidTop="true" />
-    <Tile num="17" name="Furnace" color="#ff00fff2" isFramed="true" />
-    <Tile num="18" name="Workbench" color="#ff00fff2" isFramed="true" isSolidTop="true" />
-    <Tile num="19" name="Wooden Platform" color="#ff6B3A18" isSolid="true" isSolidTop="true" />
-    <Tile num="20" name="Decorative Plants" color="#ff0d6524" isFramed="true" />
-    <Tile num="21" name="Chest" color="#ffDDB800" isFramed="true" />
+    <Tile num="10" name="Door Closed" color="#ff00fff2" isFramed="true" isSolid="true" size="1x3" placement="CFBoth" />
+    <Tile num="11" name="Door Open" color="#ff00fff2" isFramed="true" isSolid="true" size="2x3" placement="CFBoth" />
+    <Tile num="12" name="Crystal Heart" color="#ffff0000" isFramed="true" size="2x2" placement="floor" />
+    <Tile num="13" name="Bottle" color="#ff00fff2" isFramed="true" placement="surface" />
+    <Tile num="14" name="Table" color="#ff00fff2" isFramed="true" size="3x2" isSolidTop="true" placement="floor" isHouseItem="true" />
+    <Tile num="15" name="Chair" color="#ff00fff2" isFramed="true" size="1x2" isHouseItem="true" placement="floor" />
+    <Tile num="16" name="Anvil" color="#ff00fff2" isFramed="true" size="2x1" isSolidTop="true" placement="floor" />
+    <Tile num="17" name="Furnace" color="#ff00fff2" isFramed="true" size="3x2" lightBrightness="80%" placement="floor" />
+    <Tile num="18" name="Workbench" color="#ff00fff2" isFramed="true" size="2x1" isSolidTop="true" isHouseItem="true" placement="floor" />
+    <Tile num="19" name="Wooden Platform" color="#ff6B3A18" isSolid="true" isSolidTop="true" placement="wall" />
+    <Tile num="20" name="Decorative Plants" color="#ff0d6524" isFramed="true" growsOn="2" />
+    <Tile num="21" name="Chest" color="#ffDDB800" isFramed="true" size="2x2" placement="floor" />
     <Tile num="22" name="Demonite" color="#ff625fa7" isSolid="true" />
-    <Tile num="23" name="Corruption Grass" color="#ff8d89df" isSolid="true" />
-    <Tile num="24" name="Corruption Plants" color="#ff8d89df" isFramed="true" />
+    <Tile num="23" name="Corruption Grass" color="#ff8d89df" isSolid="true" growsOn="0" />
+    <Tile num="24" name="Corruption Plants" color="#ff8d89df" isFramed="true" growsOn="23" />
     <Tile num="25" name="Ebonstone" color="#ff4b4a82" isSolid="true" />
-    <Tile num="26" name="Demon Altar" color="#ff9000FF" isFramed="true" />
-    <Tile num="27" name="Sunflower" color="#ffC4FF14" isFramed="true" />
-    <Tile num="28" name="Pot" color="#ff8C2726" isFramed="true" />
-    <Tile num="29" name="PiggyBank" color="#ff00fff2" isFramed="true" />
-    <Tile num="30" name="BlockWood" color="#ff684934" isSolid="true" />
-    <Tile num="31" name="ShadowOrb" color="#ff000000" isFramed="true" />
-    <Tile num="32" name="Corruption Vines" color="#ff7a618f" />
-    <Tile num="33" name="Candle" color="#fffd3e03" isFramed="true" />
-    <Tile num="34" name="Chandler Copper" color="#fffd3e03" isFramed="true" />
-    <Tile num="35" name="Chandler Silver" color="#fffd3e03" isFramed="true" />
-    <Tile num="36" name="Chandler Gold" color="#fffd3e03" isFramed="true" />
-    <Tile num="37" name="Meterorite" color="#ffdf9f89" isSolid="true" />
+    <Tile num="26" name="Demon Altar" color="#ff9000FF" isFramed="true" size="3x2" placement="floor" />
+    <Tile num="27" name="Sunflower" color="#ffC4FF14" isFramed="true" growsOn="2" />
+    <Tile num="28" name="Pot" color="#ff8C2726" isFramed="true" size="2x2" placement="floor" />
+    <Tile num="29" name="Piggy Bank" color="#ff00fff2" isFramed="true" size="2x1" placement="surface" />
+    <Tile num="30" name="Block Wood" color="#ff684934" isSolid="true" />
+    <Tile num="31" name="Shadow Orb" color="#ff000000" isFramed="true" size="2x2" placement="floor" />
+    <Tile num="32" name="Corruption Vines" color="#ff7a618f" contactDmg="10" growsOn="23" />
+    <Tile num="33" name="Candle" color="#fffd3e03" isFramed="true" lightBrightness="100%" isHouseItem="true" placement="surface" />
+    <Tile num="34" name="Chandler Copper" color="#fffd3e03" isFramed="true" size="3x3" lightBrightness="100%" isHouseItem="true" placement="ceiling" />
+    <Tile num="35" name="Chandler Silver" color="#fffd3e03" isFramed="true" size="3x3" lightBrightness="100%" isHouseItem="true" placement="ceiling" />
+    <Tile num="36" name="Chandler Gold" color="#fffd3e03" isFramed="true" size="3x3" lightBrightness="100%" isHouseItem="true" placement="ceiling" />
+    <Tile num="37" name="Meteorite" color="#ffdf9f89" isSolid="true" contactDmg="20" />
     <Tile num="38" name="Block Stone" color="#ff909090" isSolid="true" />
     <Tile num="39" name="Block Red Stone" color="#ffb200ff" isSolid="true" />
     <Tile num="40" name="Clay" color="#ffac5b4d" isSolid="true" />
     <Tile num="41" name="Block Blue Stone" color="#ff545498" isSolid="true" />
-    <Tile num="42" name="Light Globe" color="#ffef904b" isFramed="true" />
+    <Tile num="42" name="Chain Lantern" color="#ffef904b" isFramed="true" size="1x2" placement="ceiling" />
     <Tile num="43" name="Block Green Stone" color="#ff39A851" isSolid="true" />
     <Tile num="44" name="Block Pink Stone" color="#ffB200FF" isSolid="true" />
     <Tile num="45" name="Block Gold" color="#ffFFD514" isSolid="true" />
     <Tile num="46" name="Block Silver" color="#ffE5E5E5" isSolid="true" />
     <Tile num="47" name="Block Copper" color="#ffFF5900" isSolid="true" />
-    <Tile num="48" name="Spikes" color="#ff6d6d6d" isSolid="true" />
-    <Tile num="49" name="Candle Blue" color="#ff2B8FFF" />
-    <Tile num="50" name="Books" color="#ff00fff2" isFramed="true" />
+    <Tile num="48" name="Spikes" color="#ff6d6d6d" isSolid="true" contactDmg="40" placement="floor" />
+    <Tile num="49" name="Water Candle" color="#ff2B8FFF" lightBrightness="75%" placement="surface" />
+    <Tile num="50" name="Books" color="#ff00fff2" isFramed="true" placement="surface" />
     <Tile num="51" name="Web" color="#ffffffff" />
-    <Tile num="52" name="Vines" color="#ff0d6524" />
+    <Tile num="52" name="Vines" color="#ff0d6524" hangsOn="2" />
     <Tile num="53" name="Sand" color="#ffffda38" isSolid="true" />
     <Tile num="54" name="Glass" color="#40FFFFFF" isSolid="true" />
-    <Tile num="55" name="Sign" color="#ffFFAE5E" isFramed="true" />
+    <Tile num="55" name="Sign" color="#ffFFAE5E" isFramed="true" size="2x2" placement="wallFloorCeiling" />
     <Tile num="56" name="Obsidian" color="#ff5751ad" isSolid="true" />
     <Tile num="57" name="Ash" color="#ff44444c" isSolid="true" />
-    <Tile num="58" name="Hellstone" color="#ff662222" isSolid="true" />
+    <Tile num="58" name="Hellstone" color="#ff662222" isSolid="true" contactDmg="20" />
     <Tile num="59" name="Mud" color="#ff5c4449" isSolid="true" />
-    <Tile num="60" name="Jungle Grass" color="#ff8fd71d" isSolid="true" />
-    <Tile num="61" name="Jungle Plants" color="#ff8fd71d" isFramed="true" />
-    <Tile num="62" name="Jungle Vines" color="#ff8ace1c" />
+    <Tile num="60" name="Jungle Grass" color="#ff8fd71d" isSolid="true" growsOn="59" />
+    <Tile num="61" name="Jungle Plants" color="#ff8fd71d" isFramed="true" growsOn="60" />
+    <Tile num="62" name="Jungle Vines" color="#ff8ace1c" hangsOn="60" />
     <Tile num="63" name="Gem Sapphire" color="#ff2a82fa" isSolid="true" />
     <Tile num="64" name="Gem Ruby" color="#ff2a82fa" isSolid="true" />
     <Tile num="65" name="Gem Emerald" color="#ff2a82fa" isSolid="true" />
     <Tile num="66" name="Gem Topaz" color="#ff2a82fa" isSolid="true" />
     <Tile num="67" name="Gem Amethyst" color="#ff2a82fa" isSolid="true" />
     <Tile num="68" name="Gem Diamond" color="#ff2a82fa" isSolid="true" />
-    <Tile num="69" name="Jungle Thorns" color="#ff5e3037" />
-    <Tile num="70" name="Mushroom Grass" color="#ff5d7fff" isSolid="true" />
-    <Tile num="71" name="Mushroom Plants" color="#ffb1ae83" isFramed="true" />
-    <Tile num="72" name="Mushroom Trees" color="#ff968f6e" isFramed="true" />
+    <Tile num="69" name="Jungle Thorns" color="#ff5e3037" contactDmg="25" growsOn="60" />
+    <Tile num="70" name="Mushroom Grass" color="#ff5d7fff" isSolid="true" growsOn="59" />
+    <Tile num="71" name="Mushroom Plants" color="#ffb1ae83" isFramed="true" growsOn="70" />
+    <Tile num="72" name="Mushroom Trees" color="#ff968f6e" isFramed="true" growsOn="70" />
     <Tile num="73" name="Plants2" color="#ff0d6524" isFramed="true" />
     <Tile num="74" name="Plants3" color="#ff0d6524" isFramed="true" />
     <Tile num="75" name="Block Obsidian" color="#ffb200ff" isSolid="true" />
     <Tile num="76" name="Block Hellstone" color="#ffC6001D" isSolid="true" />
-    <Tile num="77" name="Hellforge" color="#ffD50010" isFramed="true" />
-    <Tile num="78" name="Decorative Pot" color="#ff00fff2" isFramed="true" />
-    <Tile num="79" name="Bed" color="#ff00fff2" isFramed="true" />
-    <Tile num="80" name="Cactus" color="#ff00a500" />
-    <Tile num="81" name="Coral" color="#ffe55340" isFramed="true" />
+    <Tile num="77" name="Hellforge" color="#ffD50010" isFramed="true" size="3x2" lightBrightness="80%" placement="floor" />
+    <Tile num="78" name="Decorative Pot" color="#ff00fff2" isFramed="true" size="2x2" placement="floor" />
+    <Tile num="79" name="Bed" color="#ff00fff2" isFramed="true" size="4x2" isHouseItem="true" placement="floor" />
+    <Tile num="80" name="Cactus" color="#ff00a500" contactDmg="10" growsOn="53" />
+    <Tile num="81" name="Coral" color="#ffe55340" isFramed="true" growsOn="53" />
     <Tile num="82" name="Herb Sprouts" color="#ffff7800" isFramed="true" />
     <Tile num="83" name="Herb Stalks" color="#ffff7800" isFramed="true" />
     <Tile num="84" name="Herbs" color="#ffff7800" isFramed="true" />
-    <Tile num="85" name="Tombstone" color="#ffc0c0c0" isFramed="true" />
-    <Tile num="86" name="Loom" color="#ffff00ff" isFramed="true" />
-    <Tile num="87" name="Piano" color="#ff00fff2" isFramed="true" isSolidTop="true" />
-    <Tile num="88" name="Dresser" color="#ff00fff2" isFramed="true" isSolidTop="true" />
-    <Tile num="89" name="Bench" color="#ff00fff2" isFramed="true" />
-    <Tile num="90" name="Bathtub" color="#ff00fff2" isFramed="true" />
-    <Tile num="91" name="Banner" color="#ff00fff2" isFramed="true" />
-    <Tile num="92" name="Street Lamp" color="#ff00fff2" isFramed="true" />
-    <Tile num="93" name="Tiki Torch" color="#ff00fff2" isFramed="true" />
-    <Tile num="94" name="Keg" color="#ff00fff2" isFramed="true" />
-    <Tile num="95" name="Chinese Lantern" color="#ff00fff2" isFramed="true" />
-    <Tile num="96" name="Cooking Pot" color="#ff00fff2" isFramed="true" />
-    <Tile num="97" name="Safe" color="#ffff00ff" isFramed="true" />
-    <Tile num="98" name="Skull Lantern" color="#ffff00ff" isFramed="true" />
-    <Tile num="99" name="Trash Can" color="#ffff00D0" isFramed="true" />
-    <Tile num="100" name="Candelabra" color="#ffff00ff" isFramed="true" />
-    <Tile num="101" name="Bookcase" color="#ffff00ff" isFramed="true" isSolidTop="true" />
-    <Tile num="102" name="Throne" color="#ffff00ff" isFramed="true" />
-    <Tile num="103" name="Plate" color="#ffff00ff" isFramed="true" />
-    <Tile num="104" name="GrandFather Clock" color="#ffff00ff" isFramed="true" />
-    <Tile num="105" name="Statue" color="#ff00fff2" isFramed="true" />
-    <Tile num="106" name="Sawmill" color="#ff00fff2" isFramed="true" />
+    <Tile num="85" name="Tombstone" color="#ffc0c0c0" isFramed="true" size="2x2" placement="floor" />
+    <Tile num="86" name="Loom" color="#ffff00ff" isFramed="true" size="3x2" placement="floor" />
+    <Tile num="87" name="Piano" color="#ff00fff2" isFramed="true" size="3x2" isSolidTop="true" placement="floor" />
+    <Tile num="88" name="Dresser" color="#ff00fff2" isFramed="true" size="3x2" isSolidTop="true" isHouseItem="true" placement="floor" />
+    <Tile num="89" name="Bench" color="#ff00fff2" isFramed="true" size="3x2" isHouseItem="true" placement="floor" />
+    <Tile num="90" name="Bathtub" color="#ff00fff2" isFramed="true" size="4x2" isHouseItem="true" placement="floor" />
+    <Tile num="91" name="Banner" color="#ff00fff2" isFramed="true" size="1x3" placement="ceiling" />
+    <Tile num="92" name="Lamp Post" color="#ff00fff2" isFramed="true" size="1x6" lightBrightness="100%" placement="floor" />
+    <Tile num="93" name="Tiki Torch" color="#ff00fff2" isFramed="true" size="1x3" lightBrightness="100%" placement="floor" />
+    <Tile num="94" name="Keg" color="#ff00fff2" isFramed="true" size="2x2" placement="floor" />
+    <Tile num="95" name="Chinese Lantern" color="#ff00fff2" isFramed="true" size="2x2" lightBrightness="85%" placement="floorSurface" />
+    <Tile num="96" name="Cooking Pot" color="#ff00fff2" isFramed="true" size="2x2" placement="floorSurface" />
+    <Tile num="97" name="Safe" color="#ffff00ff" isFramed="true" size="2x2" placement="floor" />
+    <Tile num="98" name="Skull Lantern" color="#ffff00ff" isFramed="true" size="2x2" lightBrightness="100%" placement="floorSurface" />
+    <Tile num="99" name="Trash Can" color="#ffff00D0" isFramed="true" size="2x2" placement="floor" />
+    <Tile num="100" name="Candelabra" color="#ffff00ff" isFramed="true" size="2x2" lightBrightness="100%" placement="surface" />
+    <Tile num="101" name="Bookcase" color="#ffff00ff" isFramed="true" size="3x4" isSolidTop="true" isHouseItem="true" placement="floor" />
+    <Tile num="102" name="Throne" color="#ffff00ff" isFramed="true" size="3x4" isHouseItem="true" placement="floor" />
+    <Tile num="103" name="Plate" color="#ffff00ff" isFramed="true" size="2x1" placement="surface" />
+    <Tile num="104" name="Grandfather Clock" color="#ffff00ff" isFramed="true" size="2x5" placement="floor" />
+    <Tile num="105" name="Statue" color="#ff00fff2" isFramed="true" size="2x3" placement="floor" />
+    <Tile num="106" name="Sawmill" color="#ff00fff2" isFramed="true" size="3x3" placement="floor" />
   </Tiles>
   <Walls>
     <Wall num="0" name="Sky" color="#00000000" />
-    <Wall num="1" name="WallStone" color="#ff424242" isHouse="true"  />
+    <Wall num="1" name="WallStone" color="#ff424242" isHouse="true" />
     <Wall num="2" name="WallDirt" color="#ff583d2e" />
     <Wall num="3" name="WallCorruption" color="#ff312545" />
-    <Wall num="4" name="WallWood" color="#ff4a2e1c" isHouse="true"  />
-    <Wall num="5" name="WallBrick" color="#ff454545" isHouse="true"  />
-    <Wall num="6" name="WallRed" color="#ff500000" isHouse="true"  />
+    <Wall num="4" name="WallWood" color="#ff4a2e1c" isHouse="true" />
+    <Wall num="5" name="WallBrick" color="#ff454545" isHouse="true" />
+    <Wall num="6" name="WallRed" color="#ff500000" isHouse="true" />
     <Wall num="7" name="WallBlue" color="#ff000060" />
     <Wall num="8" name="WallGreen" color="#ff005000" />
     <Wall num="9" name="WallPink" color="#ff48004F" />
@@ -134,387 +134,387 @@
     <Wall num="13" name="WallHellstone" color="#ff3F0707" />
     <Wall num="14" name="WallObsidian" color="#ff000060" />
     <Wall num="15" name="WallMud" color="#ff005500" />
-    <Wall num="16" name="WallPlayerDirt" color="#ff583d2e" isHouse="true"  />
-    <Wall num="17" name="WallPlayerBlue" color="#ff000043" isHouse="true"  />
-    <Wall num="18" name="WallPlayerGreen" color="#ff003700" isHouse="true"  />
-    <Wall num="19" name="WallPlayerPink" color="#ff330037" isHouse="true"  />
-    <Wall num="20" name="WallPlayerObsidian" color="#ff000060" isHouse="true"  />
+    <Wall num="16" name="WallPlayerDirt" color="#ff583d2e" isHouse="true" />
+    <Wall num="17" name="WallPlayerBlue" color="#ff000043" isHouse="true" />
+    <Wall num="18" name="WallPlayerGreen" color="#ff003700" isHouse="true" />
+    <Wall num="19" name="WallPlayerPink" color="#ff330037" isHouse="true" />
+    <Wall num="20" name="WallPlayerObsidian" color="#ff000060" isHouse="true" />
   </Walls>
   <Items>
     <Item num="0" name="[empty]" />
-    <Item num="1" name="Iron Pickaxe" />
-    <Item num="2" name="Dirt Block" />
-    <Item num="3" name="Stone Block" />
-    <Item num="4" name="Iron Broadsword" />
-    <Item num="5" name="Mushroom" />
-    <Item num="6" name="Iron Shortsword" />
-    <Item num="7" name="Iron Hammer" />
-    <Item num="8" name="Torch" />
-    <Item num="9" name="Wood" />
-    <Item num="10" name="Iron Axe" />
-    <Item num="11" name="Iron Ore" />
-    <Item num="12" name="Copper Ore" />
-    <Item num="13" name="Gold Ore" />
-    <Item num="14" name="Silver Ore" />
-    <Item num="15" name="Copper Watch" />
-    <Item num="16" name="Silver Watch" />
-    <Item num="17" name="Gold Watch" />
-    <Item num="18" name="Depth Meter" />
-    <Item num="19" name="Gold Bar" />
-    <Item num="20" name="Copper Bar" />
-    <Item num="21" name="Silver Bar" />
-    <Item num="22" name="Iron Bar" />
-    <Item num="23" name="Gel" />
-    <Item num="24" name="Wooden Sword" />
-    <Item num="25" name="Wooden Door" />
-    <Item num="26" name="Stone Wall" />
-    <Item num="27" name="Acorn" />
-    <Item num="28" name="Lesser Healing Potion" />
-    <Item num="29" name="Life Crystal" />
-    <Item num="30" name="Dirt Wall" />
-    <Item num="31" name="Bottle" />
-    <Item num="32" name="Wooden Table" />
-    <Item num="33" name="Furnace" />
-    <Item num="34" name="Wooden Chair" />
-    <Item num="35" name="Iron Anvil" />
-    <Item num="36" name="Work Bench" />
-    <Item num="37" name="Goggles" />
-    <Item num="38" name="Lens" />
-    <Item num="39" name="Wooden Bow" />
-    <Item num="40" name="Wooden Arrow" />
-    <Item num="41" name="Flaming Arrow" />
-    <Item num="42" name="Shuriken" />
-    <Item num="43" name="Suspicious Looking Eye" />
-    <Item num="44" name="Demon Bow" />
-    <Item num="45" name="War Axe of the Night" />
-    <Item num="46" name="Light's Bane" />
-    <Item num="47" name="Unholy Arrow" />
-    <Item num="48" name="Chest" />
-    <Item num="49" name="Band of Regeneration" />
-    <Item num="50" name="Magic Mirror" />
-    <Item num="51" name="Jester's Arrow" />
-    <Item num="52" name="Angel Statue" />
-    <Item num="53" name="Cloud in a Bottle" />
-    <Item num="54" name="Hermes Boots" />
-    <Item num="55" name="Enchanted Boomerang" />
-    <Item num="56" name="Demonite Ore" />
-    <Item num="57" name="Demonite Bar" />
-    <Item num="58" name="Heart" />
-    <Item num="59" name="Corrupt Seeds" />
-    <Item num="60" name="Vile Mushroom" />
-    <Item num="61" name="Ebonstone Block" />
-    <Item num="62" name="Grass Seeds" />
-    <Item num="63" name="Sunflower" />
-    <Item num="64" name="Vilethorn" />
-    <Item num="65" name="Starfury" />
-    <Item num="66" name="Purification Powder" />
-    <Item num="67" name="Vile Powder" />
-    <Item num="68" name="Rotten Chunk" />
-    <Item num="69" name="Worm Tooth" />
-    <Item num="70" name="Worm Food" />
-    <Item num="71" name="Copper Coin" />
-    <Item num="72" name="Silver Coin" />
-    <Item num="73" name="Gold Coin" />
-    <Item num="74" name="Platinum Coin" />
-    <Item num="75" name="Fallen Star" />
-    <Item num="76" name="Copper Greaves" />
-    <Item num="77" name="Iron Greaves" />
-    <Item num="78" name="Silver Greaves" />
-    <Item num="79" name="Gold Greaves" />
-    <Item num="80" name="Copper Chainmail" />
-    <Item num="81" name="Iron Chainmail" />
-    <Item num="82" name="Silver Chainmail" />
-    <Item num="83" name="Gold Chainmail" />
-    <Item num="84" name="Grappling Hook" />
-    <Item num="85" name="Iron Chain" />
-    <Item num="86" name="Shadow Scale" />
-    <Item num="87" name="Piggy Bank" />
-    <Item num="88" name="Mining Helmet" />
-    <Item num="89" name="Copper Helmet" />
-    <Item num="90" name="Iron Helmet" />
-    <Item num="91" name="Silver Helmet" />
-    <Item num="92" name="Gold Helmet" />
-    <Item num="93" name="Wood Wall" />
-    <Item num="94" name="Wood Platform" />
-    <Item num="95" name="Flintlock Pistol" />
-    <Item num="96" name="Musket" />
-    <Item num="97" name="Musket Ball" />
-    <Item num="98" name="Minishark" />
-    <Item num="99" name="Iron Bow" />
-    <Item num="100" name="Shadow Greaves" />
-    <Item num="101" name="Shadow Scalemail" />
-    <Item num="102" name="Shadow Helmet" />
-    <Item num="103" name="Nightmare Pickaxe" />
-    <Item num="104" name="The Breaker" />
-    <Item num="105" name="Candle" />
-    <Item num="106" name="Copper Chandelier" />
-    <Item num="107" name="Silver Chandelier" />
-    <Item num="108" name="Gold Chandelier" />
-    <Item num="109" name="Mana Crystal" />
-    <Item num="110" name="Lesser Mana Potion" />
-    <Item num="111" name="Band of Starpower" />
-    <Item num="112" name="Flower of Fire" />
-    <Item num="113" name="Magic Missile" />
-    <Item num="114" name="Dirt Rod" />
-    <Item num="115" name="Orb of Light" />
-    <Item num="116" name="Meteorite" />
-    <Item num="117" name="Meteorite Bar" />
-    <Item num="118" name="Hook" />
-    <Item num="119" name="Flamarang" />
-    <Item num="120" name="Molten Fury" />
-    <Item num="121" name="Fiery Greatsword" />
-    <Item num="122" name="Molten Pickaxe" />
-    <Item num="123" name="Meteor Helmet" />
-    <Item num="124" name="Meteor Suit" />
-    <Item num="125" name="Meteor Leggings" />
-    <Item num="126" name="Bottled Water" />
-    <Item num="127" name="Space Gun" />
-    <Item num="128" name="Rocket Boots" />
-    <Item num="129" name="Gray Brick" />
-    <Item num="130" name="Gray Brick Wall" />
-    <Item num="131" name="Red Brick" />
-    <Item num="132" name="Red Brick Wall" />
-    <Item num="133" name="Clay Block" />
-    <Item num="134" name="Blue Brick" />
-    <Item num="135" name="Blue Brick Wall" />
-    <Item num="136" name="Chain Lantern" />
-    <Item num="137" name="Green Brick" />
-    <Item num="138" name="Green Brick Wall" />
-    <Item num="139" name="Pink Brick" />
-    <Item num="140" name="Pink Brick Wall" />
-    <Item num="141" name="Gold Brick" />
-    <Item num="142" name="Gold Brick Wall" />
-    <Item num="143" name="Silver Brick" />
-    <Item num="144" name="Silver Brick Wall" />
-    <Item num="145" name="Copper Brick" />
-    <Item num="146" name="Copper Brick Wall" />
-    <Item num="147" name="Spike" />
-    <Item num="148" name="Water Candle" />
-    <Item num="149" name="Book" />
-    <Item num="150" name="Cobweb" />
-    <Item num="151" name="Necro Helmet" />
-    <Item num="152" name="Necro Breastplate" />
-    <Item num="153" name="Necro Greaves" />
-    <Item num="154" name="Bone" />
-    <Item num="155" name="Muramasa" />
-    <Item num="156" name="Cobalt Shield" />
-    <Item num="157" name="Aqua Scepter" />
-    <Item num="158" name="Lucky Horseshoe" />
-    <Item num="159" name="Shiny Red Balloon" />
-    <Item num="160" name="Harpoon" />
-    <Item num="161" name="Spiky Ball" />
-    <Item num="162" name="Ball O' Hurt" />
-    <Item num="163" name="Blue Moon" />
-    <Item num="164" name="Handgun" />
-    <Item num="165" name="Water Bolt" />
-    <Item num="166" name="Bomb" />
-    <Item num="167" name="Dynamite" />
-    <Item num="168" name="Grenade" />
-    <Item num="169" name="Sand Block" />
-    <Item num="170" name="Glass" />
-    <Item num="171" name="Sign" />
-    <Item num="172" name="Ash Block" />
-    <Item num="173" name="Obsidian" />
-    <Item num="174" name="Hellstone" />
-    <Item num="175" name="Hellstone Bar" />
-    <Item num="176" name="Mud Block" />
-    <Item num="181" name="Amethyst" />
-    <Item num="180" name="Topaz" />
-    <Item num="177" name="Sapphire" />
-    <Item num="179" name="Emerald" />
-    <Item num="178" name="Ruby" />
-    <Item num="182" name="Diamond" />
-    <Item num="183" name="Glowing Mushroom" />
-    <Item num="184" name="Star" />
-    <Item num="185" name="Ivy Whip" />
-    <Item num="186" name="Breathing Reed" />
-    <Item num="187" name="Flipper" />
-    <Item num="188" name="Healing Potion" />
-    <Item num="189" name="Mana Potion" />
-    <Item num="190" name="Blade of Grass" />
-    <Item num="191" name="Thorn Chakram" />
-    <Item num="192" name="Obsidian Brick" />
-    <Item num="193" name="Obsidian Skull" />
-    <Item num="194" name="Mushroom Grass Seeds" />
-    <Item num="195" name="Jungle Grass Seeds" />
-    <Item num="196" name="Wooden Hammer" />
-    <Item num="197" name="Star Cannon" />
-    <Item num="198" name="Blue Phaseblade" />
-    <Item num="199" name="Red Phaseblade" />
-    <Item num="200" name="Green Phaseblade" />
-    <Item num="201" name="Purple Phaseblade" />
-    <Item num="202" name="White Phaseblade" />
-    <Item num="203" name="Yellow Phaseblade" />
-    <Item num="204" name="Meteor Hamaxe" />
-    <Item num="205" name="Empty Bucket" />
-    <Item num="206" name="Water Bucket" />
-    <Item num="207" name="Lava Bucket" />
-    <Item num="208" name="Jungle Rose" />
-    <Item num="209" name="Stinger" />
-    <Item num="210" name="Vine" />
-    <Item num="211" name="Feral Claws" />
-    <Item num="212" name="Anklet of the Wind" />
-    <Item num="213" name="Staff of Regrowth" />
-    <Item num="214" name="Hellstone Brick" />
-    <Item num="215" name="Whoopie Cushion" />
-    <Item num="216" name="Shackle" />
-    <Item num="217" name="Molten Hamaxe" />
-    <Item num="218" name="Flamelash" />
-    <Item num="219" name="Phoenix Blaster" />
-    <Item num="220" name="Sunfury" />
-    <Item num="221" name="Hellforge" />
-    <Item num="222" name="Clay Pot" />
-    <Item num="223" name="Nature's Gift" />
-    <Item num="224" name="Bed" />
-    <Item num="225" name="Silk" />
-    <Item num="226" name="Lesser Restoration Potion" />
-    <Item num="227" name="Restoration Potion" />
-    <Item num="228" name="Jungle Hat" />
-    <Item num="229" name="Jungle Shirt" />
-    <Item num="230" name="Jungle Pants" />
-    <Item num="231" name="Molten Helmet" />
-    <Item num="232" name="Molten Breastplate" />
-    <Item num="233" name="Molten Greaves" />
-    <Item num="234" name="Meteor Shot" />
-    <Item num="235" name="Sticky Bomb" />
-    <Item num="236" name="Black Lens" />
-    <Item num="237" name="Sunglasses" />
-    <Item num="238" name="Wizard Hat" />
-    <Item num="239" name="Top Hat" />
-    <Item num="240" name="Tuxedo Shirt" />
-    <Item num="241" name="Tuxedo Pants" />
-    <Item num="242" name="Summer Hat" />
-    <Item num="243" name="Bunny Hood" />
-    <Item num="244" name="Plumber's Hat" />
-    <Item num="245" name="Plumber's Shirt" />
-    <Item num="246" name="Plumber's Pants" />
-    <Item num="247" name="Hero's Hat" />
-    <Item num="248" name="Hero's Shirt" />
-    <Item num="249" name="Hero's Pants" />
-    <Item num="250" name="Fish Bowl" />
-    <Item num="251" name="Archaeologist's Hat" />
-    <Item num="252" name="Archaeologist's Jacket" />
-    <Item num="253" name="Archaeologist's Pants" />
-    <Item num="254" name="Black Dye" />
-    <Item num="255" name="Green Dye" />
-    <Item num="256" name="Ninja Hood" />
-    <Item num="257" name="Ninja Shirt" />
-    <Item num="258" name="Ninja Pants" />
-    <Item num="259" name="Leather" />
-    <Item num="260" name="Red Hat" />
-    <Item num="261" name="Goldfish" />
-    <Item num="262" name="Robe" />
-    <Item num="263" name="Robot Hat" />
-    <Item num="264" name="Gold Crown" />
-    <Item num="265" name="Hellfire Arrow" />
-    <Item num="266" name="Sandgun" />
-    <Item num="267" name="Guide Voodoo Doll" />
-    <Item num="268" name="Diving Helmet" />
-    <Item num="269" name="Familiar Shirt" />
-    <Item num="270" name="Familiar Pants" />
-    <Item num="271" name="Familiar Wig" />
-    <Item num="272" name="Demon Scythe" />
-    <Item num="273" name="Night's Edge" />
-    <Item num="274" name="Dark Lance" />
-    <Item num="275" name="Coral" />
-    <Item num="276" name="Cactus" />
-    <Item num="277" name="Trident" />
-    <Item num="278" name="Silver Bullet" />
-    <Item num="279" name="Throwing Knife" />
-    <Item num="280" name="Spear" />
-    <Item num="281" name="Blowpipe" />
-    <Item num="282" name="Glowstick" />
-    <Item num="283" name="Seed" />
-    <Item num="284" name="Wooden Boomerang" />
-    <Item num="285" name="Aglet" />
-    <Item num="286" name="Sticky Glowstick" />
-    <Item num="287" name="Poisoned Knife" />
-    <Item num="288" name="Obsidian Skin Potion" />
-    <Item num="289" name="Regeneration Potion" />
-    <Item num="290" name="Swiftness Potion" />
-    <Item num="291" name="Gills Potion" />
-    <Item num="292" name="Ironskin Potion" />
-    <Item num="293" name="Mana Regeneration Potion" />
-    <Item num="294" name="Magic Power Potion" />
-    <Item num="295" name="Featherfall Potion" />
-    <Item num="296" name="Spelunker Potion" />
-    <Item num="297" name="Invisibility Potion" />
-    <Item num="298" name="Shine Potion" />
-    <Item num="299" name="Night Owl Potion" />
-    <Item num="300" name="Battle Potion" />
-    <Item num="301" name="Thorns Potion" />
-    <Item num="302" name="Water Walking Potion" />
-    <Item num="303" name="Archery Potion" />
-    <Item num="304" name="Hunter Potion" />
-    <Item num="305" name="Gravitation Potion" />
-    <Item num="306" name="Gold Chest" />
-    <Item num="307" name="Daybloom Seeds" />
-    <Item num="308" name="Moonglow Seeds" />
-    <Item num="309" name="Blinkroot Seeds" />
-    <Item num="310" name="Deathweed Seeds" />
-    <Item num="311" name="Waterleaf Seeds" />
-    <Item num="312" name="Fireblossom Seeds" />
-    <Item num="313" name="Daybloom" />
-    <Item num="314" name="Moonglow" />
-    <Item num="315" name="Blinkroot" />
-    <Item num="316" name="Deathweed" />
-    <Item num="317" name="Waterleaf" />
-    <Item num="318" name="Fireblossom" />
-    <Item num="319" name="Shark Fin" />
-    <Item num="320" name="Feather" />
-    <Item num="321" name="Tombstone" />
-    <Item num="322" name="Mime Mask" />
-    <Item num="323" name="Antlion Mandible" />
-    <Item num="324" name="Illegal Gun Parts" />
-    <Item num="325" name="The Doctor's Shirt" />
-    <Item num="326" name="The Doctor's Pants" />
-    <Item num="327" name="Golden Key" />
-    <Item num="328" name="Shadow Chest" />
-    <Item num="329" name="Shadow Key" />
-    <Item num="330" name="Obsidian Brick Wall" />
-    <Item num="331" name="Jungle Spores" />
-    <Item num="332" name="Loom" />
-    <Item num="333" name="Piano" />
-    <Item num="334" name="Dresser" />
-    <Item num="335" name="Bench" />
-    <Item num="336" name="Bathtub" />
-    <Item num="337" name="Red Banner" />
-    <Item num="338" name="Green Banner" />
-    <Item num="339" name="Blue Banner" />
-    <Item num="340" name="Yellow Banner" />
-    <Item num="341" name="Lamp Post" />
-    <Item num="342" name="Tiki Torch" />
-    <Item num="343" name="Barrel" />
-    <Item num="344" name="Chinese Lantern" />
-    <Item num="345" name="Cooking Pot" />
-    <Item num="346" name="Safe" />
-    <Item num="347" name="Skull Lantern" />
-    <Item num="348" name="Trash Can" />
-    <Item num="349" name="Candelabra" />
-    <Item num="350" name="Pink Vase" />
-    <Item num="351" name="Mug" />
-    <Item num="352" name="Keg" />
-    <Item num="353" name="Ale" />
-    <Item num="354" name="Bookcase" />
-    <Item num="355" name="Throne" />
-    <Item num="356" name="Bowl" />
-    <Item num="357" name="Bowl of Soup" />
-    <Item num="358" name="Toilet" />
-    <Item num="359" name="Grandfather Clock" />
-    <Item num="360" name="Statue" />
-    <Item num="361" name="Goblin Battle Standard" />
-    <Item num="362" name="Tattered Cloth" />
-    <Item name="Silver Broadsword" />
-    <Item name="Silver Shortsword" />
-    <Item name="Gold Broadsword" />
-    <Item name="Gold Shortsword" />
-    <Item name="Copper Broadsword" />
-    <Item name="Copper Shortsword" />
-    <Item name="Silver Bow" />
-    <Item name="Gold Bow" />
-    <Item name="Copper Bow" />
-    <Item name="Copper Hammer" />
-    <Item name="Silver Hammer" />
-    <Item name="Gold Hammer" />
+    <Item num="1" name="Iron Pickaxe" type="tool" />
+    <Item num="2" name="Dirt Block" type="block" />
+    <Item num="3" name="Stone Block" type="block" />
+    <Item num="4" name="Iron Broadsword" type="weapon" />
+    <Item num="5" name="Mushroom" type="plant" />
+    <Item num="6" name="Iron Shortsword" type="weapon" />
+    <Item num="7" name="Iron Hammer" type="tool" />
+    <Item num="8" name="Torch" type="light" />
+    <Item num="9" name="Wood" type="block" />
+    <Item num="10" name="Iron Axe" type="tool" />
+    <Item num="11" name="Iron Ore" type="block" />
+    <Item num="12" name="Copper Ore" type="block" />
+    <Item num="13" name="Gold Ore" type="block" />
+    <Item num="14" name="Silver Ore" type="block" />
+    <Item num="15" name="Copper Watch" type="accessory" />
+    <Item num="16" name="Silver Watch" type="accessory" />
+    <Item num="17" name="Gold Watch" type="accessory" />
+    <Item num="18" name="Depth Meter" type="accessory" />
+    <Item num="19" name="Gold Bar" type="material" />
+    <Item num="20" name="Copper Bar" type="material" />
+    <Item num="21" name="Silver Bar" type="material" />
+    <Item num="22" name="Iron Bar" type="material" />
+    <Item num="23" name="Gel" type="material" />
+    <Item num="24" name="Wooden Sword" type="weapon" />
+    <Item num="25" name="Wooden Door" type="furniture" />
+    <Item num="26" name="Stone Wall" type="wall" />
+    <Item num="27" name="Acorn" type="plant" />
+    <Item num="28" name="Lesser Healing Potion" type="potion" />
+    <Item num="29" name="Life Crystal" type="consumable" />
+    <Item num="30" name="Dirt Wall" type="wall" />
+    <Item num="31" name="Bottle" type="material" />
+    <Item num="32" name="Wooden Table" type="furniture" />
+    <Item num="33" name="Furnace" type="furniture" />
+    <Item num="34" name="Wooden Chair" type="furniture" />
+    <Item num="35" name="Iron Anvil" type="furniture" />
+    <Item num="36" name="Work Bench" type="furniture" />
+    <Item num="37" name="Goggles" type="armor" />
+    <Item num="38" name="Lens" type="material" />
+    <Item num="39" name="Wooden Bow" type="weapon" />
+    <Item num="40" name="Wooden Arrow" type="ammo" />
+    <Item num="41" name="Flaming Arrow" type="ammo" />
+    <Item num="42" name="Shuriken" type="weapon" />
+    <Item num="43" name="Suspicious Looking Eye" type="consumable" />
+    <Item num="44" name="Demon Bow" type="weapon" />
+    <Item num="45" name="War Axe of the Night" type="weapon" />
+    <Item num="46" name="Light's Bane" type="weapon" />
+    <Item num="47" name="Unholy Arrow" type="ammo" />
+    <Item num="48" name="Chest" type="storage" />
+    <Item num="49" name="Band of Regeneration" type="accessory" />
+    <Item num="50" name="Magic Mirror" type="tool" />
+    <Item num="51" name="Jester's Arrow" type="ammo" />
+    <Item num="52" name="Angel Statue" type="furniture" />
+    <Item num="53" name="Cloud in a Bottle" type="accessory" />
+    <Item num="54" name="Hermes Boots" type="accessory" />
+    <Item num="55" name="Enchanted Boomerang" type="weapon" />
+    <Item num="56" name="Demonite Ore" type="block" />
+    <Item num="57" name="Demonite Bar" type="material" />
+    <Item num="58" name="Heart" type="consumable" />
+    <Item num="59" name="Corrupt Seeds" type="plant" />
+    <Item num="60" name="Vile Mushroom" type="plant" />
+    <Item num="61" name="Ebonstone Block" type="block" />
+    <Item num="62" name="Grass Seeds" type="plant" />
+    <Item num="63" name="Sunflower" type="plant" />
+    <Item num="64" name="Vilethorn" type="plant" />
+    <Item num="65" name="Starfury" type="weapon" />
+    <Item num="66" name="Purification Powder" type="tool" />
+    <Item num="67" name="Vile Powder" type="weapon" />
+    <Item num="68" name="Rotten Chunk" type="material" />
+    <Item num="69" name="Worm Tooth" type="material" />
+    <Item num="70" name="Worm Food" type="consumable" />
+    <Item num="71" name="Copper Coin" type="money" />
+    <Item num="72" name="Silver Coin" type="money" />
+    <Item num="73" name="Gold Coin" type="money" />
+    <Item num="74" name="Platinum Coin" type="money" />
+    <Item num="75" name="Fallen Star" type="material" />
+    <Item num="76" name="Copper Greaves" type="armor" />
+    <Item num="77" name="Iron Greaves" type="armor" />
+    <Item num="78" name="Silver Greaves" type="armor" />
+    <Item num="79" name="Gold Greaves" type="armor" />
+    <Item num="80" name="Copper Chainmail" type="armor" />
+    <Item num="81" name="Iron Chainmail" type="armor" />
+    <Item num="82" name="Silver Chainmail" type="armor" />
+    <Item num="83" name="Gold Chainmail" type="armor" />
+    <Item num="84" name="Grappling Hook" type="tool" />
+    <Item num="85" name="Iron Chain" type="material" />
+    <Item num="86" name="Shadow Scale" type="material" />
+    <Item num="87" name="Piggy Bank" type="storage" />
+    <Item num="88" name="Mining Helmet" type="armor" />
+    <Item num="89" name="Copper Helmet" type="armor" />
+    <Item num="90" name="Iron Helmet" type="armor" />
+    <Item num="91" name="Silver Helmet" type="armor" />
+    <Item num="92" name="Gold Helmet" type="armor" />
+    <Item num="93" name="Wood Wall" type="wall" />
+    <Item num="94" name="Wood Platform" type="furniture" />
+    <Item num="95" name="Flintlock Pistol" type="weapon" />
+    <Item num="96" name="Musket" type="weapon" />
+    <Item num="97" name="Musket Ball" type="ammo" />
+    <Item num="98" name="Minishark" type="weapon" />
+    <Item num="99" name="Iron Bow" type="weapon" />
+    <Item num="100" name="Shadow Greaves" type="armor" />
+    <Item num="101" name="Shadow Scalemail" type="armor" />
+    <Item num="102" name="Shadow Helmet" type="armor" />
+    <Item num="103" name="Nightmare Pickaxe" type="tool" />
+    <Item num="104" name="The Breaker" type="tool" />
+    <Item num="105" name="Candle" type="light" />
+    <Item num="106" name="Copper Chandelier" type="light" />
+    <Item num="107" name="Silver Chandelier" type="light" />
+    <Item num="108" name="Gold Chandelier" type="light" />
+    <Item num="109" name="Mana Crystal" type="consumable" />
+    <Item num="110" name="Lesser Mana Potion" type="potion" />
+    <Item num="111" name="Band of Starpower" type="accessory" />
+    <Item num="112" name="Flower of Fire" type="weapon" />
+    <Item num="113" name="Magic Missile" type="weapon" />
+    <Item num="114" name="Dirt Rod" type="weapon" />
+    <Item num="115" name="Orb of Light" type="light" />
+    <Item num="116" name="Meteorite" type="block" />
+    <Item num="117" name="Meteorite Bar" type="material" />
+    <Item num="118" name="Hook" type="material" />
+    <Item num="119" name="Flamarang" type="weapon" />
+    <Item num="120" name="Molten Fury" type="weapon" />
+    <Item num="121" name="Fiery Greatsword" type="weapon" />
+    <Item num="122" name="Molten Pickaxe" type="tool" />
+    <Item num="123" name="Meteor Helmet" type="armor" />
+    <Item num="124" name="Meteor Suit" type="armor" />
+    <Item num="125" name="Meteor Leggings" type="armor" />
+    <Item num="126" name="Bottled Water" type="material" />
+    <Item num="127" name="Space Gun" type="weapon" />
+    <Item num="128" name="Rocket Boots" type="accessory" />
+    <Item num="129" name="Gray Brick" type="block" />
+    <Item num="130" name="Gray Brick Wall" type="wall" />
+    <Item num="131" name="Red Brick" type="block" />
+    <Item num="132" name="Red Brick Wall" type="wall" />
+    <Item num="133" name="Clay Block" type="block" />
+    <Item num="134" name="Blue Brick" type="block" />
+    <Item num="135" name="Blue Brick Wall" type="wall" />
+    <Item num="136" name="Chain Lantern" type="light" />
+    <Item num="137" name="Green Brick" type="block" />
+    <Item num="138" name="Green Brick Wall" type="wall" />
+    <Item num="139" name="Pink Brick" type="block" />
+    <Item num="140" name="Pink Brick Wall" type="wall" />
+    <Item num="141" name="Gold Brick" type="block" />
+    <Item num="142" name="Gold Brick Wall" type="wall" />
+    <Item num="143" name="Silver Brick" type="block" />
+    <Item num="144" name="Silver Brick Wall" type="wall" />
+    <Item num="145" name="Copper Brick" type="block" />
+    <Item num="146" name="Copper Brick Wall" type="wall" />
+    <Item num="147" name="Spike" type="furniture" />
+    <Item num="148" name="Water Candle" type="light" />
+    <Item num="149" name="Book" type="furniture" />
+    <Item num="150" name="Cobweb" type="material" />
+    <Item num="151" name="Necro Helmet" type="armor" />
+    <Item num="152" name="Necro Breastplate" type="armor" />
+    <Item num="153" name="Necro Greaves" type="armor" />
+    <Item num="154" name="Bone" type="material" />
+    <Item num="155" name="Muramasa" type="weapon" />
+    <Item num="156" name="Cobalt Shield" type="accessory" />
+    <Item num="157" name="Aqua Scepter" type="weapon" />
+    <Item num="158" name="Lucky Horseshoe" type="accessory" />
+    <Item num="159" name="Shiny Red Balloon" type="accessory" />
+    <Item num="160" name="Harpoon" type="weapon" />
+    <Item num="161" name="Spiky Ball" type="consumable" />
+    <Item num="162" name="Ball O' Hurt" type="weapon" />
+    <Item num="163" name="Blue Moon" type="weapon" />
+    <Item num="164" name="Handgun" type="weapon" />
+    <Item num="165" name="Water Bolt" type="weapon" />
+    <Item num="166" name="Bomb" type="weapon" />
+    <Item num="167" name="Dynamite" type="weapon" />
+    <Item num="168" name="Grenade" type="weapon" />
+    <Item num="169" name="Sand Block" type="block" />
+    <Item num="170" name="Glass" type="block" />
+    <Item num="171" name="Sign" type="furniture" />
+    <Item num="172" name="Ash Block" type="block" />
+    <Item num="173" name="Obsidian" type="block" />
+    <Item num="174" name="Hellstone" type="block" />
+    <Item num="175" name="Hellstone Bar" type="material" />
+    <Item num="176" name="Mud Block" type="block" />
+    <Item num="181" name="Amethyst" type="material" />
+    <Item num="180" name="Topaz" type="material" />
+    <Item num="177" name="Sapphire" type="material" />
+    <Item num="179" name="Emerald" type="material" />
+    <Item num="178" name="Ruby" type="material" />
+    <Item num="182" name="Diamond" type="material" />
+    <Item num="183" name="Glowing Mushroom" type="plant" />
+    <Item num="184" name="Star" type="consumable" />
+    <Item num="185" name="Ivy Whip" type="accessory" />
+    <Item num="186" name="Breathing Reed" type="accessory" />
+    <Item num="187" name="Flipper" type="accessory" />
+    <Item num="188" name="Healing Potion" type="potion" />
+    <Item num="189" name="Mana Potion" type="potion" />
+    <Item num="190" name="Blade of Grass" type="weapon" />
+    <Item num="191" name="Thorn Chakram" type="weapon" />
+    <Item num="192" name="Obsidian Brick" type="block" />
+    <Item num="193" name="Obsidian Skull" type="accessory" />
+    <Item num="194" name="Mushroom Grass Seeds" type="plant" />
+    <Item num="195" name="Jungle Grass Seeds" type="plant" />
+    <Item num="196" name="Wooden Hammer" type="tool" />
+    <Item num="197" name="Star Cannon" type="weapon" />
+    <Item num="198" name="Blue Phaseblade" type="weapon" />
+    <Item num="199" name="Red Phaseblade" type="weapon" />
+    <Item num="200" name="Green Phaseblade" type="weapon" />
+    <Item num="201" name="Purple Phaseblade" type="weapon" />
+    <Item num="202" name="White Phaseblade" type="weapon" />
+    <Item num="203" name="Yellow Phaseblade" type="weapon" />
+    <Item num="204" name="Meteor Hamaxe" type="tool" />
+    <Item num="205" name="Empty Bucket" type="tool" />
+    <Item num="206" name="Water Bucket" type="tool" />
+    <Item num="207" name="Lava Bucket" type="tool" />
+    <Item num="208" name="Jungle Rose" type="plant" />
+    <Item num="209" name="Stinger" type="material" />
+    <Item num="210" name="Vine" type="material" />
+    <Item num="211" name="Feral Claws" type="accessory" />
+    <Item num="212" name="Anklet of the Wind" type="accessory" />
+    <Item num="213" name="Staff of Regrowth" type="weapon" />
+    <Item num="214" name="Hellstone Brick" type="block" />
+    <Item num="215" name="Whoopie Cushion" type="tool" />
+    <Item num="216" name="Shackle" type="accessory" />
+    <Item num="217" name="Molten Hamaxe" type="tool" />
+    <Item num="218" name="Flamelash" type="weapon" />
+    <Item num="219" name="Phoenix Blaster" type="weapon" />
+    <Item num="220" name="Sunfury" type="weapon" />
+    <Item num="221" name="Hellforge" type="furniture" />
+    <Item num="222" name="Clay Pot" type="furniture" />
+    <Item num="223" name="Nature's Gift" type="accessory" />
+    <Item num="224" name="Bed" type="furniture" />
+    <Item num="225" name="Silk" type="material" />
+    <Item num="226" name="Lesser Restoration Potion" type="potion" />
+    <Item num="227" name="Restoration Potion" type="potion" />
+    <Item num="228" name="Jungle Hat" type="armor" />
+    <Item num="229" name="Jungle Shirt" type="armor" />
+    <Item num="230" name="Jungle Pants" type="armor" />
+    <Item num="231" name="Molten Helmet" type="armor" />
+    <Item num="232" name="Molten Breastplate" type="armor" />
+    <Item num="233" name="Molten Greaves" type="armor" />
+    <Item num="234" name="Meteor Shot" type="ammo" />
+    <Item num="235" name="Sticky Bomb" type="weapon" />
+    <Item num="236" name="Black Lens" type="material" />
+    <Item num="237" name="Sunglasses" type="armor" />
+    <Item num="238" name="Wizard Hat" type="armor" />
+    <Item num="239" name="Top Hat" type="armor" />
+    <Item num="240" name="Tuxedo Shirt" type="armor" />
+    <Item num="241" name="Tuxedo Pants" type="armor" />
+    <Item num="242" name="Summer Hat" type="armor" />
+    <Item num="243" name="Bunny Hood" type="armor" />
+    <Item num="244" name="Plumber's Hat" type="armor" />
+    <Item num="245" name="Plumber's Shirt" type="armor" />
+    <Item num="246" name="Plumber's Pants" type="armor" />
+    <Item num="247" name="Hero's Hat" type="armor" />
+    <Item num="248" name="Hero's Shirt" type="armor" />
+    <Item num="249" name="Hero's Pants" type="armor" />
+    <Item num="250" name="Fish Bowl" type="armor" />
+    <Item num="251" name="Archaeologist's Hat" type="armor" />
+    <Item num="252" name="Archaeologist's Jacket" type="armor" />
+    <Item num="253" name="Archaeologist's Pants" type="armor" />
+    <Item num="254" name="Black Dye" type="material" />
+    <Item num="255" name="Green Dye" type="material" />
+    <Item num="256" name="Ninja Hood" type="armor" />
+    <Item num="257" name="Ninja Shirt" type="armor" />
+    <Item num="258" name="Ninja Pants" type="armor" />
+    <Item num="259" name="Leather" type="material" />
+    <Item num="260" name="Red Hat" type="armor" />
+    <Item num="261" name="Goldfish" type="consumable" />
+    <Item num="262" name="Robe" type="armor" />
+    <Item num="263" name="Robot Hat" type="armor" />
+    <Item num="264" name="Gold Crown" type="armor" />
+    <Item num="265" name="Hellfire Arrow" type="ammo" />
+    <Item num="266" name="Sandgun" type="weapon" />
+    <Item num="267" name="Guide Voodoo Doll" type="accessory" />
+    <Item num="268" name="Diving Helmet" type="armor" />
+    <Item num="269" name="Familiar Shirt" type="armor" />
+    <Item num="270" name="Familiar Pants" type="armor" />
+    <Item num="271" name="Familiar Wig" type="armor" />
+    <Item num="272" name="Demon Scythe" type="weapon" />
+    <Item num="273" name="Night's Edge" type="weapon" />
+    <Item num="274" name="Dark Lance" type="weapon" />
+    <Item num="275" name="Coral" type="material" />
+    <Item num="276" name="Cactus" type="plant" />
+    <Item num="277" name="Trident" type="weapon" />
+    <Item num="278" name="Silver Bullet" type="ammo" />
+    <Item num="279" name="Throwing Knife" type="weapon" />
+    <Item num="280" name="Spear" type="weapon" />
+    <Item num="281" name="Blowpipe" type="weapon" />
+    <Item num="282" name="Glowstick" type="light" />
+    <Item num="283" name="Seed" type="plant" />
+    <Item num="284" name="Wooden Boomerang" type="weapon" />
+    <Item num="285" name="Aglet" type="accessory" />
+    <Item num="286" name="Sticky Glowstick" type="light" />
+    <Item num="287" name="Poisoned Knife" type="weapon" />
+    <Item num="288" name="Obsidian Skin Potion" type="potion" />
+    <Item num="289" name="Regeneration Potion" type="potion" />
+    <Item num="290" name="Swiftness Potion" type="potion" />
+    <Item num="291" name="Gills Potion" type="potion" />
+    <Item num="292" name="Ironskin Potion" type="potion" />
+    <Item num="293" name="Mana Regeneration Potion" type="potion" />
+    <Item num="294" name="Magic Power Potion" type="potion" />
+    <Item num="295" name="Featherfall Potion" type="potion" />
+    <Item num="296" name="Spelunker Potion" type="potion" />
+    <Item num="297" name="Invisibility Potion" type="potion" />
+    <Item num="298" name="Shine Potion" type="potion" />
+    <Item num="299" name="Night Owl Potion" type="potion" />
+    <Item num="300" name="Battle Potion" type="potion" />
+    <Item num="301" name="Thorns Potion" type="potion" />
+    <Item num="302" name="Water Walking Potion" type="potion" />
+    <Item num="303" name="Archery Potion" type="potion" />
+    <Item num="304" name="Hunter Potion" type="potion" />
+    <Item num="305" name="Gravitation Potion" type="potion" />
+    <Item num="306" name="Gold Chest" type="storage" />
+    <Item num="307" name="Daybloom Seeds" type="plant" />
+    <Item num="308" name="Moonglow Seeds" type="plant" />
+    <Item num="309" name="Blinkroot Seeds" type="plant" />
+    <Item num="310" name="Deathweed Seeds" type="plant" />
+    <Item num="311" name="Waterleaf Seeds" type="plant" />
+    <Item num="312" name="Fireblossom Seeds" type="plant" />
+    <Item num="313" name="Daybloom" type="plant" />
+    <Item num="314" name="Moonglow" type="plant" />
+    <Item num="315" name="Blinkroot" type="plant" />
+    <Item num="316" name="Deathweed" type="plant" />
+    <Item num="317" name="Waterleaf" type="plant" />
+    <Item num="318" name="Fireblossom" type="plant" />
+    <Item num="319" name="Shark Fin" type="material" />
+    <Item num="320" name="Feather" type="material" />
+    <Item num="321" name="Tombstone" type="furniture" />
+    <Item num="322" name="Mime Mask" type="armor" />
+    <Item num="323" name="Antlion Mandible" type="material" />
+    <Item num="324" name="Illegal Gun Parts" type="material" />
+    <Item num="325" name="The Doctor's Shirt" type="armor" />
+    <Item num="326" name="The Doctor's Pants" type="armor" />
+    <Item num="327" name="Golden Key" type="tool" />
+    <Item num="328" name="Shadow Chest" type="storage" />
+    <Item num="329" name="Shadow Key" type="tool" />
+    <Item num="330" name="Obsidian Brick Wall" type="wall" />
+    <Item num="331" name="Jungle Spores" type="plant" />
+    <Item num="332" name="Loom" type="furniture" />
+    <Item num="333" name="Piano" type="furniture" />
+    <Item num="334" name="Dresser" type="furniture" />
+    <Item num="335" name="Bench" type="furniture" />
+    <Item num="336" name="Bathtub" type="furniture" />
+    <Item num="337" name="Red Banner" type="furniture" />
+    <Item num="338" name="Green Banner" type="furniture" />
+    <Item num="339" name="Blue Banner" type="furniture" />
+    <Item num="340" name="Yellow Banner" type="furniture" />
+    <Item num="341" name="Lamp Post" type="light" />
+    <Item num="342" name="Tiki Torch" type="light" />
+    <Item num="343" name="Barrel" type="storage" />
+    <Item num="344" name="Chinese Lantern" type="light" />
+    <Item num="345" name="Cooking Pot" type="furniture" />
+    <Item num="346" name="Safe" type="storage" />
+    <Item num="347" name="Skull Lantern" type="light" />
+    <Item num="348" name="Trash Can" type="storage" />
+    <Item num="349" name="Candelabra" type="light" />
+    <Item num="350" name="Pink Vase" type="furniture" />
+    <Item num="351" name="Mug" type="material" />
+    <Item num="352" name="Keg" type="furniture" />
+    <Item num="353" name="Ale" type="potion" />
+    <Item num="354" name="Bookcase" type="furniture" />
+    <Item num="355" name="Throne" type="furniture" />
+    <Item num="356" name="Bowl" type="material" />
+    <Item num="357" name="Bowl of Soup" type="potion" />
+    <Item num="358" name="Toilet" type="furniture" />
+    <Item num="359" name="Grandfather Clock" type="furniture" />
+    <Item num="360" name="Statue" type="furniture" />
+    <Item num="361" name="Goblin Battle Standard" type="consumable" />
+    <Item num="362" name="Tattered Cloth" type="material" />
+    <Item name="Silver Broadsword" type="weapon" />
+    <Item name="Silver Shortsword" type="weapon" />
+    <Item name="Gold Broadsword" type="weapon" />
+    <Item name="Gold Shortsword" type="weapon" />
+    <Item name="Copper Broadsword" type="weapon" />
+    <Item name="Copper Shortsword" type="weapon" />
+    <Item name="Silver Bow" type="weapon" />
+    <Item name="Gold Bow" type="weapon" />
+    <Item name="Copper Bow" type="weapon" />
+    <Item name="Copper Hammer" type="tool" />
+    <Item name="Silver Hammer" type="tool" />
+    <Item name="Gold Hammer" type="tool" />
   </Items>
 </Settings>


### PR DESCRIPTION
Adding some future use properties to the XML.  I'm using this XML for a new Perl Games::RolePlay::MapGen::GeneratorPlugin::Terraria module, and having a source for all item properties would also help out TEdit to remove hard-coded references.

The goal here is to have a universal settings.xml file that can be used for multiple programs to be able to identify and build items and blocks in Terraria maps.  So far, the changes to the XML shouldn't have any effect on TEdit until you start using the properties.

The following properties have been added:
- In Tile:
  - size="WxH"
    - Standard size of this block for any frame.  Must have isFramed="true" to be useful, else size defaults to 1x1.
  - isHouseItem = If this object is required to make a house, this is set.  This can be used with other properties to identify all of the house objects:
    - isSolidTop = True to both means it's a Flat Surface item
    - lightBrightness = True + non-zero means it's a Light item for a house
    - If it doesn't match either of those and isHouseItem="true", then it's a Comfort item
  - placement=any|floor|surface|floorSurface|wall|ceiling|wallFloor|wallFloorCeiling|CFBoth
    - any = default if missing; like a block, which could even float in the air
    - floor = must be on the floor, affected by gravity
    - surface = must be on a SolidTop surface object
    - floorSurface = floor or surface
    - wall = must be attached to a wall
    - ceiling = must be attached to the ceiling
    - wallFloor = wall or floor
    - wallFloorCeiling = wall or floor or ceiling (rare, signs have these)
    - CFBoth = must be attached to both the ceiling AND floor (rare, doors have these)
  - lightBrightness="###%"
    - Brightness level of object; more importantly, non-zero means it's a light object
  - contactDmg="##"
    - Amount of damage it causes if touched.  This is useful to know that, for example, Hellstone blocks are probably going to kill an NPC, so the program should either warn or refuse to put a NPC there if he's going to die all the time.
  - growsOn="##"
    - This automatically classifies the object as a plant and gives the tile # of the block that it's supposed to grow on.  A program could warn/refuse to place the X object unless it's on top of itself or tile Y.  These objects also don't need a placement property, since this essentially overrides that purpose.
  - hangsOn="##"
    - Just like growsOn, but used for vines.
- In Item:
  - type=tool|weapon|armor|accessory|block|light|storage|wall|furniture|plant|
    material|potion|consumable|ammo|money
    - tool = Pickaxe, Hammer, Axe, etc.
    - weapon = All weapons, including swords, staffs, consumable weapons (like Throwing Knives), etc.
    - armor = All items that fit into armor slot (including vanity; might split those off later on)
    - accessory = All items that fit into accessory slots
    - block = Blocks that are normally gathered through mining
    - light = Items that are primarily used as a light source, ie: Torch, Candles, etc.
    - storage = All storage furniture, including Chests, Barrels, Trash Cans, etc.
    - wall = All wall objects
    - furniture = All furniture, both decorative and crafting stations (might split later on)
    - plant = All plants (supersedes all other categories)
    - material = Objects that are primarily used for crafting material
    - potion = All items called "Potion" or containers of liquid that buff character
    - consumable = Other items that are one-use only
    - ammo = Objects that are primarily used for gun/bow ammo
    - money = Objects that go directly in the money slots

This should cover most of the universe of properties needed for Terraria.  Of course, other properties could be added, like item cost, weapon damage, etc., but the goal is having this data for building maps and only growing it if more data is actually needed.

One last item: I said that this XML should not hamper TEdit's function, and I've tested that it does indeed ignore the properties.  I am also going to include some children of Tile called "Frame".  Now, while I've tested a single child seems to not have any problems, I still want to bundle that change in as a separate Pull Request.  This new Frame tag should cover all of the "hidden" objects within the tiles and remove the need for Schematics for all of the framed objects.

Email me or reply if you want to discuss this further.
