### PR TITLE
Fix #651 - Reset XNA graphics device to new viewport paramters on resize

### DIFF
--- a/TEditXna/View/WorldRenderXna.xaml.cs
+++ b/TEditXna/View/WorldRenderXna.xaml.cs
@@ -1877,6 +1877,13 @@ namespace TEditXna.View
 
         private void xnaViewport_SizeChanged(object sender, SizeChangedEventArgs e)
         {
+            if (xnaViewport.GraphicsService == null)
+                return;
+
+            var present = xnaViewport.GraphicsService.GraphicsDevice.PresentationParameters;
+            present.BackBufferWidth  = (int) xnaViewport.RenderSize.Width;
+            present.BackBufferHeight = (int) xnaViewport.RenderSize.Height;
+            xnaViewport.GraphicsService.GraphicsDevice.Reset(present);
         }
 
         #endregion


### PR DESCRIPTION
When the `SizeChanged` event of the XNA viewport control is fired, the graphics device will be reset to the new size. The `Reset()` method appears to be the only way to resize the viewport (or technically, the backbuffer) after init.

This fixes #651, where [growing and then shrinking the window incorrectly resizes the viewport](https://gfycat.com/MisguidedMammothGoose).

## Testing

This fix was done using Visual Studio Community 2015 and tested on Windows 10 x64 without any compile or runtime exceptions. I tested window resizing, toggling the sidebar and tools (e.g. selections), with no issues found.

## Performance

This can probably be done better. Resetting the device on every resize event appears to leak memory. Tested by loading a world and resizing the window for at least 15 seconds:

* **Without fix**: [Private memory use remains at 630MB~](http://i.imgur.com/YLQIzMK.png), [System GPU memory remains at 6MB~](http://i.imgur.com/F8QhamH.png)
* **With fix**: [Private memory fluctuates around 700MB](http://i.imgur.com/NJTukbd.png), [System GPU memory increases to 32MB~](http://i.imgur.com/dYHl0mP.png)

## Notes

This is my first time using the XNA API. I used [this Gamedev post as reference](http://www.gamedev.net/topic/526616-xna-windowed-mode-resizing-problem/#entry4413275).