### PR TITLE
Issue #260:  "Swap" shortcut key (no UI)

### DIFF
--- a/TEditXna/Editor/TilePicker.cs
+++ b/TEditXna/Editor/TilePicker.cs
@@ -1,5 +1,6 @@
 ﻿using BCCL.MvvmLight;
 using TEditXNA.Terraria;
+using System.Windows.Input;
 
 namespace TEditXna.Editor
 {
@@ -81,6 +82,47 @@ namespace TEditXna.Editor
         {
             get { return _paintMode; }
             set { Set("PaintMode", ref _paintMode, value); }
+        }
+
+        public void Swap(ModifierKeys modifier)
+        {
+            switch (PaintMode)
+            {
+                case PaintMode.Tile:
+                    SwapTile();
+                    break;
+                case PaintMode.Wall:
+                    SwapWall();
+                    break;
+                case PaintMode.TileAndWall:
+                    if (modifier.HasFlag(ModifierKeys.Shift))
+                        SwapWall();
+                    else
+                        SwapTile();
+                    break;
+                case PaintMode.Liquid:
+                    SwapLiquid();
+                    break;
+            }
+        }
+
+        public void SwapTile()
+        {
+            int currentTile = Tile;
+            Tile = TileMask;
+            TileMask = currentTile;
+        }
+
+        public void SwapWall()
+        {
+            int currentWall = Wall;
+            Wall = WallMask;
+            WallMask = currentWall;
+        }
+
+        public void SwapLiquid()
+        {
+            IsLava = !IsLava;
         }
     }
 }

--- a/TEditXna/MainWindow.xaml.cs
+++ b/TEditXna/MainWindow.xaml.cs
@@ -147,6 +147,10 @@ namespace TEditXna
                 {
                     _vm.TilePicker.IsEraser = !_vm.TilePicker.IsEraser;
                 }
+                else if (string.Equals("Swap", command, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    _vm.TilePicker.Swap(Keyboard.Modifiers);
+                }
                 else
                 {
                     SetActiveTool(command);

--- a/TEditXna/settings.xml
+++ b/TEditXna/settings.xml
@@ -260,6 +260,7 @@ Single item; tag has no children. Has the following properties:
     <Shortcut Key="S" Tool="Selection" />
     <Shortcut Key="T" Tool="Sprite" />
     <Shortcut Key="Z" Tool="Eraser" />
+    <Shortcut Key="X" Tool="Swap" />
   </ShortCutKeys>
   <Tools>
     <!-- Valid Paint Modes are Tile, Wall, TileAndWall, Wire and Liquid. -->


### PR DESCRIPTION
This is a partial resolution for issue #260:  I implemented a "Swap" shortcut key for swapping tiles, walls, masks and liquids.  The Swap key, as defined in settings.xml, swaps the "primary tool" and Shift-Swap swaps the "secondary tool" (currently, only during TileAndWall).

There's no corresponding UI because my C#-fu is weak.
