### PR TITLE
Fix pasting wires (issue #666) and display full herb names

### DIFF
--- a/TEditXna/Editor/Clipboard/ClipboardManager.cs
+++ b/TEditXna/Editor/Clipboard/ClipboardManager.cs
@@ -205,11 +205,12 @@ namespace TEditXna.Editor.Clipboard
                         if (!PasteWires)
                         {
                             // if pasting wires is disabled, use any existing wire
-                            curTile.WireRed = buffer.Tiles[x, y].WireRed;
-                            curTile.WireGreen = buffer.Tiles[x, y].WireGreen;
-                            curTile.WireBlue = buffer.Tiles[x, y].WireBlue;
-                            curTile.Actuator = buffer.Tiles[x, y].Actuator;
-                            curTile.InActive = buffer.Tiles[x, y].InActive;
+                            Tile worldTile = world.Tiles[worldX, worldY];
+                            curTile.WireRed = worldTile.WireRed;
+                            curTile.WireGreen = worldTile.WireGreen;
+                            curTile.WireBlue = worldTile.WireBlue;
+                            curTile.Actuator = worldTile.Actuator;
+                            curTile.InActive = worldTile.InActive;
                         }
                         //  Update chest/sign data only if we've pasted tiles
                         if (PasteTiles)

--- a/TEditXna/Editor/MouseTile.cs
+++ b/TEditXna/Editor/MouseTile.cs
@@ -58,7 +58,17 @@ namespace TEditXna.Editor
                 Set("Tile", ref _tile, value);
 
                 if (World.TileProperties.Count > _tile.Type)
-                    TileName = _tile.IsActive ? string.Format("{0} ({1})", World.TileProperties[_tile.Type].Name, _tile.Type) : "[empty]";
+                {
+                    TEditXNA.Terraria.Objects.TileProperty tileProperty = World.TileProperties[_tile.Type];
+                    string herbKey = World.GetHerbKey(_tile.Type, _tile.U, _tile.V);
+                    if (!tileProperty.IsHerb || !World.HerbNames.ContainsKey(herbKey))
+                    {
+                        TileName = tileProperty.Name;
+                    } else {
+                        TileName = World.HerbNames[herbKey];
+                    }
+                    TileName = _tile.IsActive ? string.Format("{0} ({1})", TileName, _tile.Type) : "[empty]";
+                }
                 else
                     TileName = string.Format("INVALID TILE ({0})", _tile.Type);
 

--- a/TEditXna/Terraria/Objects/TileProperty.cs
+++ b/TEditXna/Terraria/Objects/TileProperty.cs
@@ -23,6 +23,7 @@ namespace TEditXNA.Terraria.Objects
         private bool _isGrass; /* Heathtech */
         private bool _isPlatform; /* Heathtech */
         private bool _isCactus; /* Heathtech */
+        private bool _isHerb;
         private bool _isStone; /* Heathtech */
         private bool _canBlend; /* Heathtech */
         private int? _mergeWith; /* Heathtech */
@@ -141,6 +142,12 @@ namespace TEditXNA.Terraria.Objects
         {
             get { return _isCactus; }
             set { Set("IsCactus", ref _isCactus, value); }
+        }
+
+        public bool IsHerb
+        {
+            get { return _isHerb; }
+            set { Set("IsHerb", ref _isHerb, value);  }
         }
 
         /* Heathtech */

--- a/TEditXna/Terraria/World.Settings.cs
+++ b/TEditXna/Terraria/World.Settings.cs
@@ -198,7 +198,7 @@ namespace TEditXNA.Terraria
                         {
                             herbName += " Bloom";
                         }
-                        HerbNames.Add(getHerbKey(curTile.Id, curFrame.UV.X, curFrame.UV.Y), herbName);
+                        HerbNames.Add(GetHerbKey(curTile.Id, curFrame.UV.X, curFrame.UV.Y), herbName);
                     }
                 }
                 if (curTile.Frames.Count == 0 && curTile.IsFramed)

--- a/TEditXna/Terraria/World.Settings.cs
+++ b/TEditXna/Terraria/World.Settings.cs
@@ -34,6 +34,7 @@ namespace TEditXNA.Terraria
         private static readonly Dictionary<Key, string> _shortcuts = new Dictionary<Key, string>();
         private static readonly Dictionary<int, ItemProperty> _itemLookup = new Dictionary<int, ItemProperty>();
         private static readonly Dictionary<int, string> _tallynames = new Dictionary<int, string>();
+        private static readonly Dictionary<string, string> _herbNames = new Dictionary<string, string>();
         private static Vector2 _appSize;
         internal static string AltC;
         internal static int? SteamUserId;
@@ -156,6 +157,7 @@ namespace TEditXNA.Terraria
                 curTile.IsStone = (bool?)xElement.Attribute("Stone") ?? false; /* Heathtech */
                 curTile.CanBlend = (bool?)xElement.Attribute("Blends") ?? false; /* Heathtech */
                 curTile.MergeWith = (int?)xElement.Attribute("MergeWith") ?? null; /* Heathtech */
+                curTile.IsHerb = curTile.Id >= 82 && curTile.Id <= 84;
                 foreach (var elementFrame in xElement.Elements("Frames").Elements("Frame"))
                 {
 
@@ -181,6 +183,23 @@ namespace TEditXNA.Terraria
                                         Tile = (ushort)curTile.Id, /* SBlogic */
                                         TileName = curTile.Name
                                     });
+                    if (curTile.IsHerb)
+                    {
+                        string herbName = curFrame.Name;
+                        if (curTile.Id == 82)
+                        {
+                            herbName += " Seed";
+                        }
+                        else if (curTile.Id == 83)
+                        {
+                            herbName += " Mature";
+                        }
+                        else if (curTile.Id == 84)
+                        {
+                            herbName += " Bloom";
+                        }
+                        HerbNames.Add(getHerbKey(curTile.Id, curFrame.UV.X, curFrame.UV.Y), herbName);
+                    }
                 }
                 if (curTile.Frames.Count == 0 && curTile.IsFramed)
                 {
@@ -472,9 +491,19 @@ namespace TEditXNA.Terraria
             get { return _tallynames;  }
         }
 
+        public static Dictionary<string, string> HerbNames
+        {
+            get { return _herbNames; }
+        }
+
         internal static Vector2 AppSize
         {
             get { return _appSize; }
+        }
+
+        public static string GetHerbKey(int id, short u, short v)
+        {
+            return id + "," + u + "," + v;
         }
     }
 }


### PR DESCRIPTION
When the clipboard "Paste Wire" is disabled, the code was still pasting the buffer's wiring rather than the original wiring in the world.

With all the properties that are now available, we should probably refactor PasteBufferIntoWorld to selectively paste rather than a "clone & restore."