### PR TITLE
Bypass Execution Policy

### DIFF
--- a/build_beta.bat
+++ b/build_beta.bat
@@ -9,6 +9,6 @@ set nuget=".\.nuget\nuget.exe"
 REM echo Copying Files...
 REM if exist ".\TEdit3Installer\bin\Release\TEdit3Installer.msi" copy ".\TEdit3Installer\bin\Release\TEdit3Installer.msi" .\BIN\
 
-Powershell.exe -executionpolicy remotesigned -File package.ps1
+Powershell.exe -executionpolicy bypass -File package.ps1
 
 pause


### PR DESCRIPTION
The change is just a minor fix, so that all the Execution Policy crud is just plainly ignored. Useful for making building just a little easier, and the scope is auto-limited to just this instance, so no permanent changes are made to the system's Execution Policy.