### PR TITLE
Update SpriteTool.cs

### DIFF
--- a/TEditXna/Editor/Tools/SpriteTool.cs
+++ b/TEditXna/Editor/Tools/SpriteTool.cs
@@ -1,22 +1,30 @@
 using System;
+using System.Windows.Input;
 using System.Windows.Media.Imaging;
+using TEdit.Geometry;
 using TEdit.Geometry.Primitives;
 using TEditXNA.Terraria;
 using TEditXna.ViewModel;
 using TEditXna.Terraria.Objects;
-
 namespace TEditXna.Editor.Tools
 {
     public sealed class SpriteTool : BaseTool
     {
-        public SpriteTool(WorldViewModel worldViewModel) : base(worldViewModel)
+        private bool _isLeftDown;
+        private bool _isRightDown;
+        private Vector2Int32 _startPoint;
+        private Vector2Int32 _endPoint;
+        Vector2Short[,] tiles;
+        int tilex;
+        int tiley;
+        public SpriteTool(WorldViewModel worldViewModel)
+            : base(worldViewModel)
         {
             Icon = new BitmapImage(new Uri(@"pack://application:,,,/TEditXna;component/Images/Tools/sprite.png"));
             Name = "Sprite";
             IsActive = false;
             ToolType = ToolType.Pixel;
         }
-
         public override bool PreviewIsTexture
         {
             get
@@ -26,36 +34,160 @@ namespace TEditXna.Editor.Tools
                 return false;
             }
         }
-
         public override void MouseDown(TileMouseState e)
         {
             if (_wvm.SelectedSprite == null)
                 return;
-            
-            Vector2Short[,] tiles = _wvm.SelectedSprite.GetTiles();
-            for (int x = 0; x < _wvm.SelectedSprite.Size.X; x++)
+            if (_wvm.SelectedSprite.Size.X > 1 || _wvm.SelectedSprite.Size.Y > 1)
             {
-                int tilex = x + e.Location.X;
-                for (int y = 0; y < _wvm.SelectedSprite.Size.Y; y++)
+                Vector2Short[,] tiles = _wvm.SelectedSprite.GetTiles();
+                for (int x = 0; x < _wvm.SelectedSprite.Size.X; x++)
                 {
-                    int tiley = y + e.Location.Y;
-
-                    _wvm.UndoManager.SaveTile(tilex, tiley);
-                    Tile curtile = _wvm.CurrentWorld.Tiles[tilex, tiley];
-                    curtile.IsActive = true;
-                    curtile.Type = _wvm.SelectedSprite.Tile;
-                    curtile.U = tiles[x, y].X;
-                    curtile.V = tiles[x, y].Y;
-                    _wvm.UpdateRenderPixel(tilex, tiley);
+                    int tilex = x + e.Location.X;
+                    for (int y = 0; y < _wvm.SelectedSprite.Size.Y; y++)
+                    {
+                        int tiley = y + e.Location.Y;
+                        _wvm.UndoManager.SaveTile(tilex, tiley);
+                        Tile curtile = _wvm.CurrentWorld.Tiles[tilex, tiley];
+                        curtile.IsActive = true;
+                        curtile.Type = _wvm.SelectedSprite.Tile;
+                        curtile.U = tiles[x, y].X;
+                        curtile.V = tiles[x, y].Y;
+                        _wvm.UpdateRenderPixel(tilex, tiley);
+                    }
                 }
             }
-            
-            _wvm.UndoManager.SaveUndo();
+            if (!_isRightDown && !_isLeftDown)
+            {
+                _startPoint = e.Location;
+                _wvm.CheckTiles = new bool[_wvm.CurrentWorld.TilesWide * _wvm.CurrentWorld.TilesHigh];
+            }
 
-            /* Heathtech */
-            BlendRules.ResetUVCache(_wvm, e.Location.X, e.Location.Y, _wvm.SelectedSprite.Size.X, _wvm.SelectedSprite.Size.Y);
+            _isLeftDown = (e.LeftButton == MouseButtonState.Pressed);
+            _isRightDown = (e.RightButton == MouseButtonState.Pressed);
+
+            if (_wvm.SelectedSprite.Size.X == 1 && _wvm.SelectedSprite.Size.Y == 1)
+                CheckDirectionandDraw(e.Location);
         }
+        public override void MouseMove(TileMouseState e)
+        {
+            _isLeftDown = (e.LeftButton == MouseButtonState.Pressed);
+            _isRightDown = (e.RightButton == MouseButtonState.Pressed);
 
+            if (_wvm.SelectedSprite == null)
+                return;
+            if (_wvm.SelectedSprite.Size.X == 1 && _wvm.SelectedSprite.Size.Y == 1)
+                CheckDirectionandDraw(e.Location);
+        }
+        public override void MouseUp(TileMouseState e)
+        {
+            if (_wvm.SelectedSprite == null)
+                return;
+            if (_wvm.SelectedSprite.Size.X == 1 && _wvm.SelectedSprite.Size.Y == 1)
+                CheckDirectionandDraw(e.Location);
+
+            _isLeftDown = (e.LeftButton == MouseButtonState.Pressed);
+            _isRightDown = (e.RightButton == MouseButtonState.Pressed);
+            _wvm.UndoManager.SaveUndo();
+        }
+        private void CheckDirectionandDraw(Vector2Int32 tile)
+        {
+            Vector2Int32 p = tile;
+            Vector2Int32 p2 = tile;
+            if (_isRightDown)
+            {
+                if (_isLeftDown)
+                    p.X = _startPoint.X;
+                else
+                    p.Y = _startPoint.Y;
+                DrawLine(p);
+                _startPoint = p;
+            }
+            else if (_isLeftDown)
+            {
+                if ((Keyboard.IsKeyUp(Key.LeftShift)) && (Keyboard.IsKeyUp(Key.RightShift)))
+                {
+                    DrawLine(p);
+                    _startPoint = p;
+                    _endPoint = p;
+                }
+                else if ((Keyboard.IsKeyDown(Key.LeftShift)) || (Keyboard.IsKeyDown(Key.RightShift)))
+                {
+                    DrawLineP2P(p2);
+                    _endPoint = p2;
+                }
+            }
+        }
+        private void DrawLine(Vector2Int32 to)
+        {
+            foreach (Vector2Int32 pixel in Shape.DrawLineTool(_startPoint, to))
+            {
+                if (!_wvm.CurrentWorld.ValidTileLocation(pixel)) continue;
+                int index = pixel.X + pixel.Y * _wvm.CurrentWorld.TilesWide;
+                if (!_wvm.CheckTiles[index])
+                {
+                    _wvm.CheckTiles[index] = true;
+                    if (_wvm.Selection.IsValid(pixel))
+                    {
+                        if (_wvm.SelectedSprite == null)
+                            return;
+                        tiles = _wvm.SelectedSprite.GetTiles();
+                        for (int x = 0; x < _wvm.SelectedSprite.Size.X; x++)
+                        {
+                            tilex = x + pixel.X;
+                            for (int y = 0; y < _wvm.SelectedSprite.Size.Y; y++)
+                            {
+                                tiley = y + pixel.Y;
+                                _wvm.UndoManager.SaveTile(tilex, tiley);
+                                Tile curtile = _wvm.CurrentWorld.Tiles[tilex, tiley];
+                                curtile.IsActive = true;
+                                curtile.Type = _wvm.SelectedSprite.Tile;
+                                curtile.U = tiles[x, y].X;
+                                curtile.V = tiles[x, y].Y;
+                                _wvm.UpdateRenderPixel(tilex, tiley);
+                                // Heathtech
+                                BlendRules.ResetUVCache(_wvm, pixel.X, pixel.Y, _wvm.SelectedSprite.Size.X, _wvm.SelectedSprite.Size.Y);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        private void DrawLineP2P(Vector2Int32 endPoint)
+        {
+            foreach (Vector2Int32 pixel in Shape.DrawLineTool(_startPoint, _endPoint))
+            {
+                if (!_wvm.CurrentWorld.ValidTileLocation(pixel)) continue;
+                int index = pixel.X + pixel.Y * _wvm.CurrentWorld.TilesWide;
+                if (!_wvm.CheckTiles[index])
+                {
+                    _wvm.CheckTiles[index] = true;
+                    if (_wvm.Selection.IsValid(pixel))
+                    {
+                        if (_wvm.SelectedSprite == null)
+                            return;
+                        tiles = _wvm.SelectedSprite.GetTiles();
+                        for (int x = 0; x < _wvm.SelectedSprite.Size.X; x++)
+                        {
+                            tilex = x + pixel.X;
+                            for (int y = 0; y < _wvm.SelectedSprite.Size.Y; y++)
+                            {
+                                tiley = y + pixel.Y;
+                                _wvm.UndoManager.SaveTile(tilex, tiley);
+                                Tile curtile = _wvm.CurrentWorld.Tiles[tilex, tiley];
+                                curtile.IsActive = true;
+                                curtile.Type = _wvm.SelectedSprite.Tile;
+                                curtile.U = tiles[x, y].X;
+                                curtile.V = tiles[x, y].Y;
+                                _wvm.UpdateRenderPixel(tilex, tiley);
+                            }
+                        }
+                        // Heathtech
+                        BlendRules.ResetUVCache(_wvm, pixel.X, pixel.Y, _wvm.SelectedSprite.Size.X, _wvm.SelectedSprite.Size.Y);
+                    }
+                }
+            }
+        }
         public override WriteableBitmap PreviewTool()
         {
             if (_wvm.SelectedSprite != null)


### PR DESCRIPTION
Users can now draw and make lines with sprites no larger than 1x1 tile using the sprite tool. This enables them to make lines with platforms, cart tracks, and other small sprites.
