### PR TITLE
Changes make TEdit show tile and wall textures

### DIFF
--- a/TEditXna/Editor/Clipboard/ClipboardManager.cs
+++ b/TEditXna/Editor/Clipboard/ClipboardManager.cs
@@ -10,6 +10,7 @@ using BCCL.Utility;
 using TEditXna.ViewModel;
 using XNA = Microsoft.Xna.Framework;
 using TEditXNA.Terraria;
+using TEditXna.Terraria.Objects;
 
 namespace TEditXna.Editor.Clipboard
 {
@@ -220,6 +221,9 @@ namespace TEditXna.Editor.Clipboard
                 }
             }
             _wvm.UndoManager.SaveUndo();
+
+            /* Heathtech */
+            BlendRules.ResetUVCache(_wvm, anchor.X, anchor.Y, buffer.Size.X, buffer.Size.Y);
         }
     }
 }

--- a/TEditXna/Editor/Tools/BrushTool.cs
+++ b/TEditXna/Editor/Tools/BrushTool.cs
@@ -7,6 +7,7 @@ using System.Windows.Media.Imaging;
 using BCCL.Geometry;
 using BCCL.Geometry.Primitives;
 using TEditXna.ViewModel;
+using TEditXna.Terraria.Objects;
 
 namespace TEditXna.Editor.Tools
 {
@@ -149,6 +150,9 @@ namespace TEditXna.Editor.Tools
                     {
                         _wvm.UndoManager.SaveTile(pixel);
                         _wvm.SetPixel(pixel.X, pixel.Y);
+
+                        /* Heathtech */
+                        BlendRules.ResetUVCache(_wvm, pixel.X, pixel.Y, 1, 1);
                     }
                 }
             }
@@ -174,6 +178,9 @@ namespace TEditXna.Editor.Tools
                         {
                             _wvm.UndoManager.SaveTile(pixel);
                             _wvm.SetPixel(pixel.X, pixel.Y, mode: PaintMode.Tile);
+
+                            /* Heathtech */
+                            BlendRules.ResetUVCache(_wvm, pixel.X, pixel.Y, 1, 1);
                         }
                     }
                 }
@@ -193,6 +200,9 @@ namespace TEditXna.Editor.Tools
                     {
                         _wvm.SetPixel(pixel.X, pixel.Y, mode: PaintMode.Wall);
                     }
+
+                    /* Heathtech */
+                    BlendRules.ResetUVCache(_wvm, pixel.X, pixel.Y, 1, 1);
                 }
             }
         }

--- a/TEditXna/Editor/Tools/FillTool.cs
+++ b/TEditXna/Editor/Tools/FillTool.cs
@@ -6,6 +6,7 @@ using BCCL.Geometry.Primitives;
 using Microsoft.Xna.Framework;
 using TEditXNA.Terraria;
 using TEditXna.ViewModel;
+using TEditXna.Terraria.Objects;
 
 namespace TEditXna.Editor.Tools
 {
@@ -132,9 +133,12 @@ namespace TEditXna.Editor.Tools
                 lFillLoc--;
                 tileIndex--;
                 if (lFillLoc <= 0 || _wvm.CheckTiles[tileIndex] || !CheckTileMatch(ref originTile, ref _wvm.CurrentWorld.Tiles[lFillLoc, y]) || !_wvm.Selection.IsValid(lFillLoc, y))
-                    break;			 	 //exit loop if we're at edge of bitmap or color area
+                    break; //exit loop if we're at edge of bitmap or color area
 
             }
+            /* Heathtech */
+            BlendRules.ResetUVCache(_wvm, lFillLoc + 1, y, x - lFillLoc, 1);
+
             lFillLoc++;
             if (lFillLoc < _minX)
                 _minX = lFillLoc;
@@ -149,14 +153,17 @@ namespace TEditXna.Editor.Tools
                     _wvm.SetPixel(rFillLoc, y);
                     _wvm.UpdateRenderPixel(rFillLoc, y);
                     _wvm.CheckTiles[tileIndex] = true;
+                    BlendRules.ResetUVCache(_wvm, rFillLoc, y, 1, 1);
                 }
 
                 rFillLoc++;
                 tileIndex++;
                 if (rFillLoc >= bitmapWidth || _wvm.CheckTiles[tileIndex] || !CheckTileMatch(ref originTile, ref _wvm.CurrentWorld.Tiles[rFillLoc, y]) || !_wvm.Selection.IsValid(rFillLoc, y))
-                    break;			 	 //exit loop if we're at edge of bitmap or color area
-
+                    break; //exit loop if we're at edge of bitmap or color area
             }
+            /* Heathtech */
+            BlendRules.ResetUVCache(_wvm, x, y, rFillLoc - x, 1);
+
             rFillLoc--;
             if (rFillLoc > _maxX)
                 _maxX = rFillLoc;

--- a/TEditXna/Editor/Tools/MorphTool.cs
+++ b/TEditXna/Editor/Tools/MorphTool.cs
@@ -7,6 +7,7 @@ using BCCL.Geometry;
 using BCCL.Geometry.Primitives;
 using TEditXna.ViewModel;
 using System.Linq;
+using TEditXna.Terraria.Objects;
 
 namespace TEditXna.Editor.Tools
 {
@@ -212,6 +213,9 @@ namespace TEditXna.Editor.Tools
                         _wvm.UndoManager.SaveTile(pixel);
                         MorphTile(pixel);
                         _wvm.UpdateRenderPixel(pixel);
+
+                        /* Heathtech */
+                        BlendRules.ResetUVCache(_wvm, pixel.X, pixel.Y, 1, 1);
                     }
                 }
             }

--- a/TEditXna/Editor/Tools/PasteTool.cs
+++ b/TEditXna/Editor/Tools/PasteTool.cs
@@ -4,6 +4,7 @@ using System.Windows.Media.Imaging;
 using BCCL.Geometry.Primitives;
 using Microsoft.Xna.Framework;
 using TEditXna.ViewModel;
+using TEditXna.Terraria.Objects;
 
 namespace TEditXna.Editor.Tools
 {
@@ -43,6 +44,9 @@ namespace TEditXna.Editor.Tools
         {
             _wvm.Clipboard.PasteBufferIntoWorld(anchor);
             _wvm.UpdateRenderRegion(new Rectangle(anchor.X, anchor.Y, _wvm.Clipboard.Buffer.Size.X, _wvm.Clipboard.Buffer.Size.Y));
+
+            /* Heathtech */
+            BlendRules.ResetUVCache(_wvm, anchor.X, anchor.Y, _wvm.Clipboard.Buffer.Size.X, _wvm.Clipboard.Buffer.Size.Y);
         }
     }
 }

--- a/TEditXna/Editor/Tools/PencilTool.cs
+++ b/TEditXna/Editor/Tools/PencilTool.cs
@@ -4,6 +4,8 @@ using System.Windows.Media.Imaging;
 using BCCL.Geometry;
 using BCCL.Geometry.Primitives;
 using TEditXna.ViewModel;
+using TEditXNA.Terraria;
+using TEditXna.Terraria.Objects;
 
 namespace TEditXna.Editor.Tools
 {
@@ -83,6 +85,9 @@ namespace TEditXna.Editor.Tools
                     {
                         _wvm.UndoManager.SaveTile(pixel);
                         _wvm.SetPixel(pixel.X, pixel.Y);
+
+                        /* Heathtech */
+                        BlendRules.ResetUVCache(_wvm, pixel.X, pixel.Y, 1, 1);
                     }
                 }
             }

--- a/TEditXna/Editor/Tools/SpriteTool.cs
+++ b/TEditXna/Editor/Tools/SpriteTool.cs
@@ -3,6 +3,7 @@ using System.Windows.Media.Imaging;
 using BCCL.Geometry.Primitives;
 using TEditXNA.Terraria;
 using TEditXna.ViewModel;
+using TEditXna.Terraria.Objects;
 
 namespace TEditXna.Editor.Tools
 {
@@ -50,6 +51,9 @@ namespace TEditXna.Editor.Tools
             }
             
             _wvm.UndoManager.SaveUndo();
+
+            /* Heathtech */
+            BlendRules.ResetUVCache(_wvm, e.Location.X, e.Location.Y, _wvm.SelectedSprite.Size.X, _wvm.SelectedSprite.Size.Y);
         }
 
         public override WriteableBitmap PreviewTool()

--- a/TEditXna/Editor/Undo/UndoManager.cs
+++ b/TEditXna/Editor/Undo/UndoManager.cs
@@ -6,6 +6,7 @@ using BCCL.Geometry.Primitives;
 using BCCL.MvvmLight;
 using TEditXNA.Terraria;
 using TEditXna.ViewModel;
+using TEditXna.Terraria.Objects;
 
 namespace TEditXna.Editor.Undo
 {
@@ -162,6 +163,9 @@ namespace TEditXna.Editor.Undo
 
                 _wvm.CurrentWorld.Tiles[undoTile.Location.X, undoTile.Location.Y] = (Tile)undoTile.Tile.Clone();
                 _wvm.UpdateRenderPixel(undoTile.Location);
+
+                /* Heathtech */
+                BlendRules.ResetUVCache(_wvm, undoTile.Location.X, undoTile.Location.Y, 1, 1);
             }
             foreach (var chest in buffer.Chests)
             {
@@ -199,6 +203,9 @@ namespace TEditXna.Editor.Undo
 
                 _wvm.CurrentWorld.Tiles[undoTile.Location.X, undoTile.Location.Y] = (Tile)undoTile.Tile.Clone();
                 _wvm.UpdateRenderPixel(undoTile.Location);
+
+                /* Heathtech */
+                BlendRules.ResetUVCache(_wvm, undoTile.Location.X, undoTile.Location.Y, 1, 1);
             }
             foreach (var chest in buffer.Chests)
             {

--- a/TEditXna/TEditXna.csproj
+++ b/TEditXna/TEditXna.csproj
@@ -16,7 +16,7 @@
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <IsWebBootstrapper>false</IsWebBootstrapper>
-    <PublishUrl>publish\</PublishUrl>
+    <PublishUrl>C:\Users\Heath\Documents\Visual Studio 2010\Projects\TEdit\dist\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
     <UpdateEnabled>false</UpdateEnabled>
@@ -26,9 +26,10 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationRevision>1</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
+    <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
@@ -55,7 +56,25 @@
   <PropertyGroup>
     <ApplicationIcon>Images\tedit.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <ManifestCertificateThumbprint>CAF2D5DB3BBE06CCAB4B692C63136E5B71CFF6D9</ManifestCertificateThumbprint>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ManifestKeyFile>TEditXna_TemporaryKey.pfx</ManifestKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GenerateManifests>true</GenerateManifests>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignManifests>true</SignManifests>
+  </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BCCL">
+      <HintPath>..\BCCL.dll</HintPath>
+    </Reference>
+    <Reference Include="BCCL.Xna">
+      <HintPath>..\BCCL.Xna.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" />
     <Reference Include="Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" />
     <Reference Include="System" />
@@ -122,6 +141,7 @@
     <Compile Include="Terraria\Chest.cs" />
     <Compile Include="Terraria\Item.cs" />
     <Compile Include="Terraria\NPC.cs" />
+    <Compile Include="Terraria\Objects\BlendRules.cs" />
     <Compile Include="Terraria\Objects\Enums.cs" />
     <Compile Include="Terraria\Objects\FrameProperty.cs" />
     <Compile Include="Terraria\Objects\ItemProperty.cs" />
@@ -286,16 +306,7 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <AppDesigner Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\BCCL\BCCL.Xna\BCCL.Xna.csproj">
-      <Project>{B1417485-BD24-4A20-A931-BC8659BB33A9}</Project>
-      <Name>BCCL.Xna</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\BCCL\BCCL\BCCL.csproj">
-      <Project>{3D233DE2-586B-49F1-8E83-86399078EAE6}</Project>
-      <Name>BCCL</Name>
-    </ProjectReference>
+    <None Include="TEditXna_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Images\Overlays\dungeon_marker.png" />
@@ -342,12 +353,12 @@
     <Resource Include="Images\Toolbar\arrow_undo.png" />
     <Resource Include="Images\Toolbar\new.png" />
     <EmbeddedResource Include="Images\Overlays\grid.png" />
-    <Content Include="settings.xml">
-      <SubType>Designer</SubType>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Resource Include="settings.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+  </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0,Profile=Client">
       <Visible>False</Visible>
@@ -378,11 +389,11 @@
   </ProjectExtensions>
   <PropertyGroup>
     <PostBuildEvent>
-7z a -tzip "$(ProjectDir)..\TEdit_3.1.0.0.zip" "$(TargetDir)*" -mx9 -y
-7z a -tzip "$(ProjectDir)..\TEdit_3.1.0.0.zip" "$(ProjectDir)..\README" -mx9 -y</PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>del "$(ProjectDir)..\TEdit_3.1.0.0.zip"</PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TEditXna/Terraria/Objects/TileProperty.cs
+++ b/TEditXna/Terraria/Objects/TileProperty.cs
@@ -20,6 +20,13 @@ namespace TEditXNA.Terraria.Objects
         private FramePlacement _placement;
         private Vector2Short _textureGrid;
 
+        private bool _isGrass; /* Heathtech */
+        private bool _isPlatform; /* Heathtech */
+        private bool _isCactus; /* Heathtech */
+        private bool _isStone; /* Heathtech */
+        private bool _canBlend; /* Heathtech */
+        private int? _mergeWith; /* Heathtech */
+
         public TileProperty()
         {
             _frameSize = new Vector2Short(1, 1);
@@ -27,6 +34,12 @@ namespace TEditXNA.Terraria.Objects
             _id = -1;
             _name = "UNKNOWN";
             _isFramed = false;
+            _isGrass = false; /* Heathtech */
+            _isPlatform = false; /* Heathtech */
+            _isCactus = false; /* Heathtech */
+            _isStone = false; /* Heathtech */
+            _canBlend = false; /* Heathtech */
+            _mergeWith = null; /* Heathtech */
         }
 
         public Vector2Short TextureGrid
@@ -109,5 +122,46 @@ namespace TEditXNA.Terraria.Objects
             set { Set("Image", ref _image, value); }
         }
 
+        /* Heathtech */
+        public bool IsGrass
+        {
+            get { return _isGrass; }
+            set { Set("IsGrass", ref _isGrass, value); }
+        }
+
+        /* Heathtech */
+        public bool IsPlatform
+        {
+            get { return _isPlatform; }
+            set { Set("IsPlatform", ref _isPlatform, value); }
+        }
+
+        /* Heathtech */
+        public bool IsCactus
+        {
+            get { return _isCactus; }
+            set { Set("IsCactus", ref _isCactus, value); }
+        }
+
+        /* Heathtech */
+        public bool IsStone
+        {
+            get { return _isStone; }
+            set { Set("IsStone", ref _isStone, value); }
+        }
+
+        /* Heathtech */
+        public bool CanBlend
+        {
+            get { return _canBlend; }
+            set { Set("CanBlend", ref _canBlend, value); }
+        }
+
+        /* Heathtech */
+        public int? MergeWith
+        {
+            get { return _mergeWith; }
+            set { Set("MergeWith", ref _mergeWith, value); }
+        }
     }
 }

--- a/TEditXna/Terraria/Textures.cs
+++ b/TEditXna/Terraria/Textures.cs
@@ -17,6 +17,8 @@ namespace TEditXNA.Terraria
         private readonly Dictionary<int, Texture2D> _treeBranches = new Dictionary<int, Texture2D>();
         private readonly Dictionary<int, Texture2D> _shrooms = new Dictionary<int, Texture2D>();
         private readonly Dictionary<int, Texture2D> _npcs = new Dictionary<int, Texture2D>();
+        private readonly Dictionary<int, Texture2D> _liquids = new Dictionary<int, Texture2D>(); /* Heathtech */
+        private readonly Dictionary<string, Texture2D> _misc = new Dictionary<string, Texture2D>(); /* Heathtech */
 
         public Dictionary<int, Texture2D> Tiles {get { return _tiles; } }
         public Dictionary<int, Texture2D> Backgrounds { get { return _backgrounds; } }
@@ -25,6 +27,8 @@ namespace TEditXNA.Terraria
         public Dictionary<int, Texture2D> TreeBranches { get { return _treeBranches; } }
         public Dictionary<int, Texture2D> Shrooms { get { return _shrooms; } }
         public Dictionary<int, Texture2D> Npcs { get { return _npcs; } }
+        public Dictionary<int, Texture2D> Liquids { get { return _liquids; } } /* Heathtech */
+        public Dictionary<string, Texture2D> Misc { get { return _misc; } } /* Heathtech */
         readonly ContentManager _cm;
         public ContentManager ContentManager
         {
@@ -62,8 +66,16 @@ namespace TEditXNA.Terraria
         {
             if (!Tiles.ContainsKey(num))
             {
-                string name = String.Format("Images\\Tiles_{0}", num);
-                Tiles[num] = LoadTexture(name);
+                try
+                {
+                    string name = String.Format("Images\\Tiles_{0}", num);
+                    Tiles[num] = LoadTexture(name);
+                }
+                catch
+                {
+                    string name = String.Format("CustomGFX\\Tiles_{0}", num + 50);
+                    Tiles[num] = LoadTexture(name);
+                }
             }
             return Tiles[num];
         }
@@ -120,6 +132,26 @@ namespace TEditXNA.Terraria
                 Npcs[num] = LoadTexture(name);
             }
             return Npcs[num];
+        }
+        /* Heathtech */
+        public Texture GetLiquid(int num)
+        {
+            if (!Liquids.ContainsKey(num))
+            {
+                string name = String.Format("Images\\Liquid_{0}", num);
+                Liquids[num] = LoadTexture(name);
+            }
+            return Liquids[num];
+        }
+        /* Heathtech */
+        public Texture GetMisc(string name)
+        {
+            if (!Misc.ContainsKey(name))
+            {
+                string texName = String.Format("Images\\{0}", name);
+                Misc[name] = LoadTexture(texName);
+            }
+            return Misc[name];
         }
 
         private static Color ColorKey = Color.FromNonPremultiplied(247, 119, 249, 255);

