### PR TITLE
Added SteamUserId to settings.xml, which enables opening worlds stored in Steam Cloud as the default folder

### DIFF
--- a/TEditXna/Terraria/World.Settings.cs
+++ b/TEditXna/Terraria/World.Settings.cs
@@ -35,6 +35,7 @@ namespace TEditXNA.Terraria
         private static readonly Dictionary<int, string> _tallynames = new Dictionary<int, string>();
         private static Vector2 _appSize;
         internal static string AltC;
+        internal static int? SteamUserId;
  
         static World()
         {
@@ -332,6 +333,7 @@ namespace TEditXNA.Terraria
             ToolDefaultData.LoadSettings(xmlSettings.Elements("Tools"));
 
             AltC = (string)xmlSettings.Element("AltC");
+            SteamUserId = (int?)xmlSettings.Element("SteamUserId") ?? null;
         }
 
         public static TileProperty GetBrickFromColor(byte a, byte r, byte g, byte b)

--- a/TEditXna/ViewModel/WorldViewModel.cs
+++ b/TEditXna/ViewModel/WorldViewModel.cs
@@ -704,7 +704,7 @@ namespace TEditXna.ViewModel
             ofd.Filter = "Terraria World File|*.wld|Terraria World Backup|*.bak|TEdit Backup File|*.TEdit";
             ofd.DefaultExt = "Terraria World File|*.wld";
             ofd.Title = "Load Terraria World File";
-            ofd.InitialDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), @"My Games\Terraria\Worlds");
+            ofd.InitialDirectory = DependencyChecker.PathToWorlds;
             ofd.Multiselect = false;
             if ((bool)ofd.ShowDialog())
             {
@@ -790,7 +790,7 @@ namespace TEditXna.ViewModel
             var sfd = new SaveFileDialog();
             sfd.Filter = "Terraria World File|*.wld|TEdit Backup File|*.TEdit";
             sfd.Title = "Save World As";
-            sfd.InitialDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), @"My Games\Terraria\Worlds");
+            sfd.InitialDirectory = DependencyChecker.PathToWorlds;
             if ((bool)sfd.ShowDialog())
             {
                 CurrentFile = sfd.FileName;

--- a/TEditXna/settings.xml
+++ b/TEditXna/settings.xml
@@ -52,6 +52,11 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 <Settings>
   <!-- Uncomment the following and set to custom path if desired.  -->
   <!--<AltC>D:\Dev\CODE\Terraria\Content</AltC>-->
+  <!--
+    Uncomment the following to edit Steam Cloud worlds.  Set the value to your Steam User ID;
+    otherwise 0 will try to guess your ID and fail if you have multiple Steam users.
+  -->
+  <!--SteamUserId>0</SteamUserId-->
   <App Width="800" Height="600" ClipboardRenderSize="512" />
   <ShortCutKeys>
     <Shortcut Key="A"   Tool="Arrow"        />


### PR DESCRIPTION
Not everyone knows where Steam Cloud worlds are stored, so this makes it easier.  Not compatible with OS X, but now there's a single function where it could be fixed.