### PR TITLE
GOG support/UI Fix

### DIFF
--- a/TEditXna/DependencyChecker.cs
+++ b/TEditXna/DependencyChecker.cs
@@ -24,6 +24,16 @@ namespace TEditXna
                 path = string.Empty;
             }
 
+            // SBLogic - attempt to find GOG version
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                using (Microsoft.Win32.RegistryKey key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"SOFTWARE\GOG.com\Games\1207665503\"))
+                {
+                    if (key != null)
+                        path = Path.Combine((string)key.GetValue("PATH"), "Content");
+                }
+            }
+
             // find steam
             if (string.IsNullOrWhiteSpace(path))
             {

--- a/TEditXna/MainWindow.xaml
+++ b/TEditXna/MainWindow.xaml
@@ -63,8 +63,8 @@
                     <MenuItem Header="Show Grid" IsCheckable="True" IsChecked="{Binding ShowGrid}" />
                     <Separator Margin="1" />
                     <MenuItem Header="Show Walls" IsCheckable="True" IsChecked="{Binding ShowWalls}" />
-                    <MenuItem Header="Show UndoTiles" IsCheckable="True" IsChecked="{Binding ShowTiles}" />
-                    <MenuItem Header="Show LiquidAmount" IsCheckable="True" IsChecked="{Binding ShowLiquid}" />
+                    <MenuItem Header="Show Tiles" IsCheckable="True" IsChecked="{Binding ShowTiles}" />
+                    <MenuItem Header="Show Liquid" IsCheckable="True" IsChecked="{Binding ShowLiquid}" />
                     <MenuItem Header="Show Wires" IsCheckable="True" IsChecked="{Binding ShowWires}" />
                     <Separator Margin="1" />
                     <MenuItem Header="Show Points" IsCheckable="True" IsChecked="{Binding ShowPoints}" />

--- a/TEditXna/View/WorldPropertiesView.xaml
+++ b/TEditXna/View/WorldPropertiesView.xaml
@@ -71,7 +71,11 @@
             <enum:EnumItem Value="1">1</enum:EnumItem>
             <enum:EnumItem Value="2">2</enum:EnumItem>
         </enum:EnumItemList>
-
+        <enum:EnumItemList x:Key="CrimsonBGStyleList" EnumType="{x:Type System:Int32}" SortBy="Value">
+            <enum:EnumItem Value="0">0</enum:EnumItem>
+            <enum:EnumItem Value="1">1</enum:EnumItem>
+            <enum:EnumItem Value="2">2</enum:EnumItem>
+        </enum:EnumItemList>
         <enum:EnumItemList x:Key="CommonBGStyleList" EnumType="{x:Type System:Byte}" SortBy="Value">
             <enum:EnumItem Value="0">0</enum:EnumItem>
             <enum:EnumItem Value="1">1</enum:EnumItem>
@@ -386,7 +390,7 @@
             <TextBlock Text="Crimson BG" HorizontalAlignment="Right" />
         </DockPanel>
         <DockPanel>
-            <ComboBox Height="20" Width="40" HorizontalAlignment="Left" ItemsSource="{StaticResource CommonBGStyleList}" SelectedValue="{Binding CurrentWorld.BgCrimson, Mode=TwoWay}" SelectedValuePath="Value" />
+            <ComboBox Height="20" Width="40" HorizontalAlignment="Left" ItemsSource="{StaticResource CrimsonBGStyleList}" SelectedValue="{Binding CurrentWorld.BgCrimson, Mode=TwoWay}" SelectedValuePath="Value" />
         </DockPanel>
         <DockPanel>
             <TextBlock Text="Desert BG" HorizontalAlignment="Right" />


### PR DESCRIPTION
Adds support to locate textures via the registry if the GOG.com version is installed.

Also corrects some minor GUI issues -- "Show Tiles" and "Show Liquid" in the Display menu, and correct selection for CrimsonBG in the World Properties panel.