### PR TITLE
Update Chest.cs

### DIFF
--- a/TEditXna/Terraria/Chest.cs
+++ b/TEditXna/Terraria/Chest.cs
@@ -65,6 +65,7 @@ namespace TEditXNA.Terraria
         public Chest Copy()
         {
             var chest = new Chest(_x, _y);
+            chest.Name = Name;
             //chest.Items.Clear();
             for (int i = 0; i < Chest.MaxItems; i++)
             {


### PR DESCRIPTION
When copying and pasting a chest, the copy will now hold the name of the original. This includes exporting to a schematic.
