### PR TITLE
Added a Plugin to search for a specific item in all the chests

### DIFF
--- a/TEditXna/Editor/Plugins/FindChestWithPlugin.cs
+++ b/TEditXna/Editor/Plugins/FindChestWithPlugin.cs
@@ -13,7 +13,7 @@ namespace TEditXna.Editor.Plugins
         public FindChestWithPlugin(WorldViewModel worldViewModel)
             : base(worldViewModel)
         {
-            Name = "Find Chest With";
+            Name = "Find Chests With";
         }
 
         public override void Execute()
@@ -25,19 +25,25 @@ namespace TEditXna.Editor.Plugins
             {
                 return;
             }
-            string text = view.ItemToFind;
+
+            string itemName = view.ItemToFind.ToLower();
             List<Vector2> locations = new List<Vector2>();
 
+            // Search the whole World
             for (int x = 0; x < _wvm.CurrentWorld.TilesWide; x++)
             {
                 for (int y = 0; y < _wvm.CurrentWorld.TilesHigh; y++)
                 {
+                    // Check if a tile is a chest
                     if (_wvm.CurrentWorld.Tiles[x, y].Type == (int)TileType.Chest)
                     {
+                        // Convert the tile to its respective chest
                         Chest chest = _wvm.CurrentWorld.GetChestAtTile(x, y);
+                        // Only use the chest once (chest = 2x2 so it would add 4 entries)
                         if (x == chest.X && y == chest.Y)
                         {
-                            if (chest.Items.Count(c => c.GetName().ToLower().Contains(text)) > 0)
+                            // check if the item exists in the chest
+                            if (chest.Items.Count(c => c.GetName().ToLower().Contains(itemName)) > 0)
                             {
                                 locations.Add(new Vector2(x, y));
                             }
@@ -46,6 +52,7 @@ namespace TEditXna.Editor.Plugins
                 }
             }
 
+            // show the result view with the list of locations
             FindChestWithPluginResultView resultView = new FindChestWithPluginResultView(locations);
             resultView.Show();
         }

--- a/TEditXna/Editor/Plugins/FindChestWithPlugin.cs
+++ b/TEditXna/Editor/Plugins/FindChestWithPlugin.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Xna.Framework;
+using TEditXNA.Terraria;
+using TEditXna.ViewModel;
+
+namespace TEditXna.Editor.Plugins
+{
+    public class FindChestWithPlugin : BasePlugin
+    {
+        public FindChestWithPlugin(WorldViewModel worldViewModel)
+            : base(worldViewModel)
+        {
+            Name = "Find Chest With";
+        }
+
+        public override void Execute()
+        {
+            if (_wvm.CurrentWorld == null) return;
+
+            FindChestWithPluginView view = new FindChestWithPluginView();
+            if (view.ShowDialog() == false)
+            {
+                return;
+            }
+            string text = view.ItemToFind;
+            List<Vector2> locations = new List<Vector2>();
+
+            for (int x = 0; x < _wvm.CurrentWorld.TilesWide; x++)
+            {
+                for (int y = 0; y < _wvm.CurrentWorld.TilesHigh; y++)
+                {
+                    if (_wvm.CurrentWorld.Tiles[x, y].Type == (int)TileType.Chest)
+                    {
+                        Chest chest = _wvm.CurrentWorld.GetChestAtTile(x, y);
+                        if (x == chest.X && y == chest.Y)
+                        {
+                            if (chest.Items.Count(c => c.GetName().ToLower().Contains(text)) > 0)
+                            {
+                                locations.Add(new Vector2(x, y));
+                            }
+                        }
+                    }
+                }
+            }
+
+            FindChestWithPluginResultView resultView = new FindChestWithPluginResultView(locations);
+            resultView.Show();
+        }
+    }
+}

--- a/TEditXna/Editor/Plugins/FindChestWithPluginResultView.xaml
+++ b/TEditXna/Editor/Plugins/FindChestWithPluginResultView.xaml
@@ -1,0 +1,14 @@
+﻿<Window x:Class="TEditXna.Editor.Plugins.FindChestWithPluginResultView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="clr-namespace:TEditXna.View" SizeToContent="WidthAndHeight"
+        Title="FindChestWithPlugin" ResizeMode="CanResizeWithGrip" WindowStartupLocation="CenterOwner" Icon="/TEditXna;component/Images/tedit.ico">
+    <DockPanel Background="{StaticResource ControlBackgroundBrush}" VerticalAlignment="Stretch" Height="200">
+        <TextBlock Text="These location could be found." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Center" Foreground="{StaticResource TextBrush}" DockPanel.Dock="Top"/>
+        <Grid DockPanel.Dock="Bottom">
+            <Button Margin="5" Content="Close" HorizontalAlignment="Center" Padding="20, 3" Click="CloseButtonClick" />
+        </Grid>
+
+        <ListBox Name="LocationList"/>
+    </DockPanel>
+</Window>

--- a/TEditXna/Editor/Plugins/FindChestWithPluginResultView.xaml.cs
+++ b/TEditXna/Editor/Plugins/FindChestWithPluginResultView.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using Microsoft.Xna.Framework;
+
+namespace TEditXna.Editor.Plugins
+{
+    /// <summary>
+    /// Interaction logic for ReplaceAllPlugin.xaml
+    /// </summary>
+    public partial class FindChestWithPluginResultView : Window
+    {
+        public FindChestWithPluginResultView(IEnumerable<Vector2> locations)
+        {
+            InitializeComponent();
+            foreach (Vector2 location in locations)
+            {
+                LocationList.Items.Add(String.Format("{0} - {1}", location.X, location.Y));
+            }
+        }
+
+        public void CloseButtonClick(object sender, RoutedEventArgs routedEventArgs)
+        {
+            this.Close();
+        }
+    }
+}

--- a/TEditXna/Editor/Plugins/FindChestWithPluginResultView.xaml.cs
+++ b/TEditXna/Editor/Plugins/FindChestWithPluginResultView.xaml.cs
@@ -24,6 +24,7 @@ namespace TEditXna.Editor.Plugins
             InitializeComponent();
             foreach (Vector2 location in locations)
             {
+                // Was to lazy to do it with Bindings (sorry)
                 LocationList.Items.Add(String.Format("{0} - {1}", location.X, location.Y));
             }
         }