--- a/TEditXna/Terraria/Tile.cs
+++ b/TEditXna/Terraria/Tile.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BCCL.Geometry.Primitives;
 
 namespace TEditXNA.Terraria
 {
@@ -13,6 +14,15 @@ namespace TEditXNA.Terraria
         public byte Wall;
         public byte Liquid;
         public Int16 U, V;
+
+        [NonSerialized] /* Heathtech */
+        public ushort uvTileCache = 0xFFFF; //Caches the UV position of a tile, since it is costly to generate each frame
+        [NonSerialized] /* Heathtech */
+        public ushort uvWallCache = 0xFFFF; //Caches the UV position of a wall tile
+        [NonSerialized] /* Heathtech */
+        public byte lazyMergeId = 0xFF; //The ID here refers to a number that helps blocks know whether they are actually merged with a nearby tile
+        [NonSerialized] /* Heathtech */
+        public bool hasLazyChecked = false; //Whether the above check has taken place
 
         #region BitFlags
         //private const int IsActivePosition = 0;

--- a/TEditXna/Terraria/World.Settings.cs
+++ b/TEditXna/Terraria/World.Settings.cs
@@ -15,7 +15,7 @@ namespace TEditXNA.Terraria
 {
     public partial class World
     {
-        public static uint CompatibleVersion = 39;
+        public static uint CompatibleVersion = 37;
         private static readonly Dictionary<string, XNA.Color> _globalColors = new Dictionary<string, XNA.Color>();
         private static readonly Dictionary<string, int> _npcIds = new Dictionary<string, int>();
         private static readonly Dictionary<byte, string> _prefix = new Dictionary<byte, string>();
@@ -126,6 +126,12 @@ namespace TEditXNA.Terraria
                 curTile.FrameSize = StringToVector2Short((string)xElement.Attribute("Size"), 1, 1);
                 curTile.Placement = InLineEnumTryParse<FramePlacement>((string)xElement.Attribute("Placement"));
                 curTile.TextureGrid = StringToVector2Short((string)xElement.Attribute("TextureGrid"), 16, 16);
+                curTile.IsGrass = "Grass".Equals((string)xElement.Attribute("Special")); /* Heathtech */
+                curTile.IsPlatform = "Platform".Equals((string)xElement.Attribute("Special")); /* Heathtech */
+                curTile.IsCactus = "Cactus".Equals((string)xElement.Attribute("Special")); /* Heathtech */
+                curTile.IsStone = (bool?)xElement.Attribute("Stone") ?? false; /* Heathtech */
+                curTile.CanBlend = (bool?)xElement.Attribute("Blends") ?? false; /* Heathtech */
+                curTile.MergeWith = (int?)xElement.Attribute("MergeWith") ?? null; /* Heathtech */
                 foreach (var elementFrame in xElement.Elements("Frames").Elements("Frame"))
                 {
 

--- a/TEditXna/View/WorldRenderXna.xaml.cs
+++ b/TEditXna/View/WorldRenderXna.xaml.cs
@@ -34,6 +34,7 @@ namespace TEditXna.View
         private Vector2 _scrollPosition = new Vector2(0, 0);
         private SimpleProvider _serviceProvider;
         private SpriteBatch _spriteBatch;
+        private SpriteBatch _overlayBatch; /* Heathtech */
         private Textures _textureDictionary;
         private Texture2D[] _tileMap;
         private Texture2D _preview;
@@ -133,6 +134,7 @@ namespace TEditXna.View
             // Load services, textures and initialize spritebatch
             _serviceProvider = new SimpleProvider(xnaViewport.GraphicsService);
             _spriteBatch = new SpriteBatch(e.GraphicsDevice);
+            _overlayBatch = new SpriteBatch(e.GraphicsDevice); /* Heathtech */
             _textureDictionary = new Textures(_serviceProvider);
         }
 
@@ -320,6 +322,9 @@ namespace TEditXna.View
             // Start SpriteBatch
             _spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
 
+            /* Heathtech */ // Start SpriteBatch for overlayed tiles
+            _overlayBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+
 
             // Draw Pixel Map tiles
 
@@ -328,6 +333,13 @@ namespace TEditXna.View
             // Draw sprite overlays
             if (_wvm.ShowTextures && _textureDictionary.Valid)
                 DrawSprites();
+
+            /* Heathtech */ // End SpriteBatch to apply proper blending
+            _spriteBatch.End();
+            _overlayBatch.End();
+
+            /* Heathtech */ // Startup SpriteBatch again to finish rendering
+            _spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
 
             if (_wvm.ShowGrid)
                 DrawGrid();
@@ -345,7 +357,6 @@ namespace TEditXna.View
                 DrawSelection();
 
             DrawToolPreview();
-
 
             // End SpriteBatch
             _spriteBatch.End();
@@ -405,84 +416,762 @@ namespace TEditXna.View
             }
 
         }
+
+        /* Heathtech */ //Pretty much overwrote this whole function.  The original part is still intact, but much more hidden
         private void DrawSprites()
         {
             Rectangle visibleBounds = GetViewingArea();
+            TEditXna.Terraria.Objects.BlendRules blendRules = TEditXna.Terraria.Objects.BlendRules.Instance;
             if (visibleBounds.Height * visibleBounds.Width < 25000)
             {
-                for (int x = visibleBounds.Left; x < visibleBounds.Right; x++)
+                //Extended the viewing space to give tiles time to cache their UV's
+                for (int y = visibleBounds.Top - 1; y < visibleBounds.Bottom + 2; y++)
                 {
-                    for (int y = visibleBounds.Top; y < visibleBounds.Bottom; y++)
+                    for (int x = visibleBounds.Left - 1; x < visibleBounds.Right + 2; x++)
                     {
+                        if (x < 0 || y < 0 || x >= _wvm.CurrentWorld.TilesWide || y >= _wvm.CurrentWorld.TilesHigh)
+                        {
+                            continue;
+                        }
+
                         var curtile = _wvm.CurrentWorld.Tiles[x, y];
                         var tileprop = World.TileProperties[curtile.Type];
-                        if (tileprop.IsFramed && curtile.IsActive)
+
+                        //Neighbor tiles are often used when dynamically determining which UV position to render
+                        int e = 0, n = 1, w = 2, s = 3, ne = 4, nw = 5, sw = 6, se = 7;
+                        Tile[] neighborTile = new Tile[8];
+                        neighborTile[e] = (x + 1) < _wvm.CurrentWorld.TilesWide ? _wvm.CurrentWorld.Tiles[x + 1, y] : null;
+                        neighborTile[n] = (y - 1) > 0 ? _wvm.CurrentWorld.Tiles[x, y - 1] : null;
+                        neighborTile[w] = (x - 1) > 0 ? _wvm.CurrentWorld.Tiles[x - 1, y] : null;
+                        neighborTile[s] = (y + 1) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x, y + 1] : null;
+                        neighborTile[ne] = (x + 1) < _wvm.CurrentWorld.TilesWide && (y - 1) > 0 ? _wvm.CurrentWorld.Tiles[x + 1, y - 1] : null;
+                        neighborTile[nw] = (x - 1) > 0 && (y - 1) > 0 ? _wvm.CurrentWorld.Tiles[x - 1, y - 1] : null;
+                        neighborTile[sw] = (x - 1) > 0 && (y + 1) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x - 1, y + 1] : null;
+                        neighborTile[se] = (x + 1) < _wvm.CurrentWorld.TilesWide && (y + 1) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x + 1, y + 1] : null;
+
+                        if (_wvm.ShowWalls)
                         {
-                            var source = new Rectangle(curtile.U, curtile.V, tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
-                            if (source.Width <= 0)
-                                source.Width = 16;
-                            if (source.Height <= 0)
-                                source.Height = 16;
-
-                            var tileTex = _textureDictionary.GetTile(curtile.Type);
-
-                            if (tileTex != null)
+                            if (curtile.Wall > 0)
                             {
-                                if (source.Bottom > tileTex.Height)
-                                    source.Height -= (source.Bottom - tileTex.Height);
-                                if (source.Right > tileTex.Width)
-                                    source.Width -= (source.Right - tileTex.Width);
+                                var wallTex = _textureDictionary.GetWall(curtile.Wall);
 
-                                if (source.Width <= 0 || source.Height <= 0)
-                                    continue;
-
-                                var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
-                                var texsize = tileprop.TextureGrid;
-                                if (texsize.X != 16 || texsize.Y != 16)
+                                if (wallTex != null)
                                 {
-                                    dest.Width = (int)(texsize.X * (_zoom / 16));
-                                    dest.Height = (int)(texsize.Y * (_zoom / 16));
-
-                                    var frame = (tileprop.Frames.FirstOrDefault(f => f.UV == new Vector2Short(curtile.U, curtile.V)));
-                                    var frameAnchor = FrameAnchor.None;
-                                    if (frame != null)
-                                        frameAnchor = frame.Anchor;
-                                    switch (frameAnchor)
+                                    if (curtile.uvWallCache == 0xFFFF)
                                     {
-                                        case FrameAnchor.None:
-                                            dest.X += (int)(((16 - texsize.X) / 2F) * _zoom / 16);
-                                            dest.Y += (int)(((16 - texsize.Y) / 2F) * _zoom / 16);
-                                            break;
-                                        case FrameAnchor.Left:
-                                            //position.X += (16 - texsize.X) / 2;
-                                            dest.Y += (int)(((16 - texsize.Y) / 2F) * _zoom / 16);
-                                            break;
-                                        case FrameAnchor.Right:
-                                            dest.X += (int)((16 - texsize.X) * _zoom / 16);
-                                            dest.Y += (int)(((16 - texsize.Y) / 2F) * _zoom / 16);
-                                            break;
-                                        case FrameAnchor.Top:
-                                            dest.X += (int)(((16 - texsize.X) / 2F) * _zoom / 16);
-                                            //position.Y += (16 - texsize.Y);
-                                            break;
-                                        case FrameAnchor.Bottom:
-                                            dest.X += (int)(((16 - texsize.X) / 2F) * _zoom / 16);
-                                            dest.Y += (int)((16 - texsize.Y) * _zoom / 16);
-                                            break;
+                                        int sameStyle = 0x00000000;
+                                        sameStyle |= (neighborTile[e] != null && neighborTile[e].Wall == curtile.Wall) ? 0x0001 : 0x0000;
+                                        sameStyle |= (neighborTile[n] != null && neighborTile[n].Wall == curtile.Wall) ? 0x0010 : 0x0000;
+                                        sameStyle |= (neighborTile[w] != null && neighborTile[w].Wall == curtile.Wall) ? 0x0100 : 0x0000;
+                                        sameStyle |= (neighborTile[s] != null && neighborTile[s].Wall == curtile.Wall) ? 0x1000 : 0x0000;
+                                        Vector2Int32 uvBlend = blendRules.GetUVForMasks((uint)sameStyle, 0x00000000, 0);
+                                        curtile.uvWallCache = (ushort)((uvBlend.Y << 8) + uvBlend.X);
                                     }
 
+                                    var texsize = new Vector2Int32(32, 32);
+                                    var source = new Rectangle((curtile.uvWallCache & 0x00FF) * (texsize.X + 4), (curtile.uvWallCache >> 8) * (texsize.Y + 4), texsize.X, texsize.Y);
+                                    var dest = new Rectangle(1 + (int)((_scrollPosition.X + x - 0.5) * _zoom), 1 + (int)((_scrollPosition.Y + y - 0.5) * _zoom), (int)_zoom * 2, (int)_zoom * 2);
+
+                                    _spriteBatch.Draw(wallTex, dest, source, Color.White, 0f, default(Vector2), SpriteEffects.None, 1);
+                                }
+                            }
+                        }
+                        if (_wvm.ShowTiles)
+                        {
+                            if (curtile.IsActive)
+                            {
+                                if (tileprop.IsFramed)
+                                {
+                                    Rectangle source = new Rectangle(), dest = new Rectangle();
+                                    var tileTex = _textureDictionary.GetTile(curtile.Type);
+
+                                    bool isTree = false, isMushroom = false;
+                                    bool isLeft = false, isBase = false, isRight = false;
+                                    if (curtile.Type == 5 && curtile.U >= 22 && curtile.V >= 198)
+                                    {
+                                        isTree = true;
+                                        switch (curtile.U)
+                                        {
+                                            case 22: isBase = true; break;
+                                            case 44: isLeft = true; break;
+                                            case 66: isRight = true; break;
+                                        }
+                                        //Abuse uvTileCache to remember what type of tree it is, since potentially scanning a hundred of blocks PER tree tile sounds slow
+                                        int treeType = (curtile.uvTileCache & 0x000F);
+
+                                        if (treeType > 4) //Tree type not yet set
+                                        {
+                                            //Check tree type
+                                            treeType = 0; //Default to normal in case no grass grows beneath the tree
+                                            int baseX = (isLeft) ? 1 : (isRight) ? -1 : 0;
+                                            for (int i = 0; i < 100; i++)
+                                            {
+                                                Tile checkTile = (y + i) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x + baseX, y + i] : null;
+                                                bool found = true;
+                                                if (checkTile != null && checkTile.IsActive)
+                                                {
+                                                    switch (checkTile.Type)
+                                                    {
+                                                        case 2: treeType = 0; break; //Normal
+                                                        case 23: treeType = 1; break; //Corruption
+                                                        case 60: treeType = 2; break; //Jungle
+                                                        case 109: treeType = 3; break; //Hallow
+                                                        case 147: treeType = 4; break; //Snow
+                                                        default: found = false; break;
+                                                    }
+                                                    if (found == true)
+                                                    {
+                                                        curtile.uvTileCache = (ushort)((0x00 << 8) + 0x01 * treeType);
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        if (isBase)
+                                        {
+                                            tileTex = (Texture2D)_textureDictionary.GetTreeTops(treeType);
+                                        }
+                                        else
+                                        {
+                                            tileTex = (Texture2D)_textureDictionary.GetTreeBranches(treeType);
+                                        }
+                                    }
+                                    if (curtile.Type == 72 && curtile.U >= 36)
+                                    {
+                                        isMushroom = true;
+                                        tileTex = (Texture2D)_textureDictionary.GetShroomTop(0);
+                                    }
+
+                                    if (tileTex != null)
+                                    {
+                                        if (!isTree && !isMushroom)
+                                        {
+                                            source = new Rectangle(curtile.U, curtile.V, tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                            if (source.Width <= 0)
+                                                source.Width = 16;
+                                            if (source.Height <= 0)
+                                                source.Height = 16;
+
+                                            if (source.Bottom > tileTex.Height)
+                                                source.Height -= (source.Bottom - tileTex.Height);
+                                            if (source.Right > tileTex.Width)
+                                                source.Width -= (source.Right - tileTex.Width);
+
+                                            if (source.Width <= 0 || source.Height <= 0)
+                                                continue;
+
+                                            dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                            var texsize = tileprop.TextureGrid;
+                                            if (texsize.X != 16 || texsize.Y != 16)
+                                            {
+                                                dest.Width = (int)(texsize.X * (_zoom / 16));
+                                                dest.Height = (int)(texsize.Y * (_zoom / 16));
+
+                                                var frame = (tileprop.Frames.FirstOrDefault(f => f.UV == new Vector2Short(curtile.U, curtile.V)));
+                                                var frameAnchor = FrameAnchor.None;
+                                                if (frame != null)
+                                                    frameAnchor = frame.Anchor;
+                                                switch (frameAnchor)
+                                                {
+                                                    case FrameAnchor.None:
+                                                        dest.X += (int)(((16 - texsize.X) / 2F) * _zoom / 16);
+                                                        dest.Y += (int)(((16 - texsize.Y) / 2F) * _zoom / 16);
+                                                        break;
+                                                    case FrameAnchor.Left:
+                                                        //position.X += (16 - texsize.X) / 2;
+                                                        dest.Y += (int)(((16 - texsize.Y) / 2F) * _zoom / 16);
+                                                        break;
+                                                    case FrameAnchor.Right:
+                                                        dest.X += (int)((16 - texsize.X) * _zoom / 16);
+                                                        dest.Y += (int)(((16 - texsize.Y) / 2F) * _zoom / 16);
+                                                        break;
+                                                    case FrameAnchor.Top:
+                                                        dest.X += (int)(((16 - texsize.X) / 2F) * _zoom / 16);
+                                                        //position.Y += (16 - texsize.Y);
+                                                        break;
+                                                    case FrameAnchor.Bottom:
+                                                        dest.X += (int)(((16 - texsize.X) / 2F) * _zoom / 16);
+                                                        dest.Y += (int)((16 - texsize.Y) * _zoom / 16);
+                                                        break;
+                                                }
+                                            }
+                                        }
+                                        else if (isTree)
+                                        {
+                                            source = new Rectangle(0, 0, 40, 40);
+                                            dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                            FrameAnchor frameAnchor = FrameAnchor.None;
+
+                                            int treeType = (curtile.uvTileCache & 0x000F);
+                                            if (isBase)
+                                            {
+                                                switch (treeType)
+                                                {
+                                                    case 0:
+                                                    case 1:
+                                                    case 4:
+                                                        source.Width = 80;
+                                                        source.Height = 80;
+                                                        break;
+                                                    case 2:
+                                                        source.Width = 114;
+                                                        source.Height = 96;
+                                                        break;
+                                                    case 3:
+                                                        source.X = (x % 3) * (82 * 3);
+                                                        source.Width = 80;
+                                                        source.Height = 140;
+                                                        break;
+                                                }
+                                                source.X += ((curtile.V - 198) / 22) * (source.Width + 2);
+                                                frameAnchor = FrameAnchor.Bottom;
+                                            }
+                                            else if (isLeft)
+                                            {
+                                                source.X = 0;
+                                                switch (treeType)
+                                                {
+                                                    case 3:
+                                                        source.Y = (x % 3) * (42 * 3);
+                                                        break;
+                                                }
+                                                frameAnchor = FrameAnchor.Right;
+                                                source.Y += ((curtile.V - 198) / 22) * (source.Height + 2);
+                                            }
+                                            else if (isRight)
+                                            {
+                                                source.X = 42;
+                                                switch (treeType)
+                                                {
+                                                    case 3:
+                                                        source.Y = (x % 3) * (42 * 3);
+                                                        break;
+                                                }
+                                                frameAnchor = FrameAnchor.Left;
+                                                source.Y += ((curtile.V - 198) / 22) * (source.Height + 2);
+                                            }
+                                            dest.Width = (int)(_zoom * source.Width / 16f);
+                                            dest.Height = (int)(_zoom * source.Height / 16f);
+                                            switch (frameAnchor)
+                                            {
+                                                case FrameAnchor.None:
+                                                    dest.X += (int)(((16 - source.Width) / 2F) * _zoom / 16);
+                                                    dest.Y += (int)(((16 - source.Height) / 2F) * _zoom / 16);
+                                                    break;
+                                                case FrameAnchor.Left:
+                                                    dest.Y += (int)(((16 - source.Height) / 2F) * _zoom / 16);
+                                                    break;
+                                                case FrameAnchor.Right:
+                                                    dest.X += (int)((16 - source.Width) * _zoom / 16);
+                                                    dest.Y += (int)(((16 - source.Height) / 2F) * _zoom / 16);
+                                                    break;
+                                                case FrameAnchor.Top:
+                                                    dest.X += (int)(((16 - source.Width) / 2F) * _zoom / 16);
+                                                    break;
+                                                case FrameAnchor.Bottom:
+                                                    dest.X += (int)(((16 - source.Width) / 2F) * _zoom / 16);
+                                                    dest.Y += (int)((16 - source.Height) * _zoom / 16);
+                                                    break;
+                                            }
+                                        }
+                                        else if (isMushroom)
+                                        {
+                                            source = new Rectangle(0, 0, 60, 42);
+                                            dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                            source.X = (curtile.V / 18) * 62;
+
+                                            dest.Width = (int)(_zoom * source.Width / 16f);
+                                            dest.Height = (int)(_zoom * source.Height / 16f);
+                                            dest.X += (int)(((16 - source.Width) / 2F) * _zoom / 16);
+                                            dest.Y += (int)((16 - source.Height) * _zoom / 16);
+                                        }
+
+                                        _spriteBatch.Draw(tileTex, dest, source, Color.White, 0f, default(Vector2), SpriteEffects.None, 0);
+                                    }
+                                }
+                                else if (tileprop.IsPlatform)
+                                {
+                                    var tileTex = _textureDictionary.GetTile(curtile.Type);
+
+                                    if (tileTex != null)
+                                    {
+                                        Vector2Int32 uv;
+                                        if (curtile.uvTileCache == 0xFFFF)
+                                        {
+                                            uv = new Vector2Int32(0, 0);
+                                            byte state = 0x00;
+                                            state |= (byte)((neighborTile[w] != null && neighborTile[w].IsActive && neighborTile[w].Type == curtile.Type) ? 0x01 : 0x00);
+                                            state |= (byte)((neighborTile[w] != null && neighborTile[w].IsActive && World.TileProperties[neighborTile[w].Type].IsSolid && neighborTile[w].Type != curtile.Type) ? 0x02 : 0x00);
+                                            state |= (byte)((neighborTile[e] != null && neighborTile[e].IsActive && neighborTile[e].Type == curtile.Type) ? 0x04 : 0x00);
+                                            state |= (byte)((neighborTile[e] != null && neighborTile[e].IsActive && World.TileProperties[neighborTile[e].Type].IsSolid && neighborTile[e].Type != curtile.Type) ? 0x08 : 0x00);
+                                            switch (state)
+                                            {
+                                                case 0x00:
+                                                case 0x0A:
+                                                    uv.X = 5;
+                                                    break;
+                                                case 0x01:
+                                                    uv.X = 1;
+                                                    break;
+                                                case 0x02:
+                                                    uv.X = 6;
+                                                    break;
+                                                case 0x04:
+                                                    uv.X = 2;
+                                                    break;
+                                                case 0x05:
+                                                    uv.X = 0;
+                                                    break;
+                                                case 0x06:
+                                                    uv.X = 3;
+                                                    break;
+                                                case 0x08:
+                                                    uv.X = 7;
+                                                    break;
+                                                case 0x09:
+                                                    uv.X = 4;
+                                                    break;
+                                            }
+                                            uv.Y = blendRules.randomVariation.Next(3);
+                                            curtile.uvTileCache = (ushort)((uv.Y << 8) + uv.X);
+                                        }
+
+                                        var texsize = new Vector2Int32(tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                        if (texsize.X == 0 || texsize.Y == 0)
+                                        {
+                                            texsize = new Vector2Int32(16, 16);
+                                        }
+                                        var source = new Rectangle((curtile.uvTileCache & 0x00FF) * (texsize.X + 2), (curtile.uvTileCache >> 8) * (texsize.Y + 2), texsize.X, texsize.Y);
+                                        var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                        _spriteBatch.Draw(tileTex, dest, source, Color.White, 0f, default(Vector2), SpriteEffects.None, 0);
+                                    }
+                                }
+                                else if (tileprop.IsCactus)
+                                {
+                                    
+                                    var tileTex = _textureDictionary.GetTile(curtile.Type);
+
+                                    if ((curtile.uvTileCache & 0x00FF) >= 16)
+                                    {
+                                        tileTex = (Texture2D)_textureDictionary.GetMisc("Evil_Cactus");
+                                    }
+                                    else if ((curtile.uvTileCache & 0x00FF) >= 8)
+                                    {
+                                        tileTex = (Texture2D)_textureDictionary.GetMisc("Good_Cactus");
+                                    }
+
+                                    if (tileTex != null)
+                                    {
+                                        Vector2Int32 uv;
+                                        if (curtile.uvTileCache == 0xFFFF || curtile.hasLazyChecked == false)
+                                        {
+                                            bool isLeft = false, isRight = false, isBase = false;
+
+                                            //Has this cactus been base-evaluated yet?
+                                            int neighborX = (neighborTile[w].uvTileCache & 0x00FF) % 8; //Why % 8? If X >= 8, use hallow, If X >= 16, use corruption
+                                            if (neighborX == 0 || neighborX == 1 || neighborX == 4 || neighborX == 5)
+                                            {
+                                                isRight = true;
+                                            }
+                                            neighborX = neighborTile[e].uvTileCache & 0x00FF;
+                                            if (neighborX == 0 || neighborX == 1 || neighborX == 4 || neighborX == 5)
+                                            {
+                                                isLeft = true;
+                                            }
+                                            neighborX = curtile.uvTileCache & 0x00FF;
+                                            if (neighborX == 0 || neighborX == 1 || neighborX == 4 || neighborX == 5)
+                                            {
+                                                isBase = true;
+                                            }
+
+                                            //Evaluate Base
+                                            if (isLeft == false && isRight == false && isBase == false)
+                                            {
+                                                int length1 = 0;
+                                                int length2 = 0;
+                                                while (true)
+                                                {
+                                                    Tile checkTile = (y + length1) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x, y + length1] : null;
+                                                    if (checkTile == null || checkTile.IsActive == false || checkTile.Type != curtile.Type)
+                                                    {
+                                                        break;
+                                                    }
+                                                    length1++;
+                                                }
+                                                if (x + 1 < _wvm.CurrentWorld.TilesWide)
+                                                {
+                                                    while (true)
+                                                    {
+                                                        Tile checkTile = (y + length2) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x + 1, y + length2] : null;
+                                                        if (checkTile == null || checkTile.IsActive == false || checkTile.Type != curtile.Type)
+                                                        {
+                                                            break;
+                                                        }
+                                                        length2++;
+                                                    }
+                                                }
+                                                int baseX = 0;
+                                                int baseY = length1;
+                                                isBase = true;
+                                                if (length2 >= length1)
+                                                {
+                                                    baseX = 1;
+                                                    baseY = length2;
+                                                    isBase = false;
+                                                    isLeft = true;
+                                                }
+                                                for (int cy = y; cy < y + baseY; cy++)
+                                                {
+                                                    if (_wvm.CurrentWorld.Tiles[x + baseX, cy].uvTileCache == 0xFFFF)
+                                                    {
+                                                        if (cy == y)
+                                                        {
+                                                            _wvm.CurrentWorld.Tiles[x + baseX, cy].uvTileCache = 0x00 << 8 + 0x00;
+                                                        }
+                                                        else
+                                                        {
+                                                            _wvm.CurrentWorld.Tiles[x + baseX, cy].uvTileCache = 0x01 << 8 + 0x00;
+                                                        }
+                                                    }
+                                                }
+                                            }
+
+                                            uv = new Vector2Int32(0, 0);
+                                            byte state = 0x00;
+                                            state |= (byte)((neighborTile[e] != null && neighborTile[e].IsActive && neighborTile[e].Type == curtile.Type) ? 0x01 : 0x00);
+                                            state |= (byte)((neighborTile[n] != null && neighborTile[n].IsActive && neighborTile[n].Type == curtile.Type) ? 0x02 : 0x00);
+                                            state |= (byte)((neighborTile[w] != null && neighborTile[w].IsActive && neighborTile[w].Type == curtile.Type) ? 0x04 : 0x00);
+                                            state |= (byte)((neighborTile[s] != null && neighborTile[s].IsActive && neighborTile[s].Type == curtile.Type) ? 0x08 : 0x00);
+                                            //state |= (byte)((neighborTile[ne] != null && neighborTile[ne].IsActive && neighborTile[ne].Type == curtile.Type) ? 0x10 : 0x00);
+                                            //state |= (byte)((neighborTile[nw] != null && neighborTile[nw].IsActive && neighborTile[nw].Type == curtile.Type) ? 0x20 : 0x00);
+                                            state |= (byte)((neighborTile[sw] != null && neighborTile[sw].IsActive && neighborTile[sw].Type == curtile.Type) ? 0x40 : 0x00);
+                                            state |= (byte)((neighborTile[se] != null && neighborTile[se].IsActive && neighborTile[se].Type == curtile.Type) ? 0x80 : 0x00);
+
+                                            if (isLeft)
+                                            {
+                                                uv.X = 3;
+                                                if ((state & 0x08) != 0x00) //s
+                                                {
+                                                    if ((state & 0x02) != 0x00) //n
+                                                    {
+                                                        uv.Y = 1;
+                                                    }
+                                                    else //!n
+                                                    {
+                                                        uv.Y = 0;
+                                                    }
+                                                }
+                                                else //!s
+                                                {
+                                                    if ((state & 0x02) != 0x00) //n
+                                                    {
+                                                        uv.Y = 2;
+                                                    }
+                                                    else //!n
+                                                    {
+                                                        uv.X = 6;
+                                                        uv.Y = 2;
+                                                    }
+                                                }
+                                            }
+                                            if (isRight)
+                                            {
+                                                uv.X = 2;
+                                                if ((state & 0x08) != 0x00) //s
+                                                {
+                                                    if ((state & 0x02) != 0x00) //n
+                                                    {
+                                                        uv.Y = 1;
+                                                    }
+                                                    else //!n
+                                                    {
+                                                        uv.Y = 0;
+                                                    }
+                                                }
+                                                else //!s
+                                                {
+                                                    if ((state & 0x02) != 0x00) //n
+                                                    {
+                                                        uv.Y = 2;
+                                                    }
+                                                    else //!n
+                                                    {
+                                                        uv.X = 6;
+                                                        uv.Y = 1;
+                                                    }
+                                                }
+                                            }
+                                            if (isBase)
+                                            {
+                                                if ((state & 0x02) != 0x00) //n
+                                                {
+                                                    uv.Y = 2;
+                                                    if ((state & 0x04) != 0x00 && (state & 0x40) == 0x00 && ((state & 0x01) == 0x00 || (state & 0x80) != 0x00)) //w !sw (!e or se)
+                                                    {
+                                                        uv.X = 4;
+                                                    }
+                                                    else if ((state & 0x01) != 0x00 && (state & 0x80) == 0x00 && ((state & 0x04) == 0x00 || (state & 0x40) != 0x00)) //e !se (!w or sw)
+                                                    {
+                                                        uv.X = 1;
+                                                    }
+                                                    else if ((state & 0x04) != 0x00 && (state & 0x40) == 0x00 && (state & 0x01) != 0x00 && (state & 0x80) == 0x00) //w !sw e !se
+                                                    {
+                                                        uv.X = 5;
+                                                    }
+                                                    else
+                                                    {
+                                                        uv.X = 0;
+                                                        uv.Y = 1;
+                                                    }
+                                                }
+                                                else //!n
+                                                {
+                                                    uv.Y = 0;
+                                                    if ((state & 0x04) != 0x00 && (state & 0x40) == 0x00 && ((state & 0x01) == 0x00 || (state & 0x80) != 0x00)) //w !sw (!e or se)
+                                                    {
+                                                        uv.X = 4;
+                                                    }
+                                                    else if ((state & 0x01) != 0x00 && (state & 0x80) == 0x00 && ((state & 0x04) == 0x00 || (state & 0x40) != 0x00)) //e !se (!w or sw)
+                                                    {
+                                                        uv.X = 1;
+                                                    }
+                                                    else if ((state & 0x04) != 0x00 && (state & 0x40) == 0x00 && (state & 0x01) != 0x00 && (state & 0x80) == 0x00) //w !sw e !se
+                                                    {
+                                                        uv.X = 5;
+                                                    }
+                                                    else
+                                                    {
+                                                        uv.X = 0;
+                                                        uv.Y = 0;
+                                                    }
+                                                }
+                                            }
+
+                                            //Check if cactus is good or evil
+                                            for (int i = 0; i < 100; i++)
+                                            {
+                                                int baseX = (isLeft) ? 1 : (isRight) ? -1 : 0;
+                                                Tile checkTile = (y + i) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x + baseX, y + i] : null;
+                                                if (checkTile != null && checkTile.IsActive && checkTile.Type == 112) //Corruption
+                                                {
+                                                    uv.X += 16;
+                                                    break;
+                                                }
+                                                else if (checkTile != null && checkTile.IsActive && checkTile.Type == 116) //Hallow
+                                                {
+                                                    uv.X += 8;
+                                                    break;
+                                                }
+                                            }
+                                            curtile.hasLazyChecked = true;
+
+                                            curtile.uvTileCache = (ushort)((uv.Y << 8) + uv.X);
+                                        }
+
+                                        var texsize = new Vector2Int32(tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                        if (texsize.X == 0 || texsize.Y == 0)
+                                        {
+                                            texsize = new Vector2Int32(16, 16);
+                                        }
+                                        var source = new Rectangle(((curtile.uvTileCache & 0x00FF) % 8) * (texsize.X + 2), (curtile.uvTileCache >> 8) * (texsize.Y + 2), texsize.X, texsize.Y);
+                                        var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                        _spriteBatch.Draw(tileTex, dest, source, Color.White, 0f, default(Vector2), SpriteEffects.None, 0);
+                                    }
+                                }
+                                else if (tileprop.CanBlend)
+                                {
+                                    var tileTex = _textureDictionary.GetTile(curtile.Type);
+
+                                    if (tileTex != null)
+                                    {
+                                        if (curtile.uvTileCache == 0xFFFF || curtile.hasLazyChecked == false)
+                                        {
+                                            int sameStyle = 0x00000000;
+                                            int mergeMask = 0x00000000;
+                                            int strictness = 0;
+                                            if (tileprop.MergeWith.HasValue && tileprop.MergeWith.Value == -1) //Basically for cobweb
+                                            {
+                                                sameStyle |= (neighborTile[e] != null && neighborTile[e].IsActive) ? 0x0001 : 0x0000;
+                                                sameStyle |= (neighborTile[n] != null && neighborTile[n].IsActive) ? 0x0010 : 0x0000;
+                                                sameStyle |= (neighborTile[w] != null && neighborTile[w].IsActive) ? 0x0100 : 0x0000;
+                                                sameStyle |= (neighborTile[s] != null && neighborTile[s].IsActive) ? 0x1000 : 0x0000;
+                                            }
+                                            else if (tileprop.IsStone) //Stone & Gems
+                                            {
+                                                sameStyle |= (neighborTile[e] != null && neighborTile[e].IsActive && World.TileProperties[neighborTile[e].Type].IsStone) ? 0x0001 : 0x0000;
+                                                sameStyle |= (neighborTile[n] != null && neighborTile[n].IsActive && World.TileProperties[neighborTile[n].Type].IsStone) ? 0x0010 : 0x0000;
+                                                sameStyle |= (neighborTile[w] != null && neighborTile[w].IsActive && World.TileProperties[neighborTile[w].Type].IsStone) ? 0x0100 : 0x0000;
+                                                sameStyle |= (neighborTile[s] != null && neighborTile[s].IsActive && World.TileProperties[neighborTile[s].Type].IsStone) ? 0x1000 : 0x0000;
+                                                sameStyle |= (neighborTile[ne] != null && neighborTile[ne].IsActive && World.TileProperties[neighborTile[ne].Type].IsStone) ? 0x00010000 : 0x00000000;
+                                                sameStyle |= (neighborTile[nw] != null && neighborTile[nw].IsActive && World.TileProperties[neighborTile[nw].Type].IsStone) ? 0x00100000 : 0x00000000;
+                                                sameStyle |= (neighborTile[sw] != null && neighborTile[sw].IsActive && World.TileProperties[neighborTile[sw].Type].IsStone) ? 0x01000000 : 0x00000000;
+                                                sameStyle |= (neighborTile[se] != null && neighborTile[se].IsActive && World.TileProperties[neighborTile[se].Type].IsStone) ? 0x10000000 : 0x00000000;
+                                            }
+                                            else //Everything else
+                                            {
+                                                //Join to nearby tiles if their merge type is this tile's type
+                                                sameStyle |= (neighborTile[e] != null && neighborTile[e].IsActive && World.TileProperties[neighborTile[e].Type].MergeWith.HasValue && World.TileProperties[neighborTile[e].Type].MergeWith.Value == curtile.Type) ? 0x0001 : 0x0000;
+                                                sameStyle |= (neighborTile[n] != null && neighborTile[n].IsActive && World.TileProperties[neighborTile[n].Type].MergeWith.HasValue && World.TileProperties[neighborTile[n].Type].MergeWith.Value == curtile.Type) ? 0x0010 : 0x0000;
+                                                sameStyle |= (neighborTile[w] != null && neighborTile[w].IsActive && World.TileProperties[neighborTile[w].Type].MergeWith.HasValue && World.TileProperties[neighborTile[w].Type].MergeWith.Value == curtile.Type) ? 0x0100 : 0x0000;
+                                                sameStyle |= (neighborTile[s] != null && neighborTile[s].IsActive && World.TileProperties[neighborTile[s].Type].MergeWith.HasValue && World.TileProperties[neighborTile[s].Type].MergeWith.Value == curtile.Type) ? 0x1000 : 0x0000;
+                                                sameStyle |= (neighborTile[ne] != null && neighborTile[ne].IsActive && World.TileProperties[neighborTile[ne].Type].MergeWith.HasValue && World.TileProperties[neighborTile[ne].Type].MergeWith.Value == curtile.Type) ? 0x00010000 : 0x00000000;
+                                                sameStyle |= (neighborTile[nw] != null && neighborTile[nw].IsActive && World.TileProperties[neighborTile[nw].Type].MergeWith.HasValue && World.TileProperties[neighborTile[nw].Type].MergeWith.Value == curtile.Type) ? 0x00100000 : 0x00000000;
+                                                sameStyle |= (neighborTile[sw] != null && neighborTile[sw].IsActive && World.TileProperties[neighborTile[sw].Type].MergeWith.HasValue && World.TileProperties[neighborTile[sw].Type].MergeWith.Value == curtile.Type) ? 0x01000000 : 0x00000000;
+                                                sameStyle |= (neighborTile[se] != null && neighborTile[se].IsActive && World.TileProperties[neighborTile[se].Type].MergeWith.HasValue && World.TileProperties[neighborTile[se].Type].MergeWith.Value == curtile.Type) ? 0x10000000 : 0x00000000;
+                                                //Join if nearby tiles have the same type as this tile's type
+                                                sameStyle |= (neighborTile[e] != null && neighborTile[e].IsActive && curtile.Type == neighborTile[e].Type) ? 0x0001 : 0x0000;
+                                                sameStyle |= (neighborTile[n] != null && neighborTile[n].IsActive && curtile.Type == neighborTile[n].Type) ? 0x0010 : 0x0000;
+                                                sameStyle |= (neighborTile[w] != null && neighborTile[w].IsActive && curtile.Type == neighborTile[w].Type) ? 0x0100 : 0x0000;
+                                                sameStyle |= (neighborTile[s] != null && neighborTile[s].IsActive && curtile.Type == neighborTile[s].Type) ? 0x1000 : 0x0000;
+                                                sameStyle |= (neighborTile[ne] != null && neighborTile[ne].IsActive && curtile.Type == neighborTile[ne].Type) ? 0x00010000 : 0x00000000;
+                                                sameStyle |= (neighborTile[nw] != null && neighborTile[nw].IsActive && curtile.Type == neighborTile[nw].Type) ? 0x00100000 : 0x00000000;
+                                                sameStyle |= (neighborTile[sw] != null && neighborTile[sw].IsActive && curtile.Type == neighborTile[sw].Type) ? 0x01000000 : 0x00000000;
+                                                sameStyle |= (neighborTile[se] != null && neighborTile[se].IsActive && curtile.Type == neighborTile[se].Type) ? 0x10000000 : 0x00000000;
+                                            }
+                                            if (curtile.hasLazyChecked == false)
+                                            {
+                                                bool lazyCheckReady = true;
+                                                lazyCheckReady &= (neighborTile[e] == null || neighborTile[e].IsActive == false || World.TileProperties[neighborTile[e].Type].MergeWith.HasValue == false || World.TileProperties[neighborTile[e].Type].MergeWith.Value != curtile.Type) ? true : (neighborTile[e].lazyMergeId != 0xFF);
+                                                lazyCheckReady &= (neighborTile[n] == null || neighborTile[n].IsActive == false || World.TileProperties[neighborTile[n].Type].MergeWith.HasValue == false || World.TileProperties[neighborTile[n].Type].MergeWith.Value != curtile.Type) ? true : (neighborTile[n].lazyMergeId != 0xFF);
+                                                lazyCheckReady &= (neighborTile[w] == null || neighborTile[w].IsActive == false || World.TileProperties[neighborTile[w].Type].MergeWith.HasValue == false || World.TileProperties[neighborTile[w].Type].MergeWith.Value != curtile.Type) ? true : (neighborTile[w].lazyMergeId != 0xFF);
+                                                lazyCheckReady &= (neighborTile[s] == null || neighborTile[s].IsActive == false || World.TileProperties[neighborTile[s].Type].MergeWith.HasValue == false || World.TileProperties[neighborTile[s].Type].MergeWith.Value != curtile.Type) ? true : (neighborTile[s].lazyMergeId != 0xFF);
+                                                if (lazyCheckReady)
+                                                {
+                                                    sameStyle &= 0x11111110 | ((neighborTile[e] == null || neighborTile[e].IsActive == false || World.TileProperties[neighborTile[e].Type].MergeWith.HasValue == false || World.TileProperties[neighborTile[e].Type].MergeWith.Value != curtile.Type) ? 0x00000001 : ((neighborTile[e].lazyMergeId & 0x04) >> 2));
+                                                    sameStyle &= 0x11111101 | ((neighborTile[n] == null || neighborTile[n].IsActive == false || World.TileProperties[neighborTile[n].Type].MergeWith.HasValue == false || World.TileProperties[neighborTile[n].Type].MergeWith.Value != curtile.Type) ? 0x00000010 : ((neighborTile[n].lazyMergeId & 0x08) << 1));
+                                                    sameStyle &= 0x11111011 | ((neighborTile[w] == null || neighborTile[w].IsActive == false || World.TileProperties[neighborTile[w].Type].MergeWith.HasValue == false || World.TileProperties[neighborTile[w].Type].MergeWith.Value != curtile.Type) ? 0x00000100 : ((neighborTile[w].lazyMergeId & 0x01) << 8));
+                                                    sameStyle &= 0x11110111 | ((neighborTile[s] == null || neighborTile[s].IsActive == false || World.TileProperties[neighborTile[s].Type].MergeWith.HasValue == false || World.TileProperties[neighborTile[s].Type].MergeWith.Value != curtile.Type) ? 0x00001000 : ((neighborTile[s].lazyMergeId & 0x02) << 11));
+                                                    curtile.hasLazyChecked = true;
+                                                }
+                                            }
+                                            if (tileprop.MergeWith.HasValue && tileprop.MergeWith.Value > -1) //Merges with a specific type
+                                            {
+                                                mergeMask |= (neighborTile[e] != null && neighborTile[e].IsActive && neighborTile[e].Type == tileprop.MergeWith.Value) ? 0x0001 : 0x0000;
+                                                mergeMask |= (neighborTile[n] != null && neighborTile[n].IsActive && neighborTile[n].Type == tileprop.MergeWith.Value) ? 0x0010 : 0x0000;
+                                                mergeMask |= (neighborTile[w] != null && neighborTile[w].IsActive && neighborTile[w].Type == tileprop.MergeWith.Value) ? 0x0100 : 0x0000;
+                                                mergeMask |= (neighborTile[s] != null && neighborTile[s].IsActive && neighborTile[s].Type == tileprop.MergeWith.Value) ? 0x1000 : 0x0000;
+                                                mergeMask |= (neighborTile[ne] != null && neighborTile[ne].IsActive && neighborTile[ne].Type == tileprop.MergeWith.Value) ? 0x00010000 : 0x00000000;
+                                                mergeMask |= (neighborTile[nw] != null && neighborTile[nw].IsActive && neighborTile[nw].Type == tileprop.MergeWith.Value) ? 0x00100000 : 0x00000000;
+                                                mergeMask |= (neighborTile[sw] != null && neighborTile[sw].IsActive && neighborTile[sw].Type == tileprop.MergeWith.Value) ? 0x01000000 : 0x00000000;
+                                                mergeMask |= (neighborTile[se] != null && neighborTile[se].IsActive && neighborTile[se].Type == tileprop.MergeWith.Value) ? 0x10000000 : 0x00000000;
+                                                strictness = 1;
+                                            }
+                                            if (tileprop.IsGrass)
+                                            {
+                                                strictness = 2;
+                                            }
+
+                                            Vector2Int32 uvBlend = blendRules.GetUVForMasks((uint)sameStyle, (uint)mergeMask, strictness);
+                                            curtile.uvTileCache = (ushort)((uvBlend.Y << 8) + uvBlend.X);
+                                            curtile.lazyMergeId = blendRules.lazyMergeValidation[uvBlend.Y, uvBlend.X];
+                                        }
+
+                                        var texsize = new Vector2Int32(tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                        if (texsize.X == 0 || texsize.Y == 0)
+                                        {
+                                            texsize = new Vector2Int32(16, 16);
+                                        }
+                                        var source = new Rectangle((curtile.uvTileCache & 0x00FF) * (texsize.X + 2), (curtile.uvTileCache >> 8) * (texsize.Y + 2), texsize.X, texsize.Y);
+                                        var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                        _spriteBatch.Draw(tileTex, dest, source, Color.White, 0f, default(Vector2), SpriteEffects.None, 0);
+                                    }
+                                }
+                            }
+                        }
+                        if (_wvm.ShowWires)
+                        {
+                            if (curtile.HasWire)
+                            {
+                                var tileTex = (Texture2D)_textureDictionary.GetMisc("Wires");
+
+                                if (tileTex != null)
+                                {
+                                    var source = new Rectangle(0, 0, 16, 16);
+                                    var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                    byte state = 0x00;
+                                    state |= (byte)((neighborTile[e] != null && neighborTile[e].HasWire == true) ? 0x01 : 0x00);
+                                    state |= (byte)((neighborTile[n] != null && neighborTile[n].HasWire == true) ? 0x02 : 0x00);
+                                    state |= (byte)((neighborTile[w] != null && neighborTile[w].HasWire == true) ? 0x04 : 0x00);
+                                    state |= (byte)((neighborTile[s] != null && neighborTile[s].HasWire == true) ? 0x08 : 0x00);
+                                    Vector2Int32 uv = new Vector2Int32(0, 0);
+                                    switch (state)
+                                    {
+                                        case 0x00: uv.X = 0; uv.Y = 3; break;
+                                        case 0x01: uv.X = 4; uv.Y = 2; break;
+                                        case 0x02: uv.X = 2; uv.Y = 2; break;
+                                        case 0x03: uv.X = 2; uv.Y = 1; break;
+                                        case 0x04: uv.X = 3; uv.Y = 2; break;
+                                        case 0x05: uv.X = 1; uv.Y = 0; break;
+                                        case 0x06: uv.X = 3; uv.Y = 1; break;
+                                        case 0x07: uv.X = 0; uv.Y = 1; break;
+                                        case 0x08: uv.X = 1; uv.Y = 2; break;
+                                        case 0x09: uv.X = 0; uv.Y = 2; break;
+                                        case 0x0A: uv.X = 0; uv.Y = 0; break;
+                                        case 0x0B: uv.X = 2; uv.Y = 0; break;
+                                        case 0x0C: uv.X = 4; uv.Y = 1; break;
+                                        case 0x0D: uv.X = 4; uv.Y = 0; break;
+                                        case 0x0E: uv.X = 3; uv.Y = 0; break;
+                                        case 0x0F: uv.X = 1; uv.Y = 1; break;
+                                    }
+                                    source.X = uv.X * (source.Width + 2);
+                                    source.Y = uv.Y * (source.Height + 2);
+
+                                    _overlayBatch.Draw(tileTex, dest, source, Color.White, 0f, default(Vector2), SpriteEffects.None, 0);
+                                }
+                            }
+                        }
+                        if (_wvm.ShowLiquid)
+                        {
+                            if (curtile.Liquid > 0)
+                            {
+                                Texture2D tileTex = null;
+                                if (curtile.IsLava == false)
+                                {
+                                    tileTex = (Texture2D)_textureDictionary.GetLiquid(0);
+                                }
+                                else
+                                {
+                                    tileTex = (Texture2D)_textureDictionary.GetLiquid(1);
                                 }
 
+                                if (tileTex != null)
+                                {
+                                    var source = new Rectangle(0, 0, 16, 16);
+                                    var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                    float alpha = 1f;
 
-                                _spriteBatch.Draw(tileTex,
-                                                  dest,
-                                                  source,
-                                                  Color.White);
+                                    if (curtile.IsLava == false)
+                                    {
+                                        alpha = 0.5f;
+                                    }
+                                    else
+                                    {
+                                        alpha = 0.85f;
+                                    }
+
+                                    if (neighborTile[n] != null && neighborTile[n].Liquid > 0)
+                                    {
+                                        source.Y = 8;
+                                        source.Height = 8;
+                                    }
+                                    else
+                                    {
+                                        source.Height = 4 + ((int)Math.Round(curtile.Liquid * 6f / 255f)) * 2;
+                                        dest.Height = (int)(source.Height * _zoom / 16f);
+                                        dest.Y = 1 + (int)((_scrollPosition.Y + y) * _zoom + ((16 - source.Height) * _zoom / 16f));
+                                    }
+
+                                    _overlayBatch.Draw(tileTex, dest, source, Color.White * alpha, 0f, default(Vector2), SpriteEffects.None, 0);
+                                }
                             }
                         }
                     }
                 }
-                //_spriteBatch.Draw();
             }
         }
 
@@ -533,7 +1222,7 @@ namespace TEditXna.View
                     Vector2.Zero,
                     _zoom,
                     SpriteEffects.None,
-                    0);
+                    1);
             }
         }
 

