### PR TITLE
Fix V3038

### DIFF
--- a/TEditXna/Geometry/Primitives/Vectors.cs
+++ b/TEditXna/Geometry/Primitives/Vectors.cs
@@ -593,7 +593,7 @@ namespace TEdit.Geometry.Primitives
                 int.TryParse(split[3], out w))
                 return false;
 
-            vector = new Vector4(x, y, y, z);
+            vector = new Vector4(x, y, z, w);
             return true;
         }
 


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- The 'y' argument was passed to 'Vector4' constructor several times. It is possible that the 'z' argument should be passed to 'z' parameter. TEditXna Vectors.cs 596