--- a/TEditXna/Editor/Plugins/FindChestWithPluginView.xaml
+++ b/TEditXna/Editor/Plugins/FindChestWithPluginView.xaml
@@ -1,0 +1,14 @@
+﻿<Window x:Class="TEditXna.Editor.Plugins.FindChestWithPluginView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="clr-namespace:TEditXna.View" SizeToContent="WidthAndHeight"
+        Title="FindChestWithPlugin" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEditXna;component/Images/tedit.ico">
+    <StackPanel Background="{StaticResource ControlBackgroundBrush}" >
+        <TextBlock Text="Enter the name of the item you are looking for." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
+        <TextBox x:Name="ItemLookup"></TextBox>
+        <Grid>
+            <Button Margin="5" Content="Cancel" HorizontalAlignment="Left" Padding="20, 3" VerticalAlignment="Center" Click="CancelButtonClick" />
+            <Button Margin="5" Content="Search" HorizontalAlignment="Right" Padding="20, 3" VerticalAlignment="Center" Click="SearchButtonClick" />
+        </Grid>
+    </StackPanel>
+</Window>

--- a/TEditXna/Editor/Plugins/FindChestWithPluginView.xaml.cs
+++ b/TEditXna/Editor/Plugins/FindChestWithPluginView.xaml.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace TEditXna.Editor.Plugins
+{
+    /// <summary>
+    /// Interaction logic for ReplaceAllPlugin.xaml
+    /// </summary>
+    public partial class FindChestWithPluginView : Window
+    {
+        public string ItemToFind { get; private set; }
+        public FindChestWithPluginView()
+        {
+            InitializeComponent();
+        }
+
+        private void CancelButtonClick(object sender, RoutedEventArgs e)
+        {
+            this.DialogResult = false;
+            this.Close();
+        }
+
+        private void SearchButtonClick(object sender, RoutedEventArgs e)
+        {
+            this.DialogResult = true;
+            this.ItemToFind = ItemLookup.Text;
+            this.Close();
+        }
+    }
+}

--- a/TEditXna/TEditXna.csproj
+++ b/TEditXna/TEditXna.csproj
@@ -125,16 +125,23 @@
     <Compile Include="Editor\MouseTile.cs" />
     <Compile Include="Editor\PaintMode.cs" />
     <Compile Include="Editor\Plugins\BasePlugin.cs" />
+    <Compile Include="Editor\Plugins\FindChestWithPluginResultView.xaml.cs">
+      <DependentUpon>FindChestWithPluginResultView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Editor\Plugins\IPlugin.cs" />
     <Compile Include="Editor\Plugins\PerlinNoise.cs" />
     <Compile Include="Editor\Plugins\RemoveAllChestsPlugin.cs" />
     <Compile Include="Editor\Plugins\RemoveAllUnlockedChestsPlugin.cs" />
     <Compile Include="Editor\Plugins\ReplaceAllPlugin.cs" />
+    <Compile Include="Editor\Plugins\FindChestWithPluginView.xaml.cs">
+      <DependentUpon>FindChestWithPluginView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Editor\Plugins\ReplaceAllPluginView.xaml.cs">
       <DependentUpon>ReplaceAllPluginView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Editor\Plugins\SandSettlePlugin.cs" />
     <Compile Include="Editor\Plugins\SimplePerlinGeneratorPlugin.cs" />
+    <Compile Include="Editor\Plugins\FindChestWithPlugin.cs" />
     <Compile Include="Editor\Plugins\UnlockAllChestsPlugin.cs" />
     <Compile Include="Editor\RectangleExt.cs" />
     <Compile Include="Editor\ScrollDirection.cs" />
@@ -327,6 +334,14 @@
       <SubType>
       </SubType>
     </Compile>
+    <Page Include="Editor\Plugins\FindChestWithPluginResultView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Editor\Plugins\FindChestWithPluginView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Editor\Plugins\ReplaceAllPluginView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -536,7 +551,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_AssemblyInfoFilename="Properties\AssemblyInfo.cs" BuildVersion_UseGlobalSettings="True" />
+      <UserProperties BuildVersion_UseGlobalSettings="True" BuildVersion_AssemblyInfoFilename="Properties\AssemblyInfo.cs" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>

--- a/TEditXna/ViewModel/ViewModelLocator.cs
+++ b/TEditXna/ViewModel/ViewModelLocator.cs
@@ -48,6 +48,7 @@ namespace TEditXna.ViewModel
             wvm.Plugins.Add(new RemoveAllChestsPlugin(wvm));
             wvm.Plugins.Add(new RemoveAllUnlockedChestsPlugin(wvm));
             wvm.Plugins.Add(new UnlockAllChestsPlugin(wvm));
+            wvm.Plugins.Add(new FindChestWithPlugin(wvm));
             return wvm;
         }
     }


### PR DESCRIPTION
I created a simple Plugin to search the World for a specific item in all the chests.
You start the plugin, a window opens and asks for the name of the item.
After you start the search a new window pops up with the coordinates of all found chests.

A neat addition would be to double click on the coordinate of a chest and the view would automatically focus the chest in the XNAView. I didn't want to destroy your architecture so I made no changes or tries there.