--- a/TEditXna/settings.xml
+++ b/TEditXna/settings.xml
@@ -249,6 +249,7 @@ Single item; tag has no children. Has the following properties:
 
 -->
 
+<?xml version="1.0" encoding="utf-8"?>
 <Settings>
   <ShortCutKeys>
     <Shortcut Key="A" Tool="Arrow" />
@@ -272,9 +273,9 @@ Single item; tag has no children. Has the following properties:
     <GlobalColor Name="Wire" Color="#70FF0000" />
   </GlobalColors>
   <Tiles>
-    <Tile Id="0" Name="Dirt Block" Color="#FF916A4F"  Solid="true"/>
-    <Tile Id="1" Name="Stone Block" Color="#FF808080"  Solid="true"/>
-    <Tile Id="2" Name="Grass" Color="#FF1CD85E"  Solid="true"/>
+    <Tile Id="0" Name="Dirt Block" Color="#FF916A4F" Solid="true" Blends="true" />
+    <Tile Id="1" Name="Stone Block" Color="#FF808080" Solid="true" Blends="true" MergeWith="0" Stone="true" />
+    <Tile Id="2" Name="Grass" Color="#FF1CD85E" Solid="true" Blends="true" MergeWith="0" Special="Grass" />
     <Tile Id="3" Name="Grass Flowers" Color="#FF0D6524" Framed="true" TextureGrid="16,20">
       <Frames>
         <Frame UV="0,0" Name="Grass" Anchor="Right" Variety="Single Blade" />
