### PR TITLE
Complete tally with monsters never killed

### DIFF
--- a/TEditXna/Terraria/KillTally.cs
+++ b/TEditXna/Terraria/KillTally.cs
@@ -84,6 +84,10 @@ namespace TEditXNA.Terraria
                         uniquecount = uniquecount + 1;
                     bannercount = bannercount + banners;
                 }
+                else
+                {
+                    sb.WriteLine("{0} {1} (never killed)", index, World.TallyNames[index]);
+                }
                 index++;
             }
             sb.Write(Environment.NewLine);


### PR DESCRIPTION
Hi,
This is just a very simple edit to display monsters never killed.
It could be useful for banner hunters, or for achievements (like Gelatin World Tour).