### PR TITLE
Fix V3088

### DIFF
--- a/TEditXna/View/WorldRenderXna.xaml.cs
+++ b/TEditXna/View/WorldRenderXna.xaml.cs
@@ -786,7 +786,7 @@ namespace TEditXna.View
                                                     dest.Width = (int)(_zoom * source.Width / 16f);
                                                     dest.Height = (int)(_zoom * source.Height / 16f);
                                                     dest.Y += (int)(((16 - source.Height - 4) / 2F) * _zoom / 16);
-                                                    dest.X -= (int)((2 * _zoom / 16));
+                                                    dest.X -= (int)(2 * _zoom / 16);
                                                     break;
                                                 case 1:
                                                     if (curtile.Type == 128)
@@ -797,15 +797,15 @@ namespace TEditXna.View
                                                     dest.Width = (int)(_zoom * source.Width / 16f);
                                                     dest.Height = (int)(_zoom * source.Height / 16f);
                                                     dest.Y += (int)(((16 - source.Height - 18) / 2F) * _zoom / 16);
-                                                    dest.X -= (int)((2 * _zoom / 16));
+                                                    dest.X -= (int)(2 * _zoom / 16);
                                                     break;
                                                 case 2:
                                                     tileTex = (Texture2D)_textureDictionary.GetArmorLegs(armor);
                                                     source = new Rectangle (2, 42, 36, 12);
                                                     dest.Width = (int)(_zoom * source.Width / 16f);
                                                     dest.Height = (int)(_zoom * source.Height / 16f);
-                                                    dest.Y -= (int)((2 * _zoom / 16));
-                                                    dest.X -= (int)((2 * _zoom / 16));
+                                                    dest.Y -= (int)(2 * _zoom / 16);
+                                                    dest.X -= (int)(2 * _zoom / 16);
                                                     break;
                                             }
                                             if (curtile.U % 100 < 36)


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The expression was enclosed by parentheses twice: '(2 * _zoom / 16)'. One pair of parentheses is unnecessary or misprint is present. TEditXna WorldRenderXna.xaml.cs 789

- The expression was enclosed by parentheses twice: '(2 * _zoom / 16)'. One pair of parentheses is unnecessary or misprint is present. TEditXna WorldRenderXna.xaml.cs 800

- The expression was enclosed by parentheses twice: '(2 * _zoom / 16)'. One pair of parentheses is unnecessary or misprint is present. TEditXna WorldRenderXna.xaml.cs 807

- The expression was enclosed by parentheses twice: '(2 * _zoom / 16)'. One pair of parentheses is unnecessary or misprint is present. TEditXna WorldRenderXna.xaml.cs 808

This code looks suspicious: there is no apparent reason for using additional parentheses here. 