@@ -322,7 +323,7 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="44,176" Name="Cursed" Anchor="Right" Variety="On" />
       </Frames>
     </Tile>
-    <Tile Id="5" Name="Tree" Color="#FF634631"  Framed="true"  TextureGrid="20,20">
+    <Tile Id="5" Name="Tree" Color="#FF634631" Framed="true" TextureGrid="20,20">
       <Frames>
         <Frame UV="0,0" Name="Tree Trunk" Anchor="Bottom" Variety="Plain A" />
         <Frame UV="22,0" Name="Tree Trunk" Anchor="Bottom" Variety="Right Indent A" />
@@ -398,10 +399,10 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="0,242" Name="Tree Trunk" Anchor="Left" Variety="Jagged" />
       </Frames>
     </Tile>
-    <Tile Id="6" Name="Iron Ore" Color="#FF6B594E"  Solid="true"/>
-    <Tile Id="7" Name="Copper Ore" Color="#FFC6561D"  Solid="true"/>
-    <Tile Id="8" Name="Gold Ore" Color="#FFB9A417"  Solid="true"/>
-    <Tile Id="9" Name="Silver Ore" Color="#FFD9DFDF"  Solid="true"/>
+    <Tile Id="6" Name="Iron Ore" Color="#FF6B594E" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="7" Name="Copper Ore" Color="#FFC6561D" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="8" Name="Gold Ore" Color="#FFB9A417" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="9" Name="Silver Ore" Color="#FFD9DFDF" Solid="true" Blends="true" MergeWith="0" />
     <Tile Id="10" Name="Wooden Door" Color="#FF00FFF2" Placement="CFBoth" Solid="true" Framed="true" Size="1,3">
       <Frames>
         <Frame UV="0,0" Variety="A" />
@@ -415,7 +416,7 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="36,0" Anchor="Left" />
       </Frames>
     </Tile>
-    <Tile Id="12" Name="Crystal Heart" Color="#FFFF0000" Placement="floor" Framed="true" Size="2,2"/>
+    <Tile Id="12" Name="Crystal Heart" Color="#FFFF0000" Placement="floor" Framed="true" Size="2,2" />
     <Tile Id="13" Name="Bottle" Color="#FF00FFF2" Placement="surface" Framed="true">
       <Frames>
         <Frame UV="0,0" Name="Bottle" />
@@ -425,7 +426,7 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="72,0" Name="Mug" />
       </Frames>
     </Tile>
-    <Tile Id="14" Name="Wooden Table" Color="#FF00FFF2" Placement="floor" SolidTop="true" Framed="true" Size="3,2" TextureGrid="16,16"/>
+    <Tile Id="14" Name="Wooden Table" Color="#FF00FFF2" Placement="floor" SolidTop="true" Framed="true" Size="3,2" TextureGrid="16,16" />
     <Tile Id="15" Name="Chair" Color="#FF00FFF2" Placement="floor" Framed="true" Size="1,2">
       <Frames>
         <Frame UV="0,0" Name="Wooden Chair" Anchor="Left" />
@@ -435,10 +436,10 @@ Single item; tag has no children. Has the following properties:
       </Frames>
     </Tile>
     <Tile Id="16" Name="Iron Anvil" Color="#FF00FFF2" Placement="floor" SolidTop="true" Framed="true" Size="2,1" TextureGrid="16,18" />
-    <Tile Id="17" Name="Furnace" Color="#FF00FFF2" Placement="floor" Light="true" Framed="true" Size="3,2"/>
+    <Tile Id="17" Name="Furnace" Color="#FF00FFF2" Placement="floor" Light="true" Framed="true" Size="3,2" />
     <Tile Id="18" Name="Work Bench" Color="#FF00FFF2" Placement="floor" SolidTop="true" Framed="true" Size="2,1" TextureGrid="16,18" />
-    <Tile Id="19" Name="Wood Platform" Color="#FF6B3A18" Placement="wall" Light="true" Solid="true" SolidTop="true"/>
-    <Tile Id="20" Name="Sapling" Color="#FF0D6524" Framed="true" Size="1,2" >
+    <Tile Id="19" Name="Wood Platform" Color="#FF6B3A18" Placement="wall" Light="true" Solid="true" SolidTop="true" Special="Platform" />
+    <Tile Id="20" Name="Sapling" Color="#FF0D6524" Framed="true" Size="1,2">
       <Frames>
         <Frame UV="0,0" Anchor="Left" />
         <Frame UV="18,0" Anchor="Bottom" />
@@ -456,9 +457,9 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="216,0" Name="Trash Can" />
       </Frames>
     </Tile>
-    <Tile Id="22" Name="Demonite Ore" Color="#FF625FA7"  Light="true" Solid="true"/>
-    <Tile Id="23" Name="Corruption" Color="#FF8D89DF"  Solid="true"/>
-    <Tile Id="24" Name="Corruption Plants" Color="#FF8D89DF"  Framed="true" TextureGrid="16,20">
+    <Tile Id="22" Name="Demonite Ore" Color="#FF625FA7" Light="true" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="23" Name="Corruption" Color="#FF8D89DF" Solid="true" Blends="true" MergeWith="0" Special="Grass" />
+    <Tile Id="24" Name="Corruption Plants" Color="#FF8D89DF" Framed="true" TextureGrid="16,20">
       <Frames>
         <Frame UV="0,0" Name="Vile Grass" Anchor="Right" Variety="Single Blade" />
         <Frame UV="18,0" Name="Vile Grass" Anchor="Right" Variety="Double Blade" />
@@ -471,9 +472,9 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="144,0" Name="Vile Mushroom" Anchor="Bottom" />
       </Frames>
     </Tile>
-    <Tile Id="25" Name="Ebonstone Block" Color="#FF4B4A82"  Solid="true"/>
-    <Tile Id="26" Name="Demon Altar" Color="#FF9000FF" Placement="floor" Light="true" Framed="true" Size="3,2"/>
-    <Tile Id="27" Name="Sunflower" Color="#FFC4FF14"  Framed="true" Size="2,4">
+    <Tile Id="25" Name="Ebonstone Block" Color="#FF4B4A82" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="26" Name="Demon Altar" Color="#FF9000FF" Placement="floor" Light="true" Framed="true" Size="3,2" />
+    <Tile Id="27" Name="Sunflower" Color="#FFC4FF14" Framed="true" Size="2,4">
       <Frames>
         <Frame UV="0,0" Variety="A" />
         <Frame UV="36,0" Variety="B" />
@@ -487,10 +488,10 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="72,0" Variety="Round" />
       </Frames>
     </Tile>
-    <Tile Id="29" Name="Piggy Bank" Color="#FF00FFF2" Placement="surface" Framed="true" Size="2,1"/>
-    <Tile Id="30" Name="Wood" Color="#FF684934"  Solid="true"/>
-    <Tile Id="31" Name="Shadow Orb" Color="#FF000000" Placement="floor" Light="true" Framed="true" Size="2,2"/>
-    <Tile Id="32" Name="Corruption Vines" Color="#FF7A618F" />
+    <Tile Id="29" Name="Piggy Bank" Color="#FF00FFF2" Placement="surface" Framed="true" Size="2,1" />
+    <Tile Id="30" Name="Wood" Color="#FF684934" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="31" Name="Shadow Orb" Color="#FF000000" Placement="floor" Light="true" Framed="true" Size="2,2" />
+    <Tile Id="32" Name="Corruption Vines" Color="#FF7A618F" Blends="true" />
     <Tile Id="33" Name="Candle" Color="#FFFD3E03" Placement="surface" Light="true" Framed="true" TextureGrid="16,20">
       <Frames>
         <Frame UV="0,0" Variety="On" />
@@ -515,23 +516,23 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="54,0" Variety="Off" />
       </Frames>
     </Tile>
-    <Tile Id="37" Name="Meteorite" Color="#FFDF9F89"  Light="true" Solid="true"/>
-    <Tile Id="38" Name="Gray Brick" Color="#FF909090"  Solid="true"/>
-    <Tile Id="39" Name="Red Brick" Color="#FFB200FF"  Solid="true"/>
-    <Tile Id="40" Name="Clay Block" Color="#FFAC5B4D"  Solid="true"/>
-    <Tile Id="41" Name="Blue Brick" Color="#FF545498"  Solid="true"/>
+    <Tile Id="37" Name="Meteorite" Color="#FFDF9F89" Light="true" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="38" Name="Gray Brick" Color="#FF909090" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="39" Name="Red Brick" Color="#FFB200FF" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="40" Name="Clay Block" Color="#FFAC5B4D" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="41" Name="Blue Brick" Color="#FF545498" Solid="true" Blends="true" MergeWith="0" />
     <Tile Id="42" Name="Chain Lantern" Color="#FFEF904B" Placement="ceiling" Light="true" Framed="true" Size="1,2">
       <Frames>
         <Frame UV="0,0" Variety="On" />
         <Frame UV="18,0" Variety="Off" />
       </Frames>
     </Tile>
-    <Tile Id="43" Name="Green Brick" Color="#FF39A851"  Solid="true"/>
-    <Tile Id="44" Name="Pink Brick" Color="#FFB200FF"  Solid="true"/>
-    <Tile Id="45" Name="Gold Brick" Color="#FFFFD514"  Solid="true"/>
-    <Tile Id="46" Name="Silver Brick" Color="#FFE5E5E5"  Solid="true"/>
-    <Tile Id="47" Name="Copper Brick" Color="#FFFF5900"  Solid="true"/>
-    <Tile Id="48" Name="Spike" Color="#FF6D6D6D" Placement="wallFloorCeiling" Solid="true"/>
+    <Tile Id="43" Name="Green Brick" Color="#FF39A851" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="44" Name="Pink Brick" Color="#FFB200FF" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="45" Name="Gold Brick" Color="#FFFFD514" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="46" Name="Silver Brick" Color="#FFE5E5E5" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="47" Name="Copper Brick" Color="#FFFF5900" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="48" Name="Spike" Color="#FF6D6D6D" Placement="wallFloorCeiling" Solid="true" Blends="true" />
     <Tile Id="49" Name="Water Candle" Color="#FF2B8FFF" Placement="surface" Light="true" TextureGrid="16,20" />
     <Tile Id="50" Name="Book" Color="#FF00FFF2" Placement="surface" Framed="true">
       <Frames>
@@ -543,10 +544,10 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="90,0" Variety="Brown, Water Bolt, Gray" />
       </Frames>
     </Tile>
-    <Tile Id="51" Name="Cobweb" Color="#FFFFFFFF" />
-    <Tile Id="52" Name="Vines" Color="#FF0D6524" />
-    <Tile Id="53" Name="Sand Block" Color="#FFFFDA38"  Solid="true"/>
-    <Tile Id="54" Name="Glass" Color="#40FFFFFF"  Solid="true"/>
+    <Tile Id="51" Name="Cobweb" Color="#FFFFFFFF" Blends="true" MergeWith="-1" />
+    <Tile Id="52" Name="Vines" Color="#FF0D6524" Blends="true" />
+    <Tile Id="53" Name="Sand Block" Color="#FFFFDA38" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="54" Name="Glass" Color="#40FFFFFF" Solid="true" Blends="true" />
     <Tile Id="55" Name="Sign" Color="#FFFFAE5E" Placement="wallFloorCeiling" Framed="true" Size="2,2">
       <Frames>
         <Frame UV="0,0" Anchor="Top" />
@@ -555,12 +556,12 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="108,0" Anchor="Right" />
       </Frames>
     </Tile>
-    <Tile Id="56" Name="Obsidian" Color="#FF5751AD"  Solid="true"/>
-    <Tile Id="57" Name="Ash Block" Color="#FF44444C"  Solid="true"/>
-    <Tile Id="58" Name="Hellstone" Color="#FF662222"  Light="true" Solid="true"/>
-    <Tile Id="59" Name="Mud Block" Color="#FF5C4449"  Solid="true"/>
-    <Tile Id="60" Name="Jungle Grass" Color="#FF8FD71D"  Solid="true"/>
-    <Tile Id="61" Name="Jungle Plants" Color="#FF8FD71D"  Light="true" Framed="true" TextureGrid="16,20">
+    <Tile Id="56" Name="Obsidian" Color="#FF5751AD" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="57" Name="Ash Block" Color="#FF44444C" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="58" Name="Hellstone" Color="#FF662222" Light="true" Solid="true" Blends="true" MergeWith="57" />
+    <Tile Id="59" Name="Mud Block" Color="#FF5C4449" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="60" Name="Jungle Grass" Color="#FF8FD71D" Solid="true" Blends="true" MergeWith="59" Special="Grass" />
+    <Tile Id="61" Name="Jungle Plants" Color="#FF8FD71D" Light="true" Framed="true" TextureGrid="16,20">
       <Frames>
         <Frame UV="0,0" Name="Jungle Grass" Anchor="Right" Variety="Single Blade" />
         <Frame UV="18,0" Name="Jungle Grass" Anchor="Right" Variety="Double Blade" />
@@ -574,16 +575,16 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="162,0" Name="Nature's Gift" Anchor="Right" Variety="Immature" />
       </Frames>
     </Tile>
-    <Tile Id="62" Name="Jungle Vines" Color="#FF8ACE1C" />
-    <Tile Id="63" Name="Gem Sapphire" Color="#FF2A82FA"  Solid="true"/>
-    <Tile Id="64" Name="Gem Ruby" Color="#FF2A82FA"  Solid="true"/>
-    <Tile Id="65" Name="Gem Emerald" Color="#FF2A82FA"  Solid="true"/>
-    <Tile Id="66" Name="Gem Topaz" Color="#FF2A82FA"  Solid="true"/>
-    <Tile Id="67" Name="Gem Amethyst" Color="#FF2A82FA"  Solid="true"/>
-    <Tile Id="68" Name="Gem Diamond" Color="#FF2A82FA"  Solid="true"/>
-    <Tile Id="69" Name="Jungle Thorns" Color="#FF5E3037" />
-    <Tile Id="70" Name="Mushroom Grass" Color="#FF5D7FFF"  Light="true" Solid="true"/>
-    <Tile Id="71" Name="Mushroom Plant" Color="#FFB1AE83"  Light="true" Framed="true" TextureGrid="16,20">
+    <Tile Id="62" Name="Jungle Vines" Color="#FF8ACE1C" Blends="true" />
+    <Tile Id="63" Name="Gem Sapphire" Color="#FF2A82FA" Solid="true" Blends="true" MergeWith="0" Stone="true" />
+    <Tile Id="64" Name="Gem Ruby" Color="#FF2A82FA" Solid="true" Blends="true" MergeWith="0" Stone="true" />
+    <Tile Id="65" Name="Gem Emerald" Color="#FF2A82FA" Solid="true" Blends="true" MergeWith="0" Stone="true" />
+    <Tile Id="66" Name="Gem Topaz" Color="#FF2A82FA" Solid="true" Blends="true" MergeWith="0" Stone="true" />
+    <Tile Id="67" Name="Gem Amethyst" Color="#FF2A82FA" Solid="true" Blends="true" MergeWith="0" Stone="true" />
+    <Tile Id="68" Name="Gem Diamond" Color="#FF2A82FA" Solid="true" Blends="true" MergeWith="0" Stone="true" />
+    <Tile Id="69" Name="Jungle Thorns" Color="#FF5E3037" Blends="true" />
+    <Tile Id="70" Name="Mushroom Grass" Color="#FF5D7FFF" Light="true" Solid="true" Blends="true" MergeWith="59" Special="Grass" />
+    <Tile Id="71" Name="Mushroom Plant" Color="#FFB1AE83" Light="true" Framed="true" TextureGrid="16,20">
       <Frames>
         <Frame UV="0,0" Variety="Double Small" />
         <Frame UV="18,0" Variety="Small" />
@@ -592,7 +593,7 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="72,0" Variety="Standard" />
       </Frames>
     </Tile>
-    <Tile Id="72" Name="Mushroom Tree" Color="#FF968F6E"  Light="true" Framed="true">
+    <Tile Id="72" Name="Mushroom Tree" Color="#FF968F6E" Light="true" Framed="true">
       <Frames>
         <Frame UV="0,0" Variety="Trunk A" />
         <Frame UV="18,0" Variety="Tree Top" Anchor="Bottom" />
@@ -602,9 +603,9 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="18,36" Variety="Tree Top" Anchor="Left" />
       </Frames>
     </Tile>
-    <Tile Id="73" Name="Tall Grass" Color="#FF0D6524"  Framed="true" Size="1,1" TextureGrid="16,32">
+    <Tile Id="73" Name="Tall Grass" Color="#FF0D6524" Framed="true" Size="1,1" TextureGrid="16,32">
       <Frames>
-        <Frame UV="0,0" Name="Grass" Variety="G"  Anchor="Bottom" />
+        <Frame UV="0,0" Name="Grass" Variety="G" Anchor="Bottom" />
         <Frame UV="18,0" Name="Grass" Variety="C" Anchor="Bottom" />
         <Frame UV="36,0" Name="Grass" Variety="?" Anchor="Bottom" />
         <Frame UV="54,0" Name="Grass" Variety="u" Anchor="Bottom" />
@@ -614,9 +615,9 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="126,0" Name="Rose" Variety="B" Anchor="Bottom" />
       </Frames>
     </Tile>
-    <Tile Id="74" Name="Tall Jungle Grass" Color="#FF0D6524"  Framed="true" Size="1,1" TextureGrid="16,32">
+    <Tile Id="74" Name="Tall Jungle Grass" Color="#FF0D6524" Framed="true" Size="1,1" TextureGrid="16,32">
       <Frames>
-        <Frame UV="0,0" Name="Jungle Grass" Variety="G"  Anchor="Bottom" />
+        <Frame UV="0,0" Name="Jungle Grass" Variety="G" Anchor="Bottom" />
         <Frame UV="18,0" Name="Jungle Grass" Variety="C" Anchor="Bottom" />
         <Frame UV="36,0" Name="Jungle Grass" Variety="?" Anchor="Bottom" />
         <Frame UV="54,0" Name="Jungle Grass" Variety="u" Anchor="Bottom" />
@@ -626,18 +627,18 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="126,0" Name="Jungle Rose" Variety="B" Anchor="Bottom" />
       </Frames>
     </Tile>
-    <Tile Id="75" Name="Obsidian Brick" Color="#FFB200FF"  Solid="true"/>
-    <Tile Id="76" Name="Hellstone Brick" Color="#FFC6001D"  Light="true" Solid="true"/>
-    <Tile Id="77" Name="Hellforge" Color="#FFD50010" Placement="floor" Light="true" Framed="true" Size="3,2"/>
-    <Tile Id="78" Name="Clay Pot" Color="#FF00FFF2" Placement="floor" Framed="true" Size="1,1"/>
+    <Tile Id="75" Name="Obsidian Brick" Color="#FFB200FF" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="76" Name="Hellstone Brick" Color="#FFC6001D" Light="true" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="77" Name="Hellforge" Color="#FFD50010" Placement="floor" Light="true" Framed="true" Size="3,2" />
+    <Tile Id="78" Name="Clay Pot" Color="#FF00FFF2" Placement="floor" Framed="true" Size="1,1" />
     <Tile Id="79" Name="Bed" Color="#FF00FFF2" Placement="floor" Framed="true" Size="4,2">
       <Frames>
         <Frame UV="0,0" Anchor="Left" />
         <Frame UV="72,0" Variety="Right" />
       </Frames>
     </Tile>
-    <Tile Id="80" Name="Cactus" Color="#FF00A500" />
-    <Tile Id="81" Name="Coral" Color="#FFE55340"  Framed="true" TextureGrid="24,26">
+    <Tile Id="80" Name="Cactus" Color="#FF00A500" Special="Cactus" />
+    <Tile Id="81" Name="Coral" Color="#FFE55340" Framed="true" TextureGrid="24,26">
       <Frames>
         <Frame UV="0,0" Variety="Red" />
         <Frame UV="26,0" Variety="Pink" />
@@ -647,7 +648,7 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="130,0" Variety="Sponge" />
       </Frames>
     </Tile>
-    <Tile Id="82" Name="Herb Sprout" Color="#FFFF7800"  Framed="true">
+    <Tile Id="82" Name="Herb Sprout" Color="#FFFF7800" Framed="true">
       <Frames>
         <Frame UV="0,0" Name="Daybloom" growsOn="2,78" />
         <Frame UV="18,0" Name="Moonglow" growsOn="60,78" />
@@ -657,7 +658,7 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="90,0" Name="Fireblossom" growsOn="57,76,78" />
       </Frames>
     </Tile>
-    <Tile Id="83" Name="Herb Mature" Color="#FFFF7800"  Light="true" Framed="true">
+    <Tile Id="83" Name="Herb Mature" Color="#FFFF7800" Light="true" Framed="true">
       <Frames>
         <Frame UV="0,0" Name="Daybloom" growsOn="2,78" />
         <Frame UV="18,0" Name="Moonglow" growsOn="60,78" />
@@ -667,7 +668,7 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="90,0" Name="Fireblossom" growsOn="57,76,78" />
       </Frames>
     </Tile>
-    <Tile Id="84" Name="Herb Bloom" Color="#FFFF7800"  Light="true" Framed="true">
+    <Tile Id="84" Name="Herb Bloom" Color="#FFFF7800" Light="true" Framed="true">
       <Frames>
         <Frame UV="0,0" Name="Daybloom" growsOn="2,78" />
         <Frame UV="18,0" Name="Moonglow" growsOn="60,78" />
@@ -685,10 +686,10 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="108,0" Variety="D" />
       </Frames>
     </Tile>
-    <Tile Id="86" Name="Loom" Color="#FFFF00FF" Placement="floor" Framed="true" Size="3,2"/>
-    <Tile Id="87" Name="Piano" Color="#FF00FFF2" Placement="floor" SolidTop="true" Framed="true" Size="3,2"/>
-    <Tile Id="88" Name="Dresser" Color="#FF00FFF2" Placement="floor" SolidTop="true" Framed="true" Size="3,2"/>
-    <Tile Id="89" Name="Bench" Color="#FF00FFF2" Placement="floor" Framed="true" Size="3,2"/>
+    <Tile Id="86" Name="Loom" Color="#FFFF00FF" Placement="floor" Framed="true" Size="3,2" />
+    <Tile Id="87" Name="Piano" Color="#FF00FFF2" Placement="floor" SolidTop="true" Framed="true" Size="3,2" />
+    <Tile Id="88" Name="Dresser" Color="#FF00FFF2" Placement="floor" SolidTop="true" Framed="true" Size="3,2" />
+    <Tile Id="89" Name="Bench" Color="#FF00FFF2" Placement="floor" Framed="true" Size="3,2" />
     <Tile Id="90" Name="Bathtub" Color="#FF00FFF2" Placement="floor" Framed="true" Size="4,2">
       <Frames>
         <Frame UV="0,0" Anchor="Left" />
