### PR TITLE
Fix V3008

### DIFF
--- a/TEditXna/Terraria/World.FileV2.cs
+++ b/TEditXna/Terraria/World.FileV2.cs
@@ -49,13 +49,13 @@ namespace TEditXNA.Terraria
             OnProgressChanged(null, new ProgressChangedEventArgs(100, "Save NPCs..."));
             sectionPointers[5] = SaveNPCs(world.NPCs, bw);
             OnProgressChanged(null, new ProgressChangedEventArgs(100, "Save Mobs..."));
-            sectionPointers[5] = SaveMobs(world.Mobs, bw);
+            sectionPointers[6] = SaveMobs(world.Mobs, bw);
             OnProgressChanged(null, new ProgressChangedEventArgs(100, "Save Tile Entities Section..."));
-            sectionPointers[6] = SaveTileEntities(world, bw);
+            sectionPointers[7] = SaveTileEntities(world, bw);
             OnProgressChanged(null, new ProgressChangedEventArgs(100, "Save Weighted Pressure Plates..."));
-            sectionPointers[7] = SavePressurePlate(world.PressurePlates, bw);
+            sectionPointers[8] = SavePressurePlate(world.PressurePlates, bw);
             OnProgressChanged(null, new ProgressChangedEventArgs(100, "Save Town Manager..."));
-            sectionPointers[8] = SaveTownManager(world.PlayerRooms, bw);
+            sectionPointers[9] = SaveTownManager(world.PlayerRooms, bw);
             OnProgressChanged(null, new ProgressChangedEventArgs(100, "Save Footers..."));
             SaveFooter(world, bw);
             UpdateSectionPointers(sectionPointers, bw);


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- The 'sectionPointers[5]' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 52, 50. TEditXna World.FileV2.cs 52