### PR TITLE
Generalized the capability to display framename on mouseover

### DIFF
--- a/TEditXna/Editor/MouseTile.cs
+++ b/TEditXna/Editor/MouseTile.cs
@@ -60,12 +60,14 @@ namespace TEditXna.Editor
                 if (World.TileProperties.Count > _tile.Type)
                 {
                     TEditXNA.Terraria.Objects.TileProperty tileProperty = World.TileProperties[_tile.Type];
-                    string herbKey = World.GetHerbKey(_tile.Type, _tile.U, _tile.V);
-                    if (!tileProperty.IsHerb || !World.HerbNames.ContainsKey(herbKey))
+                    if (!tileProperty.HasFrameName)
                     {
                         TileName = tileProperty.Name;
-                    } else {
-                        TileName = World.HerbNames[herbKey];
+                    }
+                    else
+                    {
+                        string frameNameKey = World.GetFrameNameKey(_tile.Type, _tile.U, _tile.V);
+                        TileName = World.FrameNames.ContainsKey(frameNameKey) ? World.FrameNames[frameNameKey] : tileProperty.Name + "*";
                     }
                     TileName = _tile.IsActive ? string.Format("{0} ({1})", TileName, _tile.Type) : "[empty]";
                 }

--- a/TEditXna/Terraria/Objects/TileProperty.cs
+++ b/TEditXna/Terraria/Objects/TileProperty.cs
@@ -23,7 +23,7 @@ namespace TEditXNA.Terraria.Objects
         private bool _isGrass; /* Heathtech */
         private bool _isPlatform; /* Heathtech */
         private bool _isCactus; /* Heathtech */
-        private bool _isHerb;
+        private bool _hasFrameName;
         private bool _isStone; /* Heathtech */
         private bool _canBlend; /* Heathtech */
         private int? _mergeWith; /* Heathtech */
@@ -38,6 +38,7 @@ namespace TEditXNA.Terraria.Objects
             _isGrass = false; /* Heathtech */
             _isPlatform = false; /* Heathtech */
             _isCactus = false; /* Heathtech */
+            _hasFrameName = false;
             _isStone = false; /* Heathtech */
             _canBlend = false; /* Heathtech */
             _mergeWith = null; /* Heathtech */
@@ -76,8 +77,6 @@ namespace TEditXNA.Terraria.Objects
         {
             get { return _frames; }
         }
-
-
 
         public TileProperty(int id, string name, Color color, bool isFramed = false)
         {
@@ -144,10 +143,10 @@ namespace TEditXNA.Terraria.Objects
             set { Set("IsCactus", ref _isCactus, value); }
         }
 
-        public bool IsHerb
+        public bool HasFrameName
         {
-            get { return _isHerb; }
-            set { Set("IsHerb", ref _isHerb, value);  }
+            get { return _hasFrameName; }
+            set { Set("HasFrameName", ref _hasFrameName, value);  }
         }
 
         /* Heathtech */

--- a/TEditXna/Terraria/World.Settings.cs
+++ b/TEditXna/Terraria/World.Settings.cs
@@ -193,12 +193,17 @@ namespace TEditXNA.Terraria
                         if (curFrame.Variety != null)
                             frameName += ", " + curFrame.Variety;
 
-                        for (int i=0, j=curTile.FrameSize.X; i<j; i++)
+                        //  TODO:  There must be a more efficient way than to store each frame...
+                        for (int x = 0, mx = curTile.FrameSize.X; x < mx; x++)
                         {
-                            //  TODO:  This needs to be fixed to handle frames correctly
-                            string frameNameKey = GetFrameNameKey(curTile.Id, (short) (curFrame.UV.X + (i * 18)), curFrame.UV.Y);
-                            if (!FrameNames.ContainsKey(frameNameKey))
-                                FrameNames.Add(frameNameKey, frameName);
+                            for (int y = 0, my = curTile.FrameSize.Y; y < my; y++)
+                            {
+                                string frameNameKey = GetFrameNameKey(curTile.Id, (short)(curFrame.UV.X + (x * 18)), (short)(curFrame.UV.Y + (y * 18)));
+                                if (!FrameNames.ContainsKey(frameNameKey))
+                                    FrameNames.Add(frameNameKey, frameName);
+                                else
+                                    System.Diagnostics.Debug.WriteLine(curFrame.Name + " collided with " + frameNameKey);
+                            }
                         }
                     }
                 }
@@ -504,7 +509,7 @@ namespace TEditXNA.Terraria
 
         public static string GetFrameNameKey(int id, short u, short v)
         {
-            return id + ":" + u;
+            return id + ":" + u + "," + v;
         }
     }
 }

