### PR TITLE
Update SelectionTool.cs

### DIFF
--- a/TEditXna/Editor/Tools/SelectionTool.cs
+++ b/TEditXna/Editor/Tools/SelectionTool.cs
@@ -14,6 +14,7 @@ namespace TEditXna.Editor.Tools
         private readonly WorldViewModel _wvm;
         private bool _isActive;
         private Vector2Int32 _startSelection;
+        private Vector2Int32 _modifySelection;
         private double _previewScale = 1;
 
         public SelectionTool(WorldViewModel worldViewModel)
@@ -47,8 +48,10 @@ namespace TEditXna.Editor.Tools
 
         public void MouseDown(TileMouseState e)
         {
-            if (e.LeftButton == MouseButtonState.Pressed)
+            if ((e.LeftButton == MouseButtonState.Pressed) && (Keyboard.IsKeyUp(Key.LeftShift) && Keyboard.IsKeyUp(Key.RightShift)))
                 _startSelection = e.Location;
+            if ((Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift)))
+                _modifySelection= e.Location;
             if (e.RightButton == MouseButtonState.Pressed && e.LeftButton == MouseButtonState.Released)
                 _wvm.Selection.IsActive = false;
             if (e.RightButton == MouseButtonState.Pressed && (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)))


### PR DESCRIPTION
Minor convenience. When Ctrl + Right-click is pressed using the 'Selection Tool', the current selection is set back to (or remains) 'Active'. With this, users can reselect their most recent selection with the aforementioned input.

Removed unnecessary brackets.