@@ -715,27 +716,27 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="18,0" Variety="Off" />
       </Frames>
     </Tile>
-    <Tile Id="94" Name="Keg" Color="#FF00FFF2" Placement="floor" Framed="true" Size="2,2"/>
+    <Tile Id="94" Name="Keg" Color="#FF00FFF2" Placement="floor" Framed="true" Size="2,2" />
     <Tile Id="95" Name="Chinese Lantern" Color="#FF00FFF2" Placement="floorSurface" Light="true" Framed="true" Size="2,2">
       <Frames>
         <Frame UV="0,0" Variety="On" />
         <Frame UV="36,0" Variety="Off" />
       </Frames>
     </Tile>
-    <Tile Id="96" Name="Cooking Pot" Color="#FF00FFF2" Placement="floorSurface" Framed="true" Size="2,2"/>
-    <Tile Id="97" Name="Safe" Color="#FFFF00FF" Placement="floor" Framed="true" Size="2,2"/>
-    <Tile Id="98" Name="Skull Lantern" Color="#FFFF00FF" Placement="floorSurface" Light="true" Framed="true" Size="2,2"/>
-    <Tile Id="99" Name="Trash Can" Color="#FFFF00D0" Placement="floor" Framed="true" Size="2,2"/>
+    <Tile Id="96" Name="Cooking Pot" Color="#FF00FFF2" Placement="floorSurface" Framed="true" Size="2,2" />
+    <Tile Id="97" Name="Safe" Color="#FFFF00FF" Placement="floor" Framed="true" Size="2,2" />
+    <Tile Id="98" Name="Skull Lantern" Color="#FFFF00FF" Placement="floorSurface" Light="true" Framed="true" Size="2,2" />
+    <Tile Id="99" Name="Trash Can" Color="#FFFF00D0" Placement="floor" Framed="true" Size="2,2" />
     <Tile Id="100" Name="Candelabra" Color="#FFFF00FF" Placement="surface" Light="true" Framed="true" Size="2,2">
       <Frames>
         <Frame UV="0,0" Variety="On" />
         <Frame UV="36,0" Variety="Off" />
       </Frames>
     </Tile>
-    <Tile Id="101" Name="Bookcase" Color="#FFFF00FF" Placement="floor" SolidTop="true" Framed="true" Size="3,4"/>
-    <Tile Id="102" Name="Throne" Color="#FFFF00FF" Placement="floor" Framed="true" Size="3,4"/>
-    <Tile Id="103" Name="Bowl" Color="#FFFF00FF" Placement="surface" Framed="true" Size="2,1"/>
-    <Tile Id="104" Name="Grandfather Clock" Color="#FFFF00FF" Placement="floor" Framed="true" Size="2,5"/>
+    <Tile Id="101" Name="Bookcase" Color="#FFFF00FF" Placement="floor" SolidTop="true" Framed="true" Size="3,4" />
+    <Tile Id="102" Name="Throne" Color="#FFFF00FF" Placement="floor" Framed="true" Size="3,4" />
+    <Tile Id="103" Name="Bowl" Color="#FFFF00FF" Placement="surface" Framed="true" Size="2,1" />
+    <Tile Id="104" Name="Grandfather Clock" Color="#FFFF00FF" Placement="floor" Framed="true" Size="2,5" />
     <Tile Id="105" Name="Statue" Color="#FF00FFF2" Placement="floor" Framed="true" Size="2,3">
       <Frames>
         <Frame UV="0,0" Variety="Armor Statue" />
@@ -783,11 +784,11 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="1512,0" Variety="Pirahna Statue" />
       </Frames>
     </Tile>
-    <Tile Id="106" Name="Sawmill" Color="#FF00FFF2" Placement="floor" Framed="true" Size="3,3"/>
-    <Tile Id="107" Name="Cobalt Ore" Color="#FF0B508F"  Solid="true"/>
-    <Tile Id="108" Name="Mythril Ore" Color="#FF5BA9A9"  Solid="true"/>
-    <Tile Id="109" Name="Hallowed" Color="#FF4EC1E3"  Light="true" Solid="true"/>
-    <Tile Id="110" Name="Hallowed Plants" Color="#FF1E9648"  Framed="true" TextureGrid="16,20">
+    <Tile Id="106" Name="Sawmill" Color="#FF00FFF2" Placement="floor" Framed="true" Size="3,3" />
+    <Tile Id="107" Name="Cobalt Ore" Color="#FF0B508F" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="108" Name="Mythril Ore" Color="#FF5BA9A9" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="109" Name="Hallowed" Color="#FF4EC1E3" Light="true" Solid="true" Blends="true" MergeWith="0" Special="Grass" />
+    <Tile Id="110" Name="Hallowed Plants" Color="#FF1E9648" Framed="true" TextureGrid="16,20">
       <Frames>
         <Frame UV="0,0" Name="Grass" Anchor="Right" Variety="Single Blade" />
         <Frame UV="18,0" Name="Grass" Anchor="Right" Variety="Double Blade" />
@@ -801,11 +802,11 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="162,0" Name="Small Y" Anchor="Bottom" />
       </Frames>
     </Tile>
-    <Tile Id="111" Name="Adamantite Ore" Color="#FF801A34"  Solid="true"/>
-    <Tile Id="112" Name="Ebonsand Block" Color="#FF67627A"  Solid="true"/>
-    <Tile Id="113" Name="Hallowed Tall Plants" Color="#FF1E9648"  Framed="true" TextureGrid="16,32" >
+    <Tile Id="111" Name="Adamantite Ore" Color="#FF801A34" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="112" Name="Ebonsand Block" Color="#FF67627A" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="113" Name="Hallowed Tall Plants" Color="#FF1E9648" Framed="true" TextureGrid="16,32">
       <Frames>
-        <Frame UV="0,0" Name="Grass" Variety="G"  Anchor="Bottom" />
+        <Frame UV="0,0" Name="Grass" Variety="G" Anchor="Bottom" />
         <Frame UV="18,0" Name="Grass" Variety="C" Anchor="Bottom" />
         <Frame UV="36,0" Name="Grass" Variety="?" Anchor="Bottom" />
         <Frame UV="54,0" Name="Grass" Variety="u" Anchor="Bottom" />
@@ -815,26 +816,26 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="126,0" Name="Rose" Variety="B" Anchor="Bottom" />
       </Frames>
     </Tile>
-    <Tile Id="114" Name="Tinkerer's Workshop" Color="#FF7F5C45"  SolidTop="true" Framed="true" Size="3,2" TextureGrid="16,18"/>
-    <Tile Id="115" Name="Vines" Color="#FF327FA1" />
-    <Tile Id="116" Name="Pearlsand Block" Color="#FFD5C4C5"  Solid="true"/>
-    <Tile Id="117" Name="Pearlstone Block" Color="#FFB5ACBE"  Solid="true"/>
-    <Tile Id="118" Name="Pearlstone Brick" Color="#FFD5C4C5"  Solid="true"/>
-    <Tile Id="119" Name="Iridescent Brick" Color="#FF3F3F49"  Solid="true"/>
-    <Tile Id="120" Name="Mudstone Block" Color="#FF967A7D"  Solid="true"/>
-    <Tile Id="121" Name="Cobalt Brick" Color="#FF2576AB"  Solid="true"/>
-    <Tile Id="122" Name="Mythril Brick" Color="#FF91BF75"  Solid="true"/>
-    <Tile Id="123" Name="Silt Block" Color="#FF595353"  Solid="true"/>
-    <Tile Id="124" Name="Wooden Beam" Color="#FF5C4436" />
-    <Tile Id="125" Name="Crystal Ball" Color="#FF81A5FF"  Light="true" Framed="true"  Size="2,2"/>
-    <Tile Id="126" Name="Disco Ball" Color="#FFDBDBDB"  Light="true" Framed="true"  Size="2,2">
+    <Tile Id="114" Name="Tinkerer's Workshop" Color="#FF7F5C45" SolidTop="true" Framed="true" Size="3,2" TextureGrid="16,18" />
+    <Tile Id="115" Name="Vines" Color="#FF327FA1" Blends="true" />
+    <Tile Id="116" Name="Pearlsand Block" Color="#FFD5C4C5" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="117" Name="Pearlstone Block" Color="#FFB5ACBE" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="118" Name="Pearlstone Brick" Color="#FFD5C4C5" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="119" Name="Iridescent Brick" Color="#FF3F3F49" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="120" Name="Mudstone Block" Color="#FF967A7D" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="121" Name="Cobalt Brick" Color="#FF2576AB" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="122" Name="Mythril Brick" Color="#FF91BF75" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="123" Name="Silt Block" Color="#FF595353" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="124" Name="Wooden Beam" Color="#FF5C4436" Blends="true" />
+    <Tile Id="125" Name="Crystal Ball" Color="#FF81A5FF" Light="true" Framed="true" Size="2,2" />
+    <Tile Id="126" Name="Disco Ball" Color="#FFDBDBDB" Light="true" Framed="true" Size="2,2">
       <Frames>
         <Frame UV="0,0" Variety="On" />
         <Frame UV="36,0" Variety="Off" />
       </Frames>
     </Tile>
-    <Tile Id="127" Name="Ice" Color="#FF68B3C8"  Solid="true"/>
-    <Tile Id="128" Name="Mannequin" Color="#FF906850"  Framed="true" Size="2,3">
+    <Tile Id="127" Name="Ice" Color="#FF68B3C8" Solid="true" Blends="true" />
+    <Tile Id="128" Name="Mannequin" Color="#FF906850" Framed="true" Size="2,3">
       <Frames>
         <Frame UV="0,0" Anchor="Left" />
         <Frame UV="36,0" Anchor="Right" />
@@ -847,81 +848,81 @@ Single item; tag has no children. Has the following properties:
         <Frame UV="36,0" Variety="Purple" Anchor="Bottom" />
       </Frames>
     </Tile>
-    <Tile Id="130" Name="Active Stone Block" Color="#FFA5A5A5"  Solid="true"/>
-    <Tile Id="131" Name="Inactive Stone Block" Color="#FF1A1A1A" />
-    <Tile Id="132" Name="Lever" Color="#FFC90303"  Framed="true" Size="2,2">
+    <Tile Id="130" Name="Active Stone Block" Color="#FFA5A5A5" Solid="true" Blends="true" MergeWith="0" Stone="true" />
+    <Tile Id="131" Name="Inactive Stone Block" Color="#FF1A1A1A" Blends="true" MergeWith="0" Stone="true" />
+    <Tile Id="132" Name="Lever" Color="#FFC90303" Framed="true" Size="2,2">
       <Frames>
         <Frame UV="0,0" Anchor="Left" />
         <Frame UV="36,0" Anchor="Right" />
       </Frames>
     </Tile>
-    <Tile Id="133" Name="Adamantite Forge" Color="#FF891012"  Light="true" Framed="true" Size="3,2"/>
-    <Tile Id="134" Name="Mythril Anvil" Color="#FF96AE87"  Framed="true" Size="2,1" />
-    <Tile Id="135" Name="Pressure Plate" Color="#FFFD7272"  Framed="true">
+    <Tile Id="133" Name="Adamantite Forge" Color="#FF891012" Light="true" Framed="true" Size="3,2" />
+    <Tile Id="134" Name="Mythril Anvil" Color="#FF96AE87" Framed="true" Size="2,1" />
+    <Tile Id="135" Name="Pressure Plate" Color="#FFFD7272" Framed="true">
       <Frames>
         <Frame UV="0,0" Variety="Red" />
         <Frame UV="0,18" Variety="Green" />
       </Frames>
     </Tile>
-    <Tile Id="136" Name="Switch" Color="#FFCCC0C0"  Framed="true"/>
-    <Tile Id="137" Name="Dart Trap" Color="#FF8C8C8C"  Solid="true" Framed="true">
+    <Tile Id="136" Name="Switch" Color="#FFCCC0C0" Framed="true" />
+    <Tile Id="137" Name="Dart Trap" Color="#FF8C8C8C" Solid="true" Framed="true">
       <Frames>
         <Frame UV="0,0" Anchor="Left" />
         <Frame UV="18,0" Variety="Right" />
       </Frames>
     </Tile>
-    <Tile Id="138" Name="Boulder" Color="#FF636363"  Solid="true" Framed="true" Size="2,2"/>
-    <Tile Id="139" Name="Music Box" Color="#FF996343"  Framed="true" Size="2,2">
+    <Tile Id="138" Name="Boulder" Color="#FF636363" Solid="true" Framed="true" Size="2,2" />
+    <Tile Id="139" Name="Music Box" Color="#FF996343" Framed="true" Size="2,2">
       <Frames>
         <Frame UV="0,0" Name="Music Box (Overworld Day)" Variety="Off" />
         <Frame UV="36,0" Name="Music Box (Overworld Day)" Variety="On" />
-        <Frame UV="0,36" Name="Music Box (Eerie)"  Variety="Off"  />
-        <Frame UV="36,36" Name="Music Box (Eerie)" Variety="On"  />
+        <Frame UV="0,36" Name="Music Box (Eerie)" Variety="Off" />
+        <Frame UV="36,36" Name="Music Box (Eerie)" Variety="On" />
         <Frame UV="0,72" Name="Music Box (Night)" Variety="Off" />
-        <Frame UV="36,72" Name="Music Box (Night)" Variety="On"  />
-        <Frame UV="0,108" Name="Music Box (Title)" Variety="Off"/>
+        <Frame UV="36,72" Name="Music Box (Night)" Variety="On" />
+        <Frame UV="0,108" Name="Music Box (Title)" Variety="Off" />
         <Frame UV="36,108" Name="Music Box (Title)" Variety="On" />
-        <Frame UV="0,144" Name="Music Box (Underground)" Variety="Off"/>
+        <Frame UV="0,144" Name="Music Box (Underground)" Variety="Off" />
         <Frame UV="36,144" Name="Music Box (Underground)" Variety="On" />
-        <Frame UV="0,180" Name="Music Box (Boss 1)" Variety="Off"/>
+        <Frame UV="0,180" Name="Music Box (Boss 1)" Variety="Off" />
         <Frame UV="36,180" Name="Music Box (Boss 1)" Variety="On" />
-        <Frame UV="0,216" Name="Music Box (Jungle)" Variety="Off"/>
+        <Frame UV="0,216" Name="Music Box (Jungle)" Variety="Off" />
         <Frame UV="36,216" Name="Music Box (Jungle)" Variety="On" />
-        <Frame UV="0,252" Name="Music Box (Corruption)" Variety="Off"/>
+        <Frame UV="0,252" Name="Music Box (Corruption)" Variety="Off" />
         <Frame UV="36,252" Name="Music Box (Corruption)" Variety="On" />
-        <Frame UV="0,288" Name="Music Box (Underground Corruption)" Variety="Off"/>
+        <Frame UV="0,288" Name="Music Box (Underground Corruption)" Variety="Off" />
         <Frame UV="36,288" Name="Music Box (Underground Corruption)" Variety="On" />
-        <Frame UV="0,324" Name="Music Box (The Hallow)" Variety="Off"/>
+        <Frame UV="0,324" Name="Music Box (The Hallow)" Variety="Off" />
         <Frame UV="36,324" Name="Music Box (The Hallow)" Variety="On" />
-        <Frame UV="0,360" Name="Music Box (Boss 2)" Variety="Off"/>
+        <Frame UV="0,360" Name="Music Box (Boss 2)" Variety="Off" />
         <Frame UV="36,360" Name="Music Box (Boss 2)" Variety="On" />
-        <Frame UV="0,396" Name="Music Box (Underground Hallow)" Variety="Off"/>
+        <Frame UV="0,396" Name="Music Box (Underground Hallow)" Variety="Off" />
         <Frame UV="36,396" Name="Music Box (Underground Hallow)" Variety="On" />
-        <Frame UV="0,432" Name="Music Box (Boss 3)" Variety="Off"/>
+        <Frame UV="0,432" Name="Music Box (Boss 3)" Variety="Off" />
         <Frame UV="36,432" Name="Music Box (Boss 3)" Variety="On" />
       </Frames>
     </Tile>
-    <Tile Id="140" Name="Demonite Brick" Color="#FF7875B3"  Light="true" Solid="true"/>
-    <Tile Id="141" Name="Explosives" Color="#FFAD2323"  Framed="true" Size="1,1">
+    <Tile Id="140" Name="Demonite Brick" Color="#FF7875B3" Light="true" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="141" Name="Explosives" Color="#FFAD2323" Framed="true" Size="1,1">
       <Frames>
         <Frame UV="0,0" Variety="Single" />
         <Frame UV="0,18" Variety="Multi" />
       </Frames>
     </Tile>
-    <Tile Id="142" Name="Inlet Pump" Color="#FFC90303"  Framed="true" Size="2,2"/>
-    <Tile Id="143" Name="Outlet Pump" Color="#FFC90303"  Framed="true" Size="2,2"/>
-    <Tile Id="144" Name="Timer" Color="#FFC90303"  Framed="true">
+    <Tile Id="142" Name="Inlet Pump" Color="#FFC90303" Framed="true" Size="2,2" />
+    <Tile Id="143" Name="Outlet Pump" Color="#FFC90303" Framed="true" Size="2,2" />
+    <Tile Id="144" Name="Timer" Color="#FFC90303" Framed="true">
       <Frames>
         <Frame UV="0,0" Variety="1 Second" />
         <Frame UV="18,0" Variety="3 Second" />
         <Frame UV="36,0" Variety="5 Second" />
       </Frames>
     </Tile>
-    <Tile Id="145" Name="Candy Cane Block" Color="#FFFF0000"  Solid="true"/>
-    <Tile Id="146" Name="Green Candy Cane Block" Color="#FF00FF00"  Solid="true"/>
-    <Tile Id="147" Name="Snow Block" Color="#FFEEEEFF"  Solid="true"/>
-    <Tile Id="148" Name="Snow Brick" Color="#FFCCCCEE"  Solid="true"/>
-    <Tile Id="149" Name="Blue Light" Color="#FFFF0000"  Light="true" Framed="true" Size="1,1">
+    <Tile Id="145" Name="Candy Cane Block" Color="#FFFF0000" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="146" Name="Green Candy Cane Block" Color="#FF00FF00" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="147" Name="Snow Block" Color="#FFEEEEFF" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="148" Name="Snow Brick" Color="#FFCCCCEE" Solid="true" Blends="true" MergeWith="0" />
+    <Tile Id="149" Name="Blue Light" Color="#FFFF0000" Light="true" Framed="true" Size="1,1">
       <Frames>
         <Frame UV="0,0" Name="Blue Light" />
         <Frame UV="18,0" Name="Red Light" />
@@ -964,634 +965,634 @@ Single item; tag has no children. Has the following properties:
     <Wall Id="31" Name="Snow Wall" Color="#FF9999BB" />
   </Walls>
   <Items>
