### PR TITLE
made world id editable + added editable GUID to property view

### DIFF
--- a/TEditXna/Terraria/World.Properties.cs
+++ b/TEditXna/Terraria/World.Properties.cs
@@ -758,6 +758,12 @@ namespace TEditXNA.Terraria
             set { Set("WorldId", ref _worldId, value); }
         }
 
+        public System.Guid WorldGUID
+        {
+            get { return Guid; }
+            set { Set("WorldGUID", ref Guid, value); }
+        }
+
         public bool DownedFrost
         {
             get { return _downedFrost; }

--- a/TEditXna/View/WorldPropertiesView.xaml
+++ b/TEditXna/View/WorldPropertiesView.xaml
@@ -186,7 +186,9 @@
             <TextBlock Text="World Name" HorizontalAlignment="Right" />
             <TextBox Text="{Binding CurrentWorld.Title, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             <TextBlock Text="World Id" HorizontalAlignment="Right" />
-            <TextBlock Text="{Binding CurrentWorld.WorldId}" HorizontalAlignment="Left" />
+            <TextBox Text="{Binding CurrentWorld.WorldId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"  />
+            <TextBlock Text="World GUID" HorizontalAlignment="Right" />
+            <TextBox Text="{Binding CurrentWorld.WorldGUID, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"  />
             <TextBlock Text="Revision" HorizontalAlignment="Right" />
             <TextBlock Text="{Binding CurrentWorld.FileRevision}" HorizontalAlignment="Left" />
             <TextBlock Text="Seed" HorizontalAlignment="Right" />


### PR DESCRIPTION
this makes it easier to change a worlds guid, to use it paralllel to the original loaded world. if guid is not chanded then problems occur with the players maps