--- a/TEditXna/Terraria/World.Settings.cs
+++ b/TEditXna/Terraria/World.Settings.cs
@@ -195,8 +195,10 @@ namespace TEditXNA.Terraria
 
                         for (int i=0, j=curTile.FrameSize.X; i<j; i++)
                         {
+                            //  TODO:  This needs to be fixed to handle frames correctly
                             string frameNameKey = GetFrameNameKey(curTile.Id, (short) (curFrame.UV.X + (i * 18)), curFrame.UV.Y);
-                            FrameNames.Add(frameNameKey, frameName);
+                            if (!FrameNames.ContainsKey(frameNameKey))
+                                FrameNames.Add(frameNameKey, frameName);
                         }
                     }
                 }

--- a/TEditXna/settings.xml
+++ b/TEditXna/settings.xml
@@ -1484,7 +1484,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
         <Frame UV="36,0" Anchor="Right" />
       </Frames>
     </Tile>
-    <Tile Color="#FFE9CF5E" Placement="floor" Size="2,2" Id="21" Name="Chest" Framed="true">
+    <Tile Color="#FFE9CF5E" Placement="floor" Size="2,2" Id="21" Name="Chest" Framed="true" UseFrameName="true">
       <Frames>
         <Frame UV="0,0" Name="Chest" />
         <Frame UV="36,0" Name="Gold Chest" />
@@ -2133,7 +2133,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
         <Frame UV="130,0" Variety="Sponge" />
       </Frames>
     </Tile>
-    <Tile Color="#FFFF7800" Id="82" Name="Daybloom Seeds" Framed="true">
+    <Tile Color="#FFFF7800" Id="82" Name="Daybloom Seeds" Framed="true" UseFrameName="true" FrameNamePostfix="seed">
       <Frames>
         <Frame UV="0,0" Name="Daybloom" growsOn="2,78" />
         <Frame UV="18,0" Name="Moonglow" growsOn="60,78" />
@@ -2144,7 +2144,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
         <Frame UV="108,0" Name="Shiverthorn" growsOn="147,161" />
       </Frames>
     </Tile>
-    <Tile Name="Herb Mature" Color="#FFFF7800" Id="83" Framed="true" Light="true">
+    <Tile Name="Herb Mature" Color="#FFFF7800" Id="83" Framed="true" UseFrameName="true" Light="true">
       <Frames>
         <Frame UV="0,0" Name="Daybloom" growsOn="2,78" />
         <Frame UV="18,0" Name="Moonglow" growsOn="60,78" />
@@ -2155,7 +2155,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
         <Frame UV="108,0" Name="Shiverthorn" growsOn="147,161" />
       </Frames>
     </Tile>
-    <Tile Name="Herb Bloom" Color="#FFFF7800" Id="84" Framed="true" Light="true">
+    <Tile Name="Herb Bloom" Color="#FFFF7800" Id="84" Framed="true" UseFrameName="true" FrameNamePostfix="bloom" Light="true">
       <Frames>
         <Frame UV="0,0" Name="Daybloom" growsOn="2,78" />
         <Frame UV="18,0" Name="Moonglow" growsOn="60,78" />
@@ -8376,6 +8376,9 @@ Single tile object; may contain Frame tags. Has the following properties:
  always have isFramed set, though some single-tiled objects also have frames. Furthermore,
  some XNB tiles with frames actually don't need frame coordinations. (Yes, it's confusing;
  it usually boils Top to trial-and-error and seeing if the world file can't be read.)
+ 
+ * useFrameName - Default is false; if true, isFramed is required.  When mousing over tiles, display the frame name rather than the tile name.
+ * frameNamePostfix - Default is empty.  When useFrameName is true, append a postfix to the display name.
 
  * size - Required if not default; default is "1,1". This is the width and height of tile
  objects that span multiple tiles. If this property is beyond "1,1", then isFramed MUST be true.


### PR DESCRIPTION
I rewrote what I did in #667 so it's more generalized:

For Framed tiles, UseFrameName can be set so the editor displays the framename rather than the tilename on mouseovers
- Example: Display "Frozen Chest, Locked" rather than simply "Chest"
- Currently enabled for herbs and chests.  I didn't do any memory usage tests, but it seems like putting all framed tiles into the dictionary would be a bad idea

For tiles that UseFrameName, an optional FrameNamePostfix can be set, which is appended to the framename
- For example, herbs of id 82 display as (seed) and herbs of id 84 display as (bloom)