-    <Item Id="-24" Name="Yellow Phasesaber"/>
-    <Item Id="-23" Name="White Phasesaber"/>
-    <Item Id="-22" Name="Purple Phasesaber"/>
-    <Item Id="-21" Name="Green Phasesaber"/>
-    <Item Id="-20" Name="Red Phasesaber"/>
-    <Item Id="-19" Name="Blue Phasesaber"/>
-    <Item Id="-18" Name="Copper Bow"/>
-    <Item Id="-17" Name="Copper Hammer"/>
-    <Item Id="-16" Name="Copper Axe"/>
-    <Item Id="-15" Name="Copper Shortsword"/>
-    <Item Id="-14" Name="Copper Broadsword"/>
-    <Item Id="-13" Name="Copper Pickaxe"/>
-    <Item Id="-12" Name="Silver Bow"/>
-    <Item Id="-11" Name="Silver Hammer"/>
-    <Item Id="-10" Name="Silver Axe"/>
-    <Item Id="-9" Name="Silver Shortsword"/>
-    <Item Id="-8" Name="Silver Broadsword"/>
-    <Item Id="-7" Name="Silver Pickaxe"/>
-    <Item Id="-6" Name="Gold Bow"/>
-    <Item Id="-5" Name="Gold Hammer"/>
-    <Item Id="-4" Name="Gold Axe"/>
-    <Item Id="-3" Name="Gold Shortsword"/>
-    <Item Id="-2" Name="Gold Broadsword"/>
-    <Item Id="-1" Name="Gold Pickaxe"/>
-    <Item Id="0" Name="[empty]"/>
-    <Item Id="1" Name="Iron Pickaxe"/>
-    <Item Id="2" Name="Dirt Block"/>
-    <Item Id="3" Name="Stone Block"/>
-    <Item Id="4" Name="Iron Broadsword"/>
-    <Item Id="5" Name="Mushroom"/>
-    <Item Id="6" Name="Iron Shortsword"/>
-    <Item Id="7" Name="Iron Hammer"/>
-    <Item Id="8" Name="Torch"/>
-    <Item Id="9" Name="Wood"/>
-    <Item Id="10" Name="Iron Axe"/>
-    <Item Id="11" Name="Iron Ore"/>
-    <Item Id="12" Name="Copper Ore"/>
-    <Item Id="13" Name="Gold Ore"/>
-    <Item Id="14" Name="Silver Ore"/>
-    <Item Id="15" Name="Copper Watch"/>
-    <Item Id="16" Name="Silver Watch"/>
-    <Item Id="17" Name="Gold Watch"/>
-    <Item Id="18" Name="Depth Meter"/>
-    <Item Id="19" Name="Gold Bar"/>
-    <Item Id="20" Name="Copper Bar"/>
-    <Item Id="21" Name="Silver Bar"/>
-    <Item Id="22" Name="Iron Bar"/>
-    <Item Id="23" Name="Gel"/>
-    <Item Id="24" Name="Wooden Sword"/>
-    <Item Id="25" Name="Wooden Door"/>
-    <Item Id="26" Name="Stone Wall"/>
-    <Item Id="27" Name="Acorn"/>
-    <Item Id="28" Name="Lesser Healing Potion"/>
-    <Item Id="29" Name="Life Crystal"/>
-    <Item Id="30" Name="Dirt Wall"/>
-    <Item Id="31" Name="Bottle"/>
-    <Item Id="32" Name="Wooden Table"/>
-    <Item Id="33" Name="Furnace"/>
-    <Item Id="34" Name="Wooden Chair"/>
-    <Item Id="35" Name="Iron Anvil"/>
-    <Item Id="36" Name="Work Bench"/>
-    <Item Id="37" Name="Goggles"/>
-    <Item Id="38" Name="Lens"/>
-    <Item Id="39" Name="Wooden Bow"/>
-    <Item Id="40" Name="Wooden Arrow"/>
-    <Item Id="41" Name="Flaming Arrow"/>
-    <Item Id="42" Name="Shuriken"/>
-    <Item Id="43" Name="Suspicious Looking Eye"/>
-    <Item Id="44" Name="Demon Bow"/>
-    <Item Id="45" Name="War Axe of the Night"/>
-    <Item Id="46" Name="Light's Bane"/>
-    <Item Id="47" Name="Unholy Arrow"/>
-    <Item Id="48" Name="Chest"/>
-    <Item Id="49" Name="Band of Regeneration"/>
-    <Item Id="50" Name="Magic Mirror"/>
-    <Item Id="51" Name="Jester's Arrow"/>
-    <Item Id="52" Name="Angel Statue"/>
-    <Item Id="53" Name="Cloud in a Bottle"/>
-    <Item Id="54" Name="Hermes Boots"/>
-    <Item Id="55" Name="Enchanted Boomerang"/>
-    <Item Id="56" Name="Demonite Ore"/>
-    <Item Id="57" Name="Demonite Bar"/>
-    <Item Id="58" Name="Heart"/>
-    <Item Id="59" Name="Corrupt Seeds"/>
-    <Item Id="60" Name="Vile Mushroom"/>
-    <Item Id="61" Name="Ebonstone Block"/>
-    <Item Id="62" Name="Grass Seeds"/>
-    <Item Id="63" Name="Sunflower"/>
-    <Item Id="64" Name="Vilethorn"/>
-    <Item Id="65" Name="Starfury"/>
-    <Item Id="66" Name="Purification Powder"/>
-    <Item Id="67" Name="Vile Powder"/>
-    <Item Id="68" Name="Rotten Chunk"/>
-    <Item Id="69" Name="Worm Tooth"/>
-    <Item Id="70" Name="Worm Food"/>
-    <Item Id="71" Name="Copper Coin"/>
-    <Item Id="72" Name="Silver Coin"/>
-    <Item Id="73" Name="Gold Coin"/>
-    <Item Id="74" Name="Platinum Coin"/>
-    <Item Id="75" Name="Fallen Star"/>
-    <Item Id="76" Name="Copper Greaves"/>
-    <Item Id="77" Name="Iron Greaves"/>
-    <Item Id="78" Name="Silver Greaves"/>
-    <Item Id="79" Name="Gold Greaves"/>
-    <Item Id="80" Name="Copper Chainmail"/>
-    <Item Id="81" Name="Iron Chainmail"/>
-    <Item Id="82" Name="Silver Chainmail"/>
-    <Item Id="83" Name="Gold Chainmail"/>
-    <Item Id="84" Name="Grappling Hook"/>
-    <Item Id="85" Name="Iron Chain"/>
-    <Item Id="86" Name="Shadow Scale"/>
-    <Item Id="87" Name="Piggy Bank"/>
-    <Item Id="88" Name="Mining Helmet"/>
-    <Item Id="89" Name="Copper Helmet"/>
-    <Item Id="90" Name="Iron Helmet"/>
-    <Item Id="91" Name="Silver Helmet"/>
-    <Item Id="92" Name="Gold Helmet"/>
-    <Item Id="93" Name="Wood Wall"/>
-    <Item Id="94" Name="Wood Platform"/>
-    <Item Id="95" Name="Flintlock Pistol"/>
-    <Item Id="96" Name="Musket"/>
-    <Item Id="97" Name="Musket Ball"/>
-    <Item Id="98" Name="Minishark"/>
-    <Item Id="99" Name="Iron Bow"/>
-    <Item Id="100" Name="Shadow Greaves"/>
-    <Item Id="101" Name="Shadow Scalemail"/>
-    <Item Id="102" Name="Shadow Helmet"/>
-    <Item Id="103" Name="Nightmare Pickaxe"/>
-    <Item Id="104" Name="The Breaker"/>
-    <Item Id="105" Name="Candle"/>
-    <Item Id="106" Name="Copper Chandelier"/>
-    <Item Id="107" Name="Silver Chandelier"/>
-    <Item Id="108" Name="Gold Chandelier"/>
-    <Item Id="109" Name="Mana Crystal"/>
-    <Item Id="110" Name="Lesser Mana Potion"/>
-    <Item Id="111" Name="Band of Starpower"/>
-    <Item Id="112" Name="Flower of Fire"/>
-    <Item Id="113" Name="Magic Missile"/>
-    <Item Id="114" Name="Dirt Rod"/>
-    <Item Id="115" Name="Orb of Light"/>
-    <Item Id="116" Name="Meteorite"/>
-    <Item Id="117" Name="Meteorite Bar"/>
-    <Item Id="118" Name="Hook"/>
-    <Item Id="119" Name="Flamarang"/>
-    <Item Id="120" Name="Molten Fury"/>
-    <Item Id="121" Name="Fiery Greatsword"/>
-    <Item Id="122" Name="Molten Pickaxe"/>
-    <Item Id="123" Name="Meteor Helmet"/>
-    <Item Id="124" Name="Meteor Suit"/>
-    <Item Id="125" Name="Meteor Leggings"/>
-    <Item Id="126" Name="Bottled Water"/>
-    <Item Id="127" Name="Space Gun"/>
-    <Item Id="128" Name="Rocket Boots"/>
-    <Item Id="129" Name="Gray Brick"/>
-    <Item Id="130" Name="Gray Brick Wall"/>
-    <Item Id="131" Name="Red Brick"/>
-    <Item Id="132" Name="Red Brick Wall"/>
-    <Item Id="133" Name="Clay Block"/>
-    <Item Id="134" Name="Blue Brick"/>
-    <Item Id="135" Name="Blue Brick Wall"/>
-    <Item Id="136" Name="Chain Lantern"/>
-    <Item Id="137" Name="Green Brick"/>
-    <Item Id="138" Name="Green Brick Wall"/>
-    <Item Id="139" Name="Pink Brick"/>
-    <Item Id="140" Name="Pink Brick Wall"/>
-    <Item Id="141" Name="Gold Brick"/>
-    <Item Id="142" Name="Gold Brick Wall"/>
-    <Item Id="143" Name="Silver Brick"/>
-    <Item Id="144" Name="Silver Brick Wall"/>
-    <Item Id="145" Name="Copper Brick"/>
-    <Item Id="146" Name="Copper Brick Wall"/>
-    <Item Id="147" Name="Spike"/>
-    <Item Id="148" Name="Water Candle"/>
-    <Item Id="149" Name="Book"/>
-    <Item Id="150" Name="Cobweb"/>
-    <Item Id="151" Name="Necro Helmet"/>
-    <Item Id="152" Name="Necro Breastplate"/>
-    <Item Id="153" Name="Necro Greaves"/>
-    <Item Id="154" Name="Bone"/>
-    <Item Id="155" Name="Muramasa"/>
-    <Item Id="156" Name="Cobalt Shield"/>
-    <Item Id="157" Name="Aqua Scepter"/>
-    <Item Id="158" Name="Lucky Horseshoe"/>
-    <Item Id="159" Name="Shiny Red Balloon"/>
-    <Item Id="160" Name="Harpoon"/>
-    <Item Id="161" Name="Spiky Ball"/>
-    <Item Id="162" Name="Ball O' Hurt"/>
-    <Item Id="163" Name="Blue Moon"/>
-    <Item Id="164" Name="Handgun"/>
-    <Item Id="165" Name="Water Bolt"/>
-    <Item Id="166" Name="Bomb"/>
-    <Item Id="167" Name="Dynamite"/>
-    <Item Id="168" Name="Grenade"/>
-    <Item Id="169" Name="Sand Block"/>
-    <Item Id="170" Name="Glass"/>
-    <Item Id="171" Name="Sign"/>
-    <Item Id="172" Name="Ash Block"/>
-    <Item Id="173" Name="Obsidian"/>
-    <Item Id="174" Name="Hellstone"/>
-    <Item Id="175" Name="Hellstone Bar"/>
-    <Item Id="176" Name="Mud Block"/>
-    <Item Id="177" Name="Sapphire"/>
-    <Item Id="178" Name="Ruby"/>
-    <Item Id="179" Name="Emerald"/>
-    <Item Id="180" Name="Topaz"/>
-    <Item Id="181" Name="Amethyst"/>
-    <Item Id="182" Name="Diamond"/>
-    <Item Id="183" Name="Glowing Mushroom"/>
-    <Item Id="184" Name="Star"/>
-    <Item Id="185" Name="Ivy Whip"/>
-    <Item Id="186" Name="Breathing Reed"/>
-    <Item Id="187" Name="Flipper"/>
-    <Item Id="188" Name="Healing Potion"/>
-    <Item Id="189" Name="Mana Potion"/>
-    <Item Id="190" Name="Blade of Grass"/>
-    <Item Id="191" Name="Thorn Chakram"/>
-    <Item Id="192" Name="Obsidian Brick"/>
-    <Item Id="193" Name="Obsidian Skull"/>
-    <Item Id="194" Name="Mushroom Grass Seeds"/>
-    <Item Id="195" Name="Jungle Grass Seeds"/>
-    <Item Id="196" Name="Wooden Hammer"/>
-    <Item Id="197" Name="Star Cannon"/>
-    <Item Id="198" Name="Blue Phaseblade"/>
-    <Item Id="199" Name="Red Phaseblade"/>
-    <Item Id="200" Name="Green Phaseblade"/>
-    <Item Id="201" Name="Purple Phaseblade"/>
-    <Item Id="202" Name="White Phaseblade"/>
-    <Item Id="203" Name="Yellow Phaseblade"/>
-    <Item Id="204" Name="Meteor Hamaxe"/>
-    <Item Id="205" Name="Empty Bucket"/>
-    <Item Id="206" Name="Water Bucket"/>
-    <Item Id="207" Name="Lava Bucket"/>
-    <Item Id="208" Name="Jungle Rose"/>
-    <Item Id="209" Name="Stinger"/>
-    <Item Id="210" Name="Vine"/>
-    <Item Id="211" Name="Feral Claws"/>
-    <Item Id="212" Name="Anklet of the Wind"/>
-    <Item Id="213" Name="Staff of Regrowth"/>
-    <Item Id="214" Name="Hellstone Brick"/>
-    <Item Id="215" Name="Whoopie Cushion"/>
-    <Item Id="216" Name="Shackle"/>
-    <Item Id="217" Name="Molten Hamaxe"/>
-    <Item Id="218" Name="Flamelash"/>
-    <Item Id="219" Name="Phoenix Blaster"/>
-    <Item Id="220" Name="Sunfury"/>
-    <Item Id="221" Name="Hellforge"/>
-    <Item Id="222" Name="Clay Pot"/>
-    <Item Id="223" Name="Nature's Gift"/>
-    <Item Id="224" Name="Bed"/>
-    <Item Id="225" Name="Silk"/>
-    <Item Id="226" Name="Lesser Restoration Potion"/>
-    <Item Id="227" Name="Restoration Potion"/>
-    <Item Id="228" Name="Jungle Hat"/>
-    <Item Id="229" Name="Jungle Shirt"/>
-    <Item Id="230" Name="Jungle Pants"/>
-    <Item Id="231" Name="Molten Helmet"/>
-    <Item Id="232" Name="Molten Breastplate"/>
-    <Item Id="233" Name="Molten Greaves"/>
-    <Item Id="234" Name="Meteor Shot"/>
-    <Item Id="235" Name="Sticky Bomb"/>
-    <Item Id="236" Name="Black Lens"/>
-    <Item Id="237" Name="Sunglasses"/>
-    <Item Id="238" Name="Wizard Hat"/>
-    <Item Id="239" Name="Top Hat"/>
-    <Item Id="240" Name="Tuxedo Shirt"/>
-    <Item Id="241" Name="Tuxedo Pants"/>
-    <Item Id="242" Name="Summer Hat"/>
-    <Item Id="243" Name="Bunny Hood"/>
-    <Item Id="244" Name="Plumber's Hat"/>
-    <Item Id="245" Name="Plumber's Shirt"/>
-    <Item Id="246" Name="Plumber's Pants"/>
-    <Item Id="247" Name="Hero's Hat"/>
-    <Item Id="248" Name="Hero's Shirt"/>
-    <Item Id="249" Name="Hero's Pants"/>
-    <Item Id="250" Name="Fish Bowl"/>
-    <Item Id="251" Name="Archaeologist's Hat"/>
-    <Item Id="252" Name="Archaeologist's Jacket"/>
-    <Item Id="253" Name="Archaeologist's Pants"/>
-    <Item Id="254" Name="Black Dye"/>
-    <Item Id="255" Name="Green Dye"/>
-    <Item Id="256" Name="Ninja Hood"/>
-    <Item Id="257" Name="Ninja Shirt"/>
-    <Item Id="258" Name="Ninja Pants"/>
-    <Item Id="259" Name="Leather"/>
-    <Item Id="260" Name="Red Hat"/>
-    <Item Id="261" Name="Goldfish"/>
-    <Item Id="262" Name="Robe"/>
-    <Item Id="263" Name="Robot Hat"/>
-    <Item Id="264" Name="Gold Crown"/>
-    <Item Id="265" Name="Hellfire Arrow"/>
-    <Item Id="266" Name="Sandgun"/>
-    <Item Id="267" Name="Guide Voodoo Doll"/>
-    <Item Id="268" Name="Diving Helmet"/>
-    <Item Id="269" Name="Familiar Shirt"/>
-    <Item Id="270" Name="Familiar Pants"/>
-    <Item Id="271" Name="Familiar Wig"/>
-    <Item Id="272" Name="Demon Scythe"/>
-    <Item Id="273" Name="Night's Edge"/>
-    <Item Id="274" Name="Dark Lance"/>
-    <Item Id="275" Name="Coral"/>
-    <Item Id="276" Name="Cactus"/>
-    <Item Id="277" Name="Trident"/>
-    <Item Id="278" Name="Silver Bullet"/>
-    <Item Id="279" Name="Throwing Knife"/>
-    <Item Id="280" Name="Spear"/>
-    <Item Id="281" Name="Blowpipe"/>
-    <Item Id="282" Name="Glowstick"/>
-    <Item Id="283" Name="Seed"/>
-    <Item Id="284" Name="Wooden Boomerang"/>
-    <Item Id="285" Name="Aglet"/>
-    <Item Id="286" Name="Sticky Glowstick"/>
-    <Item Id="287" Name="Poisoned Knife"/>
-    <Item Id="288" Name="Obsidian Skin Potion"/>
-    <Item Id="289" Name="Regeneration Potion"/>
-    <Item Id="290" Name="Swiftness Potion"/>
-    <Item Id="291" Name="Gills Potion"/>
-    <Item Id="292" Name="Ironskin Potion"/>
-    <Item Id="293" Name="Mana Regeneration Potion"/>
-    <Item Id="294" Name="Magic Power Potion"/>
-    <Item Id="295" Name="Featherfall Potion"/>
-    <Item Id="296" Name="Spelunker Potion"/>
-    <Item Id="297" Name="Invisibility Potion"/>
-    <Item Id="298" Name="Shine Potion"/>
-    <Item Id="299" Name="Night Owl Potion"/>
-    <Item Id="300" Name="Battle Potion"/>
-    <Item Id="301" Name="Thorns Potion"/>
-    <Item Id="302" Name="Water Walking Potion"/>
-    <Item Id="303" Name="Archery Potion"/>
-    <Item Id="304" Name="Hunter Potion"/>
-    <Item Id="305" Name="Gravitation Potion"/>
-    <Item Id="306" Name="Gold Chest"/>
-    <Item Id="307" Name="Daybloom Seeds"/>
-    <Item Id="308" Name="Moonglow Seeds"/>
-    <Item Id="309" Name="Blinkroot Seeds"/>
-    <Item Id="310" Name="Deathweed Seeds"/>
-    <Item Id="311" Name="Waterleaf Seeds"/>
-    <Item Id="312" Name="Fireblossom Seeds"/>
-    <Item Id="313" Name="Daybloom"/>
-    <Item Id="314" Name="Moonglow"/>
-    <Item Id="315" Name="Blinkroot"/>
-    <Item Id="316" Name="Deathweed"/>
-    <Item Id="317" Name="Waterleaf"/>
-    <Item Id="318" Name="Fireblossom"/>
-    <Item Id="319" Name="Shark Fin"/>
-    <Item Id="320" Name="Feather"/>
-    <Item Id="321" Name="Tombstone"/>
-    <Item Id="322" Name="Mime Mask"/>
-    <Item Id="323" Name="Antlion Mandible"/>
-    <Item Id="324" Name="Illegal Gun Parts"/>
-    <Item Id="325" Name="The Doctor's Shirt"/>
-    <Item Id="326" Name="The Doctor's Pants"/>
-    <Item Id="327" Name="Golden Key"/>
-    <Item Id="328" Name="Shadow Chest"/>
-    <Item Id="329" Name="Shadow Key"/>
-    <Item Id="330" Name="Obsidian Brick Wall"/>
-    <Item Id="331" Name="Jungle Spores"/>
-    <Item Id="332" Name="Loom"/>
-    <Item Id="333" Name="Piano"/>
-    <Item Id="334" Name="Dresser"/>
-    <Item Id="335" Name="Bench"/>
-    <Item Id="336" Name="Bathtub"/>
-    <Item Id="337" Name="Red Banner"/>
-    <Item Id="338" Name="Green Banner"/>
-    <Item Id="339" Name="Blue Banner"/>
-    <Item Id="340" Name="Yellow Banner"/>
-    <Item Id="341" Name="Lamp Post"/>
-    <Item Id="342" Name="Tiki Torch"/>
-    <Item Id="343" Name="Barrel"/>
-    <Item Id="344" Name="Chinese Lantern"/>
-    <Item Id="345" Name="Cooking Pot"/>
-    <Item Id="346" Name="Safe"/>
-    <Item Id="347" Name="Skull Lantern"/>
-    <Item Id="348" Name="Trash Can"/>
-    <Item Id="349" Name="Candelabra"/>
-    <Item Id="350" Name="Pink Vase"/>
-    <Item Id="351" Name="Mug"/>
-    <Item Id="352" Name="Keg"/>
-    <Item Id="353" Name="Ale"/>
-    <Item Id="354" Name="Bookcase"/>
-    <Item Id="355" Name="Throne"/>
-    <Item Id="356" Name="Bowl"/>
-    <Item Id="357" Name="Bowl of Soup"/>
-    <Item Id="358" Name="Toilet"/>
-    <Item Id="359" Name="Grandfather Clock"/>
-    <Item Id="360" Name="Armor Statue"/>
-    <Item Id="361" Name="Goblin Battle Standard"/>
-    <Item Id="362" Name="Tattered Cloth"/>
-    <Item Id="363" Name="Sawmill"/>
-    <Item Id="364" Name="Cobalt Ore"/>
-    <Item Id="365" Name="Mythril Ore"/>
-    <Item Id="366" Name="Adamantite Ore"/>
-    <Item Id="367" Name="Pwnhammer"/>
-    <Item Id="368" Name="Excalibur"/>
-    <Item Id="369" Name="Hallowed Seeds"/>
-    <Item Id="370" Name="Ebonsand Block"/>
-    <Item Id="371" Name="Cobalt Hat"/>
-    <Item Id="372" Name="Cobalt Helmet"/>
-    <Item Id="373" Name="Cobalt Mask"/>
-    <Item Id="374" Name="Cobalt Breastplate"/>
-    <Item Id="375" Name="Cobalt Leggings"/>
-    <Item Id="376" Name="Mythril Hood"/>
-    <Item Id="377" Name="Mythril Helmet"/>
-    <Item Id="378" Name="Mythril Hat"/>
-    <Item Id="379" Name="Mythril Chainmail"/>
-    <Item Id="380" Name="Mythril Greaves"/>
-    <Item Id="381" Name="Cobalt Bar"/>
-    <Item Id="382" Name="Mythril Bar"/>
-    <Item Id="383" Name="Cobalt Chainsaw"/>
-    <Item Id="384" Name="Mythril Chainsaw"/>
-    <Item Id="385" Name="Cobalt Drill"/>
-    <Item Id="386" Name="Mythril Drill"/>
-    <Item Id="387" Name="Adamantite Chainsaw"/>
-    <Item Id="388" Name="Adamantite Drill"/>
-    <Item Id="389" Name="Dao of Pow"/>
-    <Item Id="390" Name="Mythril Halberd"/>
-    <Item Id="391" Name="Adamantite Bar"/>
-    <Item Id="392" Name="Glass Wall"/>
-    <Item Id="393" Name="Compass"/>
-    <Item Id="394" Name="Diving Gear"/>
-    <Item Id="395" Name="GPS"/>
-    <Item Id="396" Name="Obsidian Horseshoe"/>
-    <Item Id="397" Name="Obsidian Shield"/>
-    <Item Id="398" Name="Tinkerer's Workshop"/>
-    <Item Id="399" Name="Cloud in a Balloon"/>
-    <Item Id="400" Name="Adamantite Headgear"/>
-    <Item Id="401" Name="Adamantite Helmet"/>
-    <Item Id="402" Name="Adamantite Mask"/>
-    <Item Id="403" Name="Adamantite Breastplate"/>
-    <Item Id="404" Name="Adamantite Leggings"/>
-    <Item Id="405" Name="Spectre Boots"/>
-    <Item Id="406" Name="Adamantite Glaive"/>
-    <Item Id="407" Name="Toolbelt"/>
-    <Item Id="408" Name="Pearlsand Block"/>
-    <Item Id="409" Name="Pearlstone Block"/>
-    <Item Id="410" Name="Mining Shirt"/>
-    <Item Id="411" Name="Mining Pants"/>
-    <Item Id="412" Name="Pearlstone Brick"/>
-    <Item Id="413" Name="Iridescent Brick"/>
-    <Item Id="414" Name="Mudstone Block"/>
-    <Item Id="415" Name="Cobalt Brick"/>
-    <Item Id="416" Name="Mythril Brick"/>
-    <Item Id="417" Name="Pearlstone Brick Wall"/>
-    <Item Id="418" Name="Iridescent Brick Wall"/>
-    <Item Id="419" Name="Mudstone Brick Wall"/>
-    <Item Id="420" Name="Cobalt Brick Wall"/>
-    <Item Id="421" Name="Mythril Brick Wall"/>
-    <Item Id="422" Name="Holy Water"/>
-    <Item Id="423" Name="Unholy Water"/>
-    <Item Id="424" Name="Silt Block"/>
-    <Item Id="425" Name="Fairy Bell"/>
-    <Item Id="426" Name="Breaker Blade"/>
-    <Item Id="427" Name="Blue Torch"/>
-    <Item Id="428" Name="Red Torch"/>
-    <Item Id="429" Name="Green Torch"/>
-    <Item Id="430" Name="Purple Torch"/>
-    <Item Id="431" Name="White Torch"/>
-    <Item Id="432" Name="Yellow Torch"/>
-    <Item Id="433" Name="Demon Torch"/>
-    <Item Id="434" Name="Clockwork Assault Rifle"/>
-    <Item Id="435" Name="Cobalt Repeater"/>
-    <Item Id="436" Name="Mythril Repeater"/>
-    <Item Id="437" Name="Dual Hook"/>
-    <Item Id="438" Name="Star Statue"/>
-    <Item Id="439" Name="Sword Statue"/>
-    <Item Id="440" Name="Slime Statue"/>
-    <Item Id="441" Name="Goblin Statue"/>
-    <Item Id="442" Name="Shield Statue"/>
-    <Item Id="443" Name="Bat Statue"/>
-    <Item Id="444" Name="Fish Statue"/>
-    <Item Id="445" Name="Bunny Statue"/>
-    <Item Id="446" Name="Skeleton Statue"/>
-    <Item Id="447" Name="Reaper Statue"/>
-    <Item Id="448" Name="Woman Statue"/>
-    <Item Id="449" Name="Imp Statue"/>
-    <Item Id="450" Name="Gargoyle Statue"/>
-    <Item Id="451" Name="Gloom Statue"/>
-    <Item Id="452" Name="Hornet Statue"/>
-    <Item Id="453" Name="Bomb Statue"/>
-    <Item Id="454" Name="Crab Statue"/>
-    <Item Id="455" Name="Hammer Statue"/>
-    <Item Id="456" Name="Potion Statue"/>
-    <Item Id="457" Name="Spear Statue"/>
-    <Item Id="458" Name="Cross Statue"/>
-    <Item Id="459" Name="Jellyfish Statue"/>
-    <Item Id="460" Name="Bow Statue"/>
-    <Item Id="461" Name="Boomerang Statue"/>
-    <Item Id="462" Name="Boot Statue"/>
-    <Item Id="463" Name="Chest Statue"/>
-    <Item Id="464" Name="Bird Statue"/>
-    <Item Id="465" Name="Axe Statue"/>
-    <Item Id="466" Name="Corrupt Statue"/>
-    <Item Id="467" Name="Tree Statue"/>
-    <Item Id="468" Name="Anvil Statue"/>
-    <Item Id="469" Name="Pickaxe Statue"/>
-    <Item Id="470" Name="Mushroom Statue"/>
-    <Item Id="471" Name="Eyeball Statue"/>
-    <Item Id="472" Name="Pillar Statue"/>
-    <Item Id="473" Name="Heart Statue"/>
-    <Item Id="474" Name="Pot Statue"/>
-    <Item Id="475" Name="Sunflower Statue"/>
-    <Item Id="476" Name="King Statue"/>
-    <Item Id="477" Name="Queen Statue"/>
-    <Item Id="478" Name="Pirahna Statue"/>
-    <Item Id="479" Name="Planked Wall"/>
-    <Item Id="480" Name="Wooden Beam"/>
-    <Item Id="481" Name="Adamantite Repeater"/>
-    <Item Id="482" Name="Adamantite Sword"/>
-    <Item Id="483" Name="Cobalt Sword"/>
-    <Item Id="484" Name="Mythril Sword"/>
-    <Item Id="485" Name="Moon Charm"/>
-    <Item Id="486" Name="Ruler"/>
-    <Item Id="487" Name="Crystal Ball"/>
-    <Item Id="488" Name="Disco Ball"/>
-    <Item Id="489" Name="Sorcerer Emblem"/>
-    <Item Id="490" Name="Warrior Emblem"/>
-    <Item Id="491" Name="Ranger Emblem"/>
-    <Item Id="492" Name="Demon Wings"/>
-    <Item Id="493" Name="Angel Wings"/>
-    <Item Id="494" Name="Magical Harp"/>
-    <Item Id="495" Name="Rainbow Rod"/>
-    <Item Id="496" Name="Ice Rod"/>
-    <Item Id="497" Name="Neptune's Shell"/>
-    <Item Id="498" Name="Mannequin"/>
-    <Item Id="499" Name="Greater Healing Potion"/>
-    <Item Id="500" Name="Greater Mana Potion"/>
-    <Item Id="501" Name="Pixie Dust"/>
-    <Item Id="502" Name="Crystal Shard"/>
-    <Item Id="503" Name="Clown Hat"/>
-    <Item Id="504" Name="Clown Shirt"/>
-    <Item Id="505" Name="Clown Pants"/>
-    <Item Id="506" Name="Flamethrower"/>
-    <Item Id="507" Name="Bell"/>
-    <Item Id="508" Name="Harp"/>
-    <Item Id="509" Name="Wrench"/>
-    <Item Id="510" Name="Wire Cutter"/>
-    <Item Id="511" Name="Active Stone Block"/>
-    <Item Id="512" Name="Inactive Stone Block"/>
-    <Item Id="513" Name="Lever"/>
-    <Item Id="514" Name="Laser Rifle"/>
-    <Item Id="515" Name="Crystal Bullet"/>
-    <Item Id="516" Name="Holy Arrow"/>
-    <Item Id="517" Name="Magic Dagger"/>
-    <Item Id="518" Name="Crystal Storm"/>
-    <Item Id="519" Name="Cursed Flames"/>
-    <Item Id="520" Name="Soul of Light"/>
-    <Item Id="521" Name="Soul of Night"/>
-    <Item Id="522" Name="Cursed Flame"/>
-    <Item Id="523" Name="Cursed Torch"/>
-    <Item Id="524" Name="Adamantite Forge"/>
-    <Item Id="525" Name="Mythril Anvil"/>
-    <Item Id="526" Name="Unicorn Horn"/>
-    <Item Id="527" Name="Dark Shard"/>
-    <Item Id="528" Name="Light Shard"/>
-    <Item Id="529" Name="Red Pressure Plate"/>
-    <Item Id="530" Name="Wire"/>
-    <Item Id="531" Name="Spell Tome"/>
-    <Item Id="532" Name="Star Cloak"/>
-    <Item Id="533" Name="Megashark"/>
-    <Item Id="534" Name="Shotgun"/>
-    <Item Id="535" Name="Philosopher's Stone"/>
-    <Item Id="536" Name="Titan Glove"/>
-    <Item Id="537" Name="Cobalt Naginata"/>
-    <Item Id="538" Name="Switch"/>
-    <Item Id="539" Name="Dart Trap"/>
-    <Item Id="540" Name="Boulder"/>
-    <Item Id="541" Name="Green Pressure Plate"/>
-    <Item Id="542" Name="Gray Pressure Plate"/>
-    <Item Id="543" Name="Brown Pressure Plate"/>
-    <Item Id="544" Name="Mechanical Eye"/>
-    <Item Id="545" Name="Cursed Arrow"/>
-    <Item Id="546" Name="Cursed Bullet"/>
-    <Item Id="547" Name="Soul of Fright"/>
-    <Item Id="548" Name="Soul of Might"/>
-    <Item Id="549" Name="Soul of Sight"/>
-    <Item Id="550" Name="Gungnir"/>
-    <Item Id="551" Name="Hallowed Plate Mail"/>
-    <Item Id="552" Name="Hallowed Greaves"/>
-    <Item Id="553" Name="Hallowed Helmet"/>
-    <Item Id="554" Name="Cross Necklace"/>
-    <Item Id="555" Name="Mana Flower"/>
-    <Item Id="556" Name="Mechanical Worm"/>
-    <Item Id="557" Name="Mechanical Skull"/>
-    <Item Id="558" Name="Hallowed Headgear"/>
-    <Item Id="559" Name="Hallowed Mask"/>
-    <Item Id="560" Name="Slime Crown"/>
-    <Item Id="561" Name="Light Disc"/>
-    <Item Id="562" Name="Music Box (Overworld Day)"/>
-    <Item Id="563" Name="Music Box (Eerie)"/>
-    <Item Id="564" Name="Music Box (Night)"/>
-    <Item Id="565" Name="Music Box (Title)"/>
-    <Item Id="566" Name="Music Box (Underground)"/>
-    <Item Id="567" Name="Music Box (Boss 1)"/>
-    <Item Id="568" Name="Music Box (Jungle)"/>
-    <Item Id="569" Name="Music Box (Corruption)"/>
-    <Item Id="570" Name="Music Box (Underground Corruption)"/>
-    <Item Id="571" Name="Music Box (The Hallow)"/>
-    <Item Id="572" Name="Music Box (Boss 2)"/>
-    <Item Id="573" Name="Music Box (Underground Hallow)"/>
-    <Item Id="574" Name="Music Box (Boss 3)"/>
-    <Item Id="575" Name="Soul of Flight"/>
-    <Item Id="576" Name="Music Box"/>
-    <Item Id="577" Name="Demonite Brick"/>
-    <Item Id="578" Name="Hallowed Repeater"/>
-    <Item Id="579" Name="Hamdrax"/>
-    <Item Id="580" Name="Explosives"/>
-    <Item Id="581" Name="Inlet Pump"/>
-    <Item Id="582" Name="Outlet Pump"/>
-    <Item Id="583" Name="1 Second Timer"/>
-    <Item Id="584" Name="3 Second Timer"/>
-    <Item Id="585" Name="5 Second Timer"/>
-    <Item Id="586" Name="Candy Cane Block"/>
-    <Item Id="587" Name="Candy Cane Wall"/>
-    <Item Id="588" Name="Santa Hat"/>
-    <Item Id="589" Name="Santa Shirt"/>
-    <Item Id="590" Name="Santa Pants"/>
-    <Item Id="591" Name="Green Candy Cane Block"/>
-    <Item Id="592" Name="Green Candy Cane Wall"/>
-    <Item Id="593" Name="Snow Block"/>
-    <Item Id="594" Name="Snow Brick"/>
-    <Item Id="595" Name="Snow Brick Wall"/>
-    <Item Id="596" Name="Blue Light"/>
-    <Item Id="597" Name="Red Light"/>
-    <Item Id="598" Name="Green Light"/>
-    <Item Id="599" Name="Blue Present"/>
-    <Item Id="600" Name="Green Present"/>
-    <Item Id="601" Name="Yellow Present"/>
-    <Item Id="602" Name="Snow Globe"/>
-    <Item Id="603" Name="Carrot"/>
+    <Item Id="-24" Name="Yellow Phasesaber" />
+    <Item Id="-23" Name="White Phasesaber" />
+    <Item Id="-22" Name="Purple Phasesaber" />
+    <Item Id="-21" Name="Green Phasesaber" />
+    <Item Id="-20" Name="Red Phasesaber" />
+    <Item Id="-19" Name="Blue Phasesaber" />
+    <Item Id="-18" Name="Copper Bow" />
+    <Item Id="-17" Name="Copper Hammer" />
+    <Item Id="-16" Name="Copper Axe" />
+    <Item Id="-15" Name="Copper Shortsword" />
+    <Item Id="-14" Name="Copper Broadsword" />
+    <Item Id="-13" Name="Copper Pickaxe" />
+    <Item Id="-12" Name="Silver Bow" />
+    <Item Id="-11" Name="Silver Hammer" />
+    <Item Id="-10" Name="Silver Axe" />
+    <Item Id="-9" Name="Silver Shortsword" />
+    <Item Id="-8" Name="Silver Broadsword" />
+    <Item Id="-7" Name="Silver Pickaxe" />
+    <Item Id="-6" Name="Gold Bow" />
+    <Item Id="-5" Name="Gold Hammer" />
+    <Item Id="-4" Name="Gold Axe" />
+    <Item Id="-3" Name="Gold Shortsword" />
+    <Item Id="-2" Name="Gold Broadsword" />
+    <Item Id="-1" Name="Gold Pickaxe" />
+    <Item Id="0" Name="[empty]" />
+    <Item Id="1" Name="Iron Pickaxe" />
+    <Item Id="2" Name="Dirt Block" />
+    <Item Id="3" Name="Stone Block" />
+    <Item Id="4" Name="Iron Broadsword" />
+    <Item Id="5" Name="Mushroom" />
+    <Item Id="6" Name="Iron Shortsword" />
+    <Item Id="7" Name="Iron Hammer" />
+    <Item Id="8" Name="Torch" />
+    <Item Id="9" Name="Wood" />
+    <Item Id="10" Name="Iron Axe" />
+    <Item Id="11" Name="Iron Ore" />
+    <Item Id="12" Name="Copper Ore" />
+    <Item Id="13" Name="Gold Ore" />
+    <Item Id="14" Name="Silver Ore" />
+    <Item Id="15" Name="Copper Watch" />
+    <Item Id="16" Name="Silver Watch" />
+    <Item Id="17" Name="Gold Watch" />
+    <Item Id="18" Name="Depth Meter" />
+    <Item Id="19" Name="Gold Bar" />
+    <Item Id="20" Name="Copper Bar" />
+    <Item Id="21" Name="Silver Bar" />
+    <Item Id="22" Name="Iron Bar" />
+    <Item Id="23" Name="Gel" />
+    <Item Id="24" Name="Wooden Sword" />
+    <Item Id="25" Name="Wooden Door" />
+    <Item Id="26" Name="Stone Wall" />
+    <Item Id="27" Name="Acorn" />
+    <Item Id="28" Name="Lesser Healing Potion" />
+    <Item Id="29" Name="Life Crystal" />
+    <Item Id="30" Name="Dirt Wall" />
+    <Item Id="31" Name="Bottle" />
+    <Item Id="32" Name="Wooden Table" />
+    <Item Id="33" Name="Furnace" />
+    <Item Id="34" Name="Wooden Chair" />
+    <Item Id="35" Name="Iron Anvil" />
+    <Item Id="36" Name="Work Bench" />
+    <Item Id="37" Name="Goggles" />
+    <Item Id="38" Name="Lens" />
+    <Item Id="39" Name="Wooden Bow" />
+    <Item Id="40" Name="Wooden Arrow" />
+    <Item Id="41" Name="Flaming Arrow" />
+    <Item Id="42" Name="Shuriken" />
+    <Item Id="43" Name="Suspicious Looking Eye" />
+    <Item Id="44" Name="Demon Bow" />
+    <Item Id="45" Name="War Axe of the Night" />
+    <Item Id="46" Name="Light's Bane" />
+    <Item Id="47" Name="Unholy Arrow" />
+    <Item Id="48" Name="Chest" />
+    <Item Id="49" Name="Band of Regeneration" />
+    <Item Id="50" Name="Magic Mirror" />
+    <Item Id="51" Name="Jester's Arrow" />
+    <Item Id="52" Name="Angel Statue" />
+    <Item Id="53" Name="Cloud in a Bottle" />
+    <Item Id="54" Name="Hermes Boots" />
+    <Item Id="55" Name="Enchanted Boomerang" />
+    <Item Id="56" Name="Demonite Ore" />
+    <Item Id="57" Name="Demonite Bar" />
+    <Item Id="58" Name="Heart" />
+    <Item Id="59" Name="Corrupt Seeds" />
+    <Item Id="60" Name="Vile Mushroom" />
+    <Item Id="61" Name="Ebonstone Block" />
+    <Item Id="62" Name="Grass Seeds" />
+    <Item Id="63" Name="Sunflower" />
+    <Item Id="64" Name="Vilethorn" />
+    <Item Id="65" Name="Starfury" />
+    <Item Id="66" Name="Purification Powder" />
+    <Item Id="67" Name="Vile Powder" />
+    <Item Id="68" Name="Rotten Chunk" />
+    <Item Id="69" Name="Worm Tooth" />
+    <Item Id="70" Name="Worm Food" />
+    <Item Id="71" Name="Copper Coin" />
+    <Item Id="72" Name="Silver Coin" />
+    <Item Id="73" Name="Gold Coin" />
+    <Item Id="74" Name="Platinum Coin" />
+    <Item Id="75" Name="Fallen Star" />
+    <Item Id="76" Name="Copper Greaves" />
+    <Item Id="77" Name="Iron Greaves" />
+    <Item Id="78" Name="Silver Greaves" />
+    <Item Id="79" Name="Gold Greaves" />
+    <Item Id="80" Name="Copper Chainmail" />
+    <Item Id="81" Name="Iron Chainmail" />
+    <Item Id="82" Name="Silver Chainmail" />
+    <Item Id="83" Name="Gold Chainmail" />
+    <Item Id="84" Name="Grappling Hook" />
+    <Item Id="85" Name="Iron Chain" />
+    <Item Id="86" Name="Shadow Scale" />
+    <Item Id="87" Name="Piggy Bank" />
+    <Item Id="88" Name="Mining Helmet" />
+    <Item Id="89" Name="Copper Helmet" />
+    <Item Id="90" Name="Iron Helmet" />
+    <Item Id="91" Name="Silver Helmet" />
+    <Item Id="92" Name="Gold Helmet" />
+    <Item Id="93" Name="Wood Wall" />
+    <Item Id="94" Name="Wood Platform" />
+    <Item Id="95" Name="Flintlock Pistol" />
+    <Item Id="96" Name="Musket" />
+    <Item Id="97" Name="Musket Ball" />
+    <Item Id="98" Name="Minishark" />
+    <Item Id="99" Name="Iron Bow" />
+    <Item Id="100" Name="Shadow Greaves" />
+    <Item Id="101" Name="Shadow Scalemail" />
+    <Item Id="102" Name="Shadow Helmet" />
+    <Item Id="103" Name="Nightmare Pickaxe" />
+    <Item Id="104" Name="The Breaker" />
+    <Item Id="105" Name="Candle" />
+    <Item Id="106" Name="Copper Chandelier" />
+    <Item Id="107" Name="Silver Chandelier" />
+    <Item Id="108" Name="Gold Chandelier" />
+    <Item Id="109" Name="Mana Crystal" />
+    <Item Id="110" Name="Lesser Mana Potion" />
+    <Item Id="111" Name="Band of Starpower" />
+    <Item Id="112" Name="Flower of Fire" />
+    <Item Id="113" Name="Magic Missile" />
+    <Item Id="114" Name="Dirt Rod" />
+    <Item Id="115" Name="Orb of Light" />
+    <Item Id="116" Name="Meteorite" />
+    <Item Id="117" Name="Meteorite Bar" />
+    <Item Id="118" Name="Hook" />
+    <Item Id="119" Name="Flamarang" />
+    <Item Id="120" Name="Molten Fury" />
+    <Item Id="121" Name="Fiery Greatsword" />
+    <Item Id="122" Name="Molten Pickaxe" />
+    <Item Id="123" Name="Meteor Helmet" />
+    <Item Id="124" Name="Meteor Suit" />
+    <Item Id="125" Name="Meteor Leggings" />
+    <Item Id="126" Name="Bottled Water" />
+    <Item Id="127" Name="Space Gun" />
+    <Item Id="128" Name="Rocket Boots" />
+    <Item Id="129" Name="Gray Brick" />
+    <Item Id="130" Name="Gray Brick Wall" />
+    <Item Id="131" Name="Red Brick" />
+    <Item Id="132" Name="Red Brick Wall" />
+    <Item Id="133" Name="Clay Block" />
+    <Item Id="134" Name="Blue Brick" />
+    <Item Id="135" Name="Blue Brick Wall" />
+    <Item Id="136" Name="Chain Lantern" />
+    <Item Id="137" Name="Green Brick" />
+    <Item Id="138" Name="Green Brick Wall" />
+    <Item Id="139" Name="Pink Brick" />
+    <Item Id="140" Name="Pink Brick Wall" />
+    <Item Id="141" Name="Gold Brick" />
+    <Item Id="142" Name="Gold Brick Wall" />
+    <Item Id="143" Name="Silver Brick" />
+    <Item Id="144" Name="Silver Brick Wall" />
+    <Item Id="145" Name="Copper Brick" />
+    <Item Id="146" Name="Copper Brick Wall" />
+    <Item Id="147" Name="Spike" />
+    <Item Id="148" Name="Water Candle" />
+    <Item Id="149" Name="Book" />
+    <Item Id="150" Name="Cobweb" />
+    <Item Id="151" Name="Necro Helmet" />
+    <Item Id="152" Name="Necro Breastplate" />
+    <Item Id="153" Name="Necro Greaves" />
+    <Item Id="154" Name="Bone" />
+    <Item Id="155" Name="Muramasa" />
+    <Item Id="156" Name="Cobalt Shield" />
+    <Item Id="157" Name="Aqua Scepter" />
+    <Item Id="158" Name="Lucky Horseshoe" />
+    <Item Id="159" Name="Shiny Red Balloon" />
+    <Item Id="160" Name="Harpoon" />
+    <Item Id="161" Name="Spiky Ball" />
+    <Item Id="162" Name="Ball O' Hurt" />
+    <Item Id="163" Name="Blue Moon" />
+    <Item Id="164" Name="Handgun" />
+    <Item Id="165" Name="Water Bolt" />
+    <Item Id="166" Name="Bomb" />
+    <Item Id="167" Name="Dynamite" />
+    <Item Id="168" Name="Grenade" />
+    <Item Id="169" Name="Sand Block" />
+    <Item Id="170" Name="Glass" />
+    <Item Id="171" Name="Sign" />
+    <Item Id="172" Name="Ash Block" />
+    <Item Id="173" Name="Obsidian" />
+    <Item Id="174" Name="Hellstone" />
+    <Item Id="175" Name="Hellstone Bar" />
+    <Item Id="176" Name="Mud Block" />
+    <Item Id="177" Name="Sapphire" />
+    <Item Id="178" Name="Ruby" />
+    <Item Id="179" Name="Emerald" />
+    <Item Id="180" Name="Topaz" />
+    <Item Id="181" Name="Amethyst" />
+    <Item Id="182" Name="Diamond" />
+    <Item Id="183" Name="Glowing Mushroom" />
+    <Item Id="184" Name="Star" />
+    <Item Id="185" Name="Ivy Whip" />
+    <Item Id="186" Name="Breathing Reed" />
+    <Item Id="187" Name="Flipper" />
+    <Item Id="188" Name="Healing Potion" />
+    <Item Id="189" Name="Mana Potion" />
+    <Item Id="190" Name="Blade of Grass" />
+    <Item Id="191" Name="Thorn Chakram" />
+    <Item Id="192" Name="Obsidian Brick" />
+    <Item Id="193" Name="Obsidian Skull" />
+    <Item Id="194" Name="Mushroom Grass Seeds" />
+    <Item Id="195" Name="Jungle Grass Seeds" />
+    <Item Id="196" Name="Wooden Hammer" />
+    <Item Id="197" Name="Star Cannon" />
+    <Item Id="198" Name="Blue Phaseblade" />
+    <Item Id="199" Name="Red Phaseblade" />
+    <Item Id="200" Name="Green Phaseblade" />
+    <Item Id="201" Name="Purple Phaseblade" />
+    <Item Id="202" Name="White Phaseblade" />
+    <Item Id="203" Name="Yellow Phaseblade" />
+    <Item Id="204" Name="Meteor Hamaxe" />
+    <Item Id="205" Name="Empty Bucket" />
+    <Item Id="206" Name="Water Bucket" />
+    <Item Id="207" Name="Lava Bucket" />
+    <Item Id="208" Name="Jungle Rose" />
+    <Item Id="209" Name="Stinger" />
+    <Item Id="210" Name="Vine" />
+    <Item Id="211" Name="Feral Claws" />
+    <Item Id="212" Name="Anklet of the Wind" />
+    <Item Id="213" Name="Staff of Regrowth" />
+    <Item Id="214" Name="Hellstone Brick" />
+    <Item Id="215" Name="Whoopie Cushion" />
+    <Item Id="216" Name="Shackle" />
+    <Item Id="217" Name="Molten Hamaxe" />
+    <Item Id="218" Name="Flamelash" />
+    <Item Id="219" Name="Phoenix Blaster" />
+    <Item Id="220" Name="Sunfury" />
+    <Item Id="221" Name="Hellforge" />
+    <Item Id="222" Name="Clay Pot" />
+    <Item Id="223" Name="Nature's Gift" />
+    <Item Id="224" Name="Bed" />
+    <Item Id="225" Name="Silk" />
+    <Item Id="226" Name="Lesser Restoration Potion" />
+    <Item Id="227" Name="Restoration Potion" />
+    <Item Id="228" Name="Jungle Hat" />
+    <Item Id="229" Name="Jungle Shirt" />
+    <Item Id="230" Name="Jungle Pants" />
+    <Item Id="231" Name="Molten Helmet" />
+    <Item Id="232" Name="Molten Breastplate" />
+    <Item Id="233" Name="Molten Greaves" />
+    <Item Id="234" Name="Meteor Shot" />
+    <Item Id="235" Name="Sticky Bomb" />
+    <Item Id="236" Name="Black Lens" />
+    <Item Id="237" Name="Sunglasses" />
+    <Item Id="238" Name="Wizard Hat" />
+    <Item Id="239" Name="Top Hat" />
+    <Item Id="240" Name="Tuxedo Shirt" />
+    <Item Id="241" Name="Tuxedo Pants" />
+    <Item Id="242" Name="Summer Hat" />
+    <Item Id="243" Name="Bunny Hood" />
+    <Item Id="244" Name="Plumber's Hat" />
+    <Item Id="245" Name="Plumber's Shirt" />
+    <Item Id="246" Name="Plumber's Pants" />
+    <Item Id="247" Name="Hero's Hat" />
+    <Item Id="248" Name="Hero's Shirt" />
+    <Item Id="249" Name="Hero's Pants" />
+    <Item Id="250" Name="Fish Bowl" />
+    <Item Id="251" Name="Archaeologist's Hat" />
+    <Item Id="252" Name="Archaeologist's Jacket" />
+    <Item Id="253" Name="Archaeologist's Pants" />
+    <Item Id="254" Name="Black Dye" />
+    <Item Id="255" Name="Green Dye" />
+    <Item Id="256" Name="Ninja Hood" />
+    <Item Id="257" Name="Ninja Shirt" />
+    <Item Id="258" Name="Ninja Pants" />
+    <Item Id="259" Name="Leather" />
+    <Item Id="260" Name="Red Hat" />
+    <Item Id="261" Name="Goldfish" />
+    <Item Id="262" Name="Robe" />
+    <Item Id="263" Name="Robot Hat" />
+    <Item Id="264" Name="Gold Crown" />
+    <Item Id="265" Name="Hellfire Arrow" />
+    <Item Id="266" Name="Sandgun" />
+    <Item Id="267" Name="Guide Voodoo Doll" />
+    <Item Id="268" Name="Diving Helmet" />
+    <Item Id="269" Name="Familiar Shirt" />
+    <Item Id="270" Name="Familiar Pants" />
+    <Item Id="271" Name="Familiar Wig" />
+    <Item Id="272" Name="Demon Scythe" />
+    <Item Id="273" Name="Night's Edge" />
+    <Item Id="274" Name="Dark Lance" />
+    <Item Id="275" Name="Coral" />
+    <Item Id="276" Name="Cactus" />
+    <Item Id="277" Name="Trident" />
+    <Item Id="278" Name="Silver Bullet" />
+    <Item Id="279" Name="Throwing Knife" />
+    <Item Id="280" Name="Spear" />
+    <Item Id="281" Name="Blowpipe" />
+    <Item Id="282" Name="Glowstick" />
+    <Item Id="283" Name="Seed" />
+    <Item Id="284" Name="Wooden Boomerang" />
+    <Item Id="285" Name="Aglet" />
+    <Item Id="286" Name="Sticky Glowstick" />
+    <Item Id="287" Name="Poisoned Knife" />
+    <Item Id="288" Name="Obsidian Skin Potion" />
+    <Item Id="289" Name="Regeneration Potion" />
+    <Item Id="290" Name="Swiftness Potion" />
+    <Item Id="291" Name="Gills Potion" />
+    <Item Id="292" Name="Ironskin Potion" />
+    <Item Id="293" Name="Mana Regeneration Potion" />
+    <Item Id="294" Name="Magic Power Potion" />
+    <Item Id="295" Name="Featherfall Potion" />
+    <Item Id="296" Name="Spelunker Potion" />
+    <Item Id="297" Name="Invisibility Potion" />
+    <Item Id="298" Name="Shine Potion" />
+    <Item Id="299" Name="Night Owl Potion" />
+    <Item Id="300" Name="Battle Potion" />
+    <Item Id="301" Name="Thorns Potion" />
+    <Item Id="302" Name="Water Walking Potion" />
+    <Item Id="303" Name="Archery Potion" />
+    <Item Id="304" Name="Hunter Potion" />
+    <Item Id="305" Name="Gravitation Potion" />
+    <Item Id="306" Name="Gold Chest" />
+    <Item Id="307" Name="Daybloom Seeds" />
+    <Item Id="308" Name="Moonglow Seeds" />
+    <Item Id="309" Name="Blinkroot Seeds" />
+    <Item Id="310" Name="Deathweed Seeds" />
+    <Item Id="311" Name="Waterleaf Seeds" />
+    <Item Id="312" Name="Fireblossom Seeds" />
+    <Item Id="313" Name="Daybloom" />
+    <Item Id="314" Name="Moonglow" />
+    <Item Id="315" Name="Blinkroot" />
+    <Item Id="316" Name="Deathweed" />
+    <Item Id="317" Name="Waterleaf" />
+    <Item Id="318" Name="Fireblossom" />
+    <Item Id="319" Name="Shark Fin" />
+    <Item Id="320" Name="Feather" />
+    <Item Id="321" Name="Tombstone" />
+    <Item Id="322" Name="Mime Mask" />
+    <Item Id="323" Name="Antlion Mandible" />
+    <Item Id="324" Name="Illegal Gun Parts" />
+    <Item Id="325" Name="The Doctor's Shirt" />
+    <Item Id="326" Name="The Doctor's Pants" />
+    <Item Id="327" Name="Golden Key" />
+    <Item Id="328" Name="Shadow Chest" />
+    <Item Id="329" Name="Shadow Key" />
+    <Item Id="330" Name="Obsidian Brick Wall" />
+    <Item Id="331" Name="Jungle Spores" />
+    <Item Id="332" Name="Loom" />
+    <Item Id="333" Name="Piano" />
+    <Item Id="334" Name="Dresser" />
+    <Item Id="335" Name="Bench" />
+    <Item Id="336" Name="Bathtub" />
+    <Item Id="337" Name="Red Banner" />
+    <Item Id="338" Name="Green Banner" />
+    <Item Id="339" Name="Blue Banner" />
+    <Item Id="340" Name="Yellow Banner" />
+    <Item Id="341" Name="Lamp Post" />
+    <Item Id="342" Name="Tiki Torch" />
+    <Item Id="343" Name="Barrel" />
+    <Item Id="344" Name="Chinese Lantern" />
+    <Item Id="345" Name="Cooking Pot" />
+    <Item Id="346" Name="Safe" />
+    <Item Id="347" Name="Skull Lantern" />
+    <Item Id="348" Name="Trash Can" />
+    <Item Id="349" Name="Candelabra" />
+    <Item Id="350" Name="Pink Vase" />
+    <Item Id="351" Name="Mug" />
+    <Item Id="352" Name="Keg" />
+    <Item Id="353" Name="Ale" />
+    <Item Id="354" Name="Bookcase" />
+    <Item Id="355" Name="Throne" />
+    <Item Id="356" Name="Bowl" />
+    <Item Id="357" Name="Bowl of Soup" />
+    <Item Id="358" Name="Toilet" />
+    <Item Id="359" Name="Grandfather Clock" />
+    <Item Id="360" Name="Armor Statue" />
+    <Item Id="361" Name="Goblin Battle Standard" />
+    <Item Id="362" Name="Tattered Cloth" />
+    <Item Id="363" Name="Sawmill" />
+    <Item Id="364" Name="Cobalt Ore" />
+    <Item Id="365" Name="Mythril Ore" />
+    <Item Id="366" Name="Adamantite Ore" />
+    <Item Id="367" Name="Pwnhammer" />
+    <Item Id="368" Name="Excalibur" />
+    <Item Id="369" Name="Hallowed Seeds" />
+    <Item Id="370" Name="Ebonsand Block" />
+    <Item Id="371" Name="Cobalt Hat" />
+    <Item Id="372" Name="Cobalt Helmet" />
+    <Item Id="373" Name="Cobalt Mask" />
+    <Item Id="374" Name="Cobalt Breastplate" />
+    <Item Id="375" Name="Cobalt Leggings" />
+    <Item Id="376" Name="Mythril Hood" />
+    <Item Id="377" Name="Mythril Helmet" />
+    <Item Id="378" Name="Mythril Hat" />
+    <Item Id="379" Name="Mythril Chainmail" />
+    <Item Id="380" Name="Mythril Greaves" />
+    <Item Id="381" Name="Cobalt Bar" />
+    <Item Id="382" Name="Mythril Bar" />
+    <Item Id="383" Name="Cobalt Chainsaw" />
+    <Item Id="384" Name="Mythril Chainsaw" />
+    <Item Id="385" Name="Cobalt Drill" />
+    <Item Id="386" Name="Mythril Drill" />
+    <Item Id="387" Name="Adamantite Chainsaw" />
+    <Item Id="388" Name="Adamantite Drill" />
+    <Item Id="389" Name="Dao of Pow" />
+    <Item Id="390" Name="Mythril Halberd" />
+    <Item Id="391" Name="Adamantite Bar" />
+    <Item Id="392" Name="Glass Wall" />
+    <Item Id="393" Name="Compass" />
+    <Item Id="394" Name="Diving Gear" />
+    <Item Id="395" Name="GPS" />
+    <Item Id="396" Name="Obsidian Horseshoe" />
+    <Item Id="397" Name="Obsidian Shield" />
+    <Item Id="398" Name="Tinkerer's Workshop" />
+    <Item Id="399" Name="Cloud in a Balloon" />
+    <Item Id="400" Name="Adamantite Headgear" />
+    <Item Id="401" Name="Adamantite Helmet" />
+    <Item Id="402" Name="Adamantite Mask" />
+    <Item Id="403" Name="Adamantite Breastplate" />
+    <Item Id="404" Name="Adamantite Leggings" />
+    <Item Id="405" Name="Spectre Boots" />
+    <Item Id="406" Name="Adamantite Glaive" />
+    <Item Id="407" Name="Toolbelt" />
+    <Item Id="408" Name="Pearlsand Block" />
+    <Item Id="409" Name="Pearlstone Block" />
+    <Item Id="410" Name="Mining Shirt" />
+    <Item Id="411" Name="Mining Pants" />
+    <Item Id="412" Name="Pearlstone Brick" />
+    <Item Id="413" Name="Iridescent Brick" />
+    <Item Id="414" Name="Mudstone Block" />
+    <Item Id="415" Name="Cobalt Brick" />
+    <Item Id="416" Name="Mythril Brick" />
+    <Item Id="417" Name="Pearlstone Brick Wall" />
+    <Item Id="418" Name="Iridescent Brick Wall" />
+    <Item Id="419" Name="Mudstone Brick Wall" />
+    <Item Id="420" Name="Cobalt Brick Wall" />
+    <Item Id="421" Name="Mythril Brick Wall" />
+    <Item Id="422" Name="Holy Water" />
+    <Item Id="423" Name="Unholy Water" />
+    <Item Id="424" Name="Silt Block" />
+    <Item Id="425" Name="Fairy Bell" />
+    <Item Id="426" Name="Breaker Blade" />
+    <Item Id="427" Name="Blue Torch" />
+    <Item Id="428" Name="Red Torch" />
+    <Item Id="429" Name="Green Torch" />
+    <Item Id="430" Name="Purple Torch" />
+    <Item Id="431" Name="White Torch" />
+    <Item Id="432" Name="Yellow Torch" />
+    <Item Id="433" Name="Demon Torch" />
+    <Item Id="434" Name="Clockwork Assault Rifle" />
+    <Item Id="435" Name="Cobalt Repeater" />
+    <Item Id="436" Name="Mythril Repeater" />
+    <Item Id="437" Name="Dual Hook" />
+    <Item Id="438" Name="Star Statue" />
+    <Item Id="439" Name="Sword Statue" />
+    <Item Id="440" Name="Slime Statue" />
+    <Item Id="441" Name="Goblin Statue" />
+    <Item Id="442" Name="Shield Statue" />
+    <Item Id="443" Name="Bat Statue" />
+    <Item Id="444" Name="Fish Statue" />
+    <Item Id="445" Name="Bunny Statue" />
+    <Item Id="446" Name="Skeleton Statue" />
+    <Item Id="447" Name="Reaper Statue" />
+    <Item Id="448" Name="Woman Statue" />
+    <Item Id="449" Name="Imp Statue" />
+    <Item Id="450" Name="Gargoyle Statue" />
+    <Item Id="451" Name="Gloom Statue" />
+    <Item Id="452" Name="Hornet Statue" />
+    <Item Id="453" Name="Bomb Statue" />
+    <Item Id="454" Name="Crab Statue" />
+    <Item Id="455" Name="Hammer Statue" />
+    <Item Id="456" Name="Potion Statue" />
+    <Item Id="457" Name="Spear Statue" />
+    <Item Id="458" Name="Cross Statue" />
+    <Item Id="459" Name="Jellyfish Statue" />
+    <Item Id="460" Name="Bow Statue" />
+    <Item Id="461" Name="Boomerang Statue" />
+    <Item Id="462" Name="Boot Statue" />
+    <Item Id="463" Name="Chest Statue" />
+    <Item Id="464" Name="Bird Statue" />
+    <Item Id="465" Name="Axe Statue" />
+    <Item Id="466" Name="Corrupt Statue" />
+    <Item Id="467" Name="Tree Statue" />
+    <Item Id="468" Name="Anvil Statue" />
+    <Item Id="469" Name="Pickaxe Statue" />
+    <Item Id="470" Name="Mushroom Statue" />
+    <Item Id="471" Name="Eyeball Statue" />
+    <Item Id="472" Name="Pillar Statue" />
+    <Item Id="473" Name="Heart Statue" />
+    <Item Id="474" Name="Pot Statue" />
+    <Item Id="475" Name="Sunflower Statue" />
+    <Item Id="476" Name="King Statue" />
+    <Item Id="477" Name="Queen Statue" />
+    <Item Id="478" Name="Pirahna Statue" />
+    <Item Id="479" Name="Planked Wall" />
+    <Item Id="480" Name="Wooden Beam" />
+    <Item Id="481" Name="Adamantite Repeater" />
+    <Item Id="482" Name="Adamantite Sword" />
+    <Item Id="483" Name="Cobalt Sword" />
+    <Item Id="484" Name="Mythril Sword" />
+    <Item Id="485" Name="Moon Charm" />
+    <Item Id="486" Name="Ruler" />
+    <Item Id="487" Name="Crystal Ball" />
+    <Item Id="488" Name="Disco Ball" />
+    <Item Id="489" Name="Sorcerer Emblem" />
+    <Item Id="490" Name="Warrior Emblem" />
+    <Item Id="491" Name="Ranger Emblem" />
+    <Item Id="492" Name="Demon Wings" />
+    <Item Id="493" Name="Angel Wings" />
+    <Item Id="494" Name="Magical Harp" />
+    <Item Id="495" Name="Rainbow Rod" />
+    <Item Id="496" Name="Ice Rod" />
+    <Item Id="497" Name="Neptune's Shell" />
+    <Item Id="498" Name="Mannequin" />
+    <Item Id="499" Name="Greater Healing Potion" />
+    <Item Id="500" Name="Greater Mana Potion" />
+    <Item Id="501" Name="Pixie Dust" />
+    <Item Id="502" Name="Crystal Shard" />
+    <Item Id="503" Name="Clown Hat" />
+    <Item Id="504" Name="Clown Shirt" />
+    <Item Id="505" Name="Clown Pants" />
+    <Item Id="506" Name="Flamethrower" />
+    <Item Id="507" Name="Bell" />
+    <Item Id="508" Name="Harp" />
+    <Item Id="509" Name="Wrench" />
+    <Item Id="510" Name="Wire Cutter" />
+    <Item Id="511" Name="Active Stone Block" />
+    <Item Id="512" Name="Inactive Stone Block" />
+    <Item Id="513" Name="Lever" />
+    <Item Id="514" Name="Laser Rifle" />
+    <Item Id="515" Name="Crystal Bullet" />
+    <Item Id="516" Name="Holy Arrow" />
+    <Item Id="517" Name="Magic Dagger" />
+    <Item Id="518" Name="Crystal Storm" />
+    <Item Id="519" Name="Cursed Flames" />
+    <Item Id="520" Name="Soul of Light" />
+    <Item Id="521" Name="Soul of Night" />
+    <Item Id="522" Name="Cursed Flame" />
+    <Item Id="523" Name="Cursed Torch" />
+    <Item Id="524" Name="Adamantite Forge" />
+    <Item Id="525" Name="Mythril Anvil" />
+    <Item Id="526" Name="Unicorn Horn" />
+    <Item Id="527" Name="Dark Shard" />
+    <Item Id="528" Name="Light Shard" />
+    <Item Id="529" Name="Red Pressure Plate" />
+    <Item Id="530" Name="Wire" />
+    <Item Id="531" Name="Spell Tome" />
+    <Item Id="532" Name="Star Cloak" />
+    <Item Id="533" Name="Megashark" />
+    <Item Id="534" Name="Shotgun" />
+    <Item Id="535" Name="Philosopher's Stone" />
+    <Item Id="536" Name="Titan Glove" />
+    <Item Id="537" Name="Cobalt Naginata" />
+    <Item Id="538" Name="Switch" />
+    <Item Id="539" Name="Dart Trap" />
+    <Item Id="540" Name="Boulder" />
+    <Item Id="541" Name="Green Pressure Plate" />
+    <Item Id="542" Name="Gray Pressure Plate" />
+    <Item Id="543" Name="Brown Pressure Plate" />
+    <Item Id="544" Name="Mechanical Eye" />
+    <Item Id="545" Name="Cursed Arrow" />
+    <Item Id="546" Name="Cursed Bullet" />
+    <Item Id="547" Name="Soul of Fright" />
+    <Item Id="548" Name="Soul of Might" />
+    <Item Id="549" Name="Soul of Sight" />
+    <Item Id="550" Name="Gungnir" />
+    <Item Id="551" Name="Hallowed Plate Mail" />
+    <Item Id="552" Name="Hallowed Greaves" />
+    <Item Id="553" Name="Hallowed Helmet" />
+    <Item Id="554" Name="Cross Necklace" />
+    <Item Id="555" Name="Mana Flower" />
+    <Item Id="556" Name="Mechanical Worm" />
+    <Item Id="557" Name="Mechanical Skull" />
+    <Item Id="558" Name="Hallowed Headgear" />
+    <Item Id="559" Name="Hallowed Mask" />
+    <Item Id="560" Name="Slime Crown" />
+    <Item Id="561" Name="Light Disc" />
+    <Item Id="562" Name="Music Box (Overworld Day)" />
+    <Item Id="563" Name="Music Box (Eerie)" />
+    <Item Id="564" Name="Music Box (Night)" />
+    <Item Id="565" Name="Music Box (Title)" />
+    <Item Id="566" Name="Music Box (Underground)" />
+    <Item Id="567" Name="Music Box (Boss 1)" />
+    <Item Id="568" Name="Music Box (Jungle)" />
+    <Item Id="569" Name="Music Box (Corruption)" />
+    <Item Id="570" Name="Music Box (Underground Corruption)" />
+    <Item Id="571" Name="Music Box (The Hallow)" />
+    <Item Id="572" Name="Music Box (Boss 2)" />
+    <Item Id="573" Name="Music Box (Underground Hallow)" />
+    <Item Id="574" Name="Music Box (Boss 3)" />
+    <Item Id="575" Name="Soul of Flight" />
+    <Item Id="576" Name="Music Box" />
+    <Item Id="577" Name="Demonite Brick" />
+    <Item Id="578" Name="Hallowed Repeater" />
+    <Item Id="579" Name="Hamdrax" />
+    <Item Id="580" Name="Explosives" />
+    <Item Id="581" Name="Inlet Pump" />
+    <Item Id="582" Name="Outlet Pump" />
+    <Item Id="583" Name="1 Second Timer" />
+    <Item Id="584" Name="3 Second Timer" />
+    <Item Id="585" Name="5 Second Timer" />
+    <Item Id="586" Name="Candy Cane Block" />
+    <Item Id="587" Name="Candy Cane Wall" />
+    <Item Id="588" Name="Santa Hat" />
+    <Item Id="589" Name="Santa Shirt" />
+    <Item Id="590" Name="Santa Pants" />
+    <Item Id="591" Name="Green Candy Cane Block" />
+    <Item Id="592" Name="Green Candy Cane Wall" />
+    <Item Id="593" Name="Snow Block" />
+    <Item Id="594" Name="Snow Brick" />
+    <Item Id="595" Name="Snow Brick Wall" />
+    <Item Id="596" Name="Blue Light" />
+    <Item Id="597" Name="Red Light" />
+    <Item Id="598" Name="Green Light" />
+    <Item Id="599" Name="Blue Present" />
+    <Item Id="600" Name="Green Present" />
+    <Item Id="601" Name="Yellow Present" />
+    <Item Id="602" Name="Snow Globe" />
+    <Item Id="603" Name="Carrot" />
   </Items>
   <Npcs>
     <Npc Id="17" Name="Merchant" />


### PR DESCRIPTION
Over the past couple days, I've been tinkering your source to make TEdit display tile and wall textures.  I feel that I have finally added enough content to be reviewed.  Not only does it show tile and wall textures, but it also shows miscellaneous things like water/lava, wires, tree tops/branches (all types), cacti (normal/good/evil), and platforms.  I tried to make it as accurate as I could, and in some regards it is more accurate than Terrafirma, but I have not tested all scenarios.

Please consider looking over and merging this functionality, if it is suitable.  Note that there will obviously be a performance and memory hit, but it is worth it, in my opinion.
