### PR TITLE
Added "Complete Bestiary" Button Via Tally

### DIFF
--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -1286,6 +1286,15 @@ namespace TEdit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Complete.
+        /// </summary>
+        public static string tool_bestiary_complete {
+            get {
+                return ResourceManager.GetString("tool_bestiary_complete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Import.
         /// </summary>
         public static string tool_bestiary_import {

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -1098,4 +1098,7 @@
   <data name="menu_language_pt" xml:space="preserve">
     <value>Português</value>
   </data>
+  <data name="tool_bestiary_complete" xml:space="preserve">
+    <value>مكتمل</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -1098,4 +1098,7 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="menu_language_zh" xml:space="preserve">
     <value>中文</value>
   </data>
+  <data name="tool_bestiary_complete" xml:space="preserve">
+    <value>Komplett</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -1098,4 +1098,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="tool_wp_tenthanniversary" xml:space="preserve">
     <value>Tenth Anniversary</value>
   </data>
+  <data name="tool_bestiary_complete" xml:space="preserve">
+    <value>Complete</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -1098,4 +1098,7 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="tool_wp_tenthanniversary" xml:space="preserve">
     <value>Dziesiąta rocznica</value>
   </data>
+  <data name="tool_bestiary_complete" xml:space="preserve">
+    <value>kompletny</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -1098,4 +1098,7 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="menu_language_ar" xml:space="preserve">
     <value>العربية</value>
   </data>
+  <data name="tool_bestiary_complete" xml:space="preserve">
+    <value>completo</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -1096,6 +1096,9 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
     <value>Track</value>
   </data>
   <data name="menu_language_pt" xml:space="preserve">
-		<value>Português</value>
-	</data>
+    <value>Português</value>
+  </data>
+  <data name="tool_bestiary_complete" xml:space="preserve">
+    <value>Complete</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -1098,4 +1098,7 @@
   <data name="tool_wp_tenthanniversary" xml:space="preserve">
     <value>Десятилетие</value>
   </data>
+  <data name="tool_bestiary_Complete" xml:space="preserve">
+    <value>полный</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1098,4 +1098,7 @@
   <data name="tool_wp_tenthanniversary" xml:space="preserve">
     <value>十周年</value>
   </data>
+  <data name="tool_bestiary_complete" xml:space="preserve">
+    <value>完全的</value>
+  </data>
 </root>

--- a/src/TEdit/Terraria/World.FileV2.cs
+++ b/src/TEdit/Terraria/World.FileV2.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using TEdit.Terraria;
 using TEdit.Helper;
+using System.Linq;
 
 namespace TEdit.Terraria
 {
@@ -44,6 +45,47 @@ namespace TEdit.Terraria
         public short SectionCount { get; set; } = GlobalSectionCount;
 
         public static bool[] SettingsTileFrameImportant { get; set; }
+
+        public static void CompleteBestiary(World world)
+        {
+            // complete the bestiary
+            var BestiaryTalkedData = "SleepingAngler,Angler,OldMan,Guide,Merchant,Dryad,BestiaryGirl,TravellingMerchant,Painter,Demolitionist,ArmsDealer,DyeTrader,SkeletonMerchant,Pirate,BoundGoblin,GoblinTinkerer,Nurse,Clothier,BartenderUnconscious,DD2Bartender,BoundMechanic,Mechanic,TownCat,TownDog,WitchDoctor,WebbedStylist,Stylist,TaxCollector,BoundWizard,Wizard,Truffle,Steampunker,TownBunny,PartyGirl,GolferRescue,Golfer,Cyborg,Princess,SantaClaus";
+            var BestiaryTalkedIDs = BestiaryTalkedData.Split(',').Reverse().ToList<string>();
+            var BestiaryNearData = "Bird,BirdBlue,BirdRed,Buggy,PartyBunny,ExplosiveBunny,GemBunnyAmethyst,GemBunnyTopaz,GemBunnySapphire,GemBunnyEmerald,GemBunnyRuby,GemBunnyDiamond,GemBunnyAmber,TownBunny,Bunny,CorruptBunny,BunnySlimed,BunnyXmas,GoldBunny,CrimsonBunny,Dolphin,Duck,Duck2,DuckWhite,DuckWhite2,EnchantedNightcrawler,FairyCritterPink,FairyCritterGreen,FairyCritterBlue,Firefly,Frog,GoldFrog,GlowingSnail,CrimsonGoldfish,GoldGoldfish,GoldGoldfishWalker,Goldfish,CorruptGoldfish,GoldfishWalker,Grasshopper,GoldGrasshopper,Grebe,Grebe2,Grubby,LadyBug,GoldLadyBug,MushiLadybug,Lavafly,LightningBug,Maggot,MagmaSnail,Mouse,GoldMouse,Owl,Penguin,PenguinBlack,CorruptPenguin,CrimsonPenguin,Pupfish,Rat,ScorpionBlack,Scorpion,Seagull,Seagull2,Seahorse,GoldSeahorse,SeaTurtle,Sluggy,Snail,GlowingSnail,SeaSnail,SquirrelRed,SquirrelGold,GemSquirrelAmethyst,GemSquirrelTopaz,GemSquirrelSapphire,GemSquirrelEmerald,GemSquirrelRuby,GemSquirrelDiamond,GemSquirrelAmber,Squirrel,Turtle,TurtleJungle,WaterStrider,GoldWaterStrider,Worm,GoldWorm,HellButterfly,EmpressButterfly,Butterfly,GoldButterfly,BlackDragonfly,BlueDragonfly,GreenDragonfly,OrangeDragonfly,RedDragonfly,YellowDragonfly,GoldDragonfly,TruffleWorm";
+            var BestiaryNearIDs = BestiaryNearData.Split(',').Reverse().ToList<string>();
+            var BestiaryKilledData = "BigHornetStingy,LittleHornetStingy,BigHornetSpikey,LittleHornetSpikey,BigHornetLeafy,LittleHornetLeafy,BigHornetHoney,LittleHornetHoney,BigHornetFatty,LittleHornetFatty,BigRainZombie,SmallRainZombie,BigPantlessSkeleton,SmallPantlessSkeleton,BigMisassembledSkeleton,SmallMisassembledSkeleton,BigHeadacheSkeleton,SmallHeadacheSkeleton,BigSkeleton,SmallSkeleton,BigFemaleZombie,SmallFemaleZombie,DemonEye2,PurpleEye2,GreenEye2,DialatedEye2,SleepyEye2,CataractEye2,BigTwiggyZombie,SmallTwiggyZombie,BigSwampZombie,SmallSwampZombie,BigSlimedZombie,SmallSlimedZombie,BigPincushionZombie,SmallPincushionZombie,BigBaldZombie,SmallBaldZombie,BigZombie,SmallZombie,BigCrimslime,LittleCrimslime,BigCrimera,LittleCrimera,GiantMossHornet,BigMossHornet,LittleMossHornet,TinyMossHornet,BigStinger,LittleStinger,HeavySkeleton,BigBoned,ShortBones,BigEater,LittleEater,JungleSlime,YellowSlime,RedSlime,PurpleSlime,BlackSlime,BabySlime,Pinky,GreenSlime,Slimer2,Slimeling,None,BlueSlime,DemonEye,Zombie,EyeofCthulhu,ServantofCthulhu,EaterofSouls,DevourerHead,DevourerBody,DevourerTail,GiantWormHead,GiantWormBody,GiantWormTail,EaterofWorldsHead,EaterofWorldsBody,EaterofWorldsTail,MotherSlime,Merchant,Nurse,ArmsDealer,Dryad,Skeleton,Guide,MeteorHead,FireImp,BurningSphere,GoblinPeon,GoblinThief,GoblinWarrior,GoblinSorcerer,ChaosBall,AngryBones,DarkCaster,WaterSphere,CursedSkull,SkeletronHead,SkeletronHand,OldMan,Demolitionist,BoneSerpentHead,BoneSerpentBody,BoneSerpentTail,Hornet,ManEater,UndeadMiner,Tim,Bunny,CorruptBunny,Harpy,CaveBat,KingSlime,JungleBat,DoctorBones,TheGroom,Clothier,Goldfish,Snatcher,CorruptGoldfish,Piranha,LavaSlime,Hellbat,Vulture,Demon,BlueJellyfish,PinkJellyfish,Shark,VoodooDemon,Crab,DungeonGuardian,Antlion,SpikeBall,DungeonSlime,BlazingWheel,GoblinScout,Bird,Pixie,None2,ArmoredSkeleton,Mummy,DarkMummy,LightMummy,CorruptSlime,Wraith,CursedHammer,EnchantedSword,Mimic,Unicorn,WyvernHead,WyvernLegs,WyvernBody,WyvernBody2,WyvernBody3,WyvernTail,GiantBat,Corruptor,DiggerHead,DiggerBody,DiggerTail,SeekerHead,SeekerBody,SeekerTail,Clinger,AnglerFish,GreenJellyfish,Werewolf,BoundGoblin,BoundWizard,GoblinTinkerer,Wizard,Clown,SkeletonArcher,GoblinArcher,VileSpit,WallofFlesh,WallofFleshEye,TheHungry,TheHungryII,LeechHead,LeechBody,LeechTail,ChaosElemental,Slimer,Gastropod,BoundMechanic,Mechanic,Retinazer,Spazmatism,SkeletronPrime,PrimeCannon,PrimeSaw,PrimeVice,PrimeLaser,BaldZombie,WanderingEye,TheDestroyer,TheDestroyerBody,TheDestroyerTail,IlluminantBat,IlluminantSlime,Probe,PossessedArmor,ToxicSludge,SantaClaus,SnowmanGangsta,MisterStabby,SnowBalla,None3,IceSlime,Penguin,PenguinBlack,IceBat,Lavabat,GiantFlyingFox,GiantTortoise,IceTortoise,Wolf,RedDevil,Arapaima,VampireBat,Vampire,Truffle,ZombieEskimo,Frankenstein,BlackRecluse,WallCreeper,WallCreeperWall,SwampThing,UndeadViking,CorruptPenguin,IceElemental,PigronCorruption,PigronHallow,RuneWizard,Crimera,Herpling,AngryTrapper,MossHornet,Derpling,Steampunker,CrimsonAxe,PigronCrimson,FaceMonster,FloatyGross,Crimslime,SpikedIceSlime,SnowFlinx,PincushionZombie,SlimedZombie,SwampZombie,TwiggyZombie,CataractEye,SleepyEye,DialatedEye,GreenEye,PurpleEye,LostGirl,Nymph,ArmoredViking,Lihzahrd,LihzahrdCrawler,FemaleZombie,HeadacheSkeleton,MisassembledSkeleton,PantlessSkeleton,SpikedJungleSlime,Moth,IcyMerman,DyeTrader,PartyGirl,Cyborg,Bee,BeeSmall,PirateDeckhand,PirateCorsair,PirateDeadeye,PirateCrossbower,PirateCaptain,CochinealBeetle,CyanBeetle,LacBeetle,SeaSnail,Squid,QueenBee,ZombieRaincoat,FlyingFish,UmbrellaSlime,FlyingSnake,Painter,WitchDoctor,Pirate,GoldfishWalker,HornetFatty,HornetHoney,HornetLeafy,HornetSpikey,HornetStingy,JungleCreeper,JungleCreeperWall,BlackRecluseWall,BloodCrawler,BloodCrawlerWall,BloodFeeder,BloodJelly,IceGolem,RainbowSlime,Golem,GolemHead,GolemFistLeft,GolemFistRight,GolemHeadFree,AngryNimbus,Eyezor,Parrot,Reaper,ZombieMushroom,ZombieMushroomHat,FungoFish,AnomuraFungus,MushiLadybug,FungiBulb,GiantFungiBulb,FungiSpore,Plantera,PlanterasHook,PlanterasTentacle,Spore,BrainofCthulhu,Creeper,IchorSticker,RustyArmoredBonesAxe,RustyArmoredBonesFlail,RustyArmoredBonesSword,RustyArmoredBonesSwordNoArmor,BlueArmoredBones,BlueArmoredBonesMace,BlueArmoredBonesNoPants,BlueArmoredBonesSword,HellArmoredBones,HellArmoredBonesSpikeShield,HellArmoredBonesMace,HellArmoredBonesSword,RaggedCaster,RaggedCasterOpenCoat,Necromancer,NecromancerArmored,DiabolistRed,DiabolistWhite,BoneLee,DungeonSpirit,GiantCursedSkull,Paladin,SkeletonSniper,TacticalSkeleton,SkeletonCommando,AngryBonesBig,AngryBonesBigMuscle,AngryBonesBigHelmet,BirdBlue,BirdRed,Squirrel,Mouse,Raven,SlimeMasked,BunnySlimed,HoppinJack,Scarecrow1,Scarecrow2,Scarecrow3,Scarecrow4,Scarecrow5,Scarecrow6,Scarecrow7,Scarecrow8,Scarecrow9,Scarecrow10,HeadlessHorseman,Ghost,DemonEyeOwl,DemonEyeSpaceship,ZombieDoctor,ZombieSuperman,ZombiePixie,SkeletonTopHat,SkeletonAstonaut,SkeletonAlien,MourningWood,Splinterling,Pumpking,PumpkingBlade,Hellhound,Poltergeist,ZombieXmas,ZombieSweater,SlimeRibbonWhite,SlimeRibbonYellow,SlimeRibbonGreen,SlimeRibbonRed,BunnyXmas,ZombieElf,ZombieElfBeard,ZombieElfGirl,PresentMimic,GingerbreadMan,Yeti,Everscream,IceQueen,SantaNK1,ElfCopter,Nutcracker,NutcrackerSpinning,ElfArcher,Krampus,Flocko,Stylist,WebbedStylist,Firefly,Butterfly,Worm,LightningBug,Snail,GlowingSnail,Frog,Duck,Duck2,DuckWhite,DuckWhite2,ScorpionBlack,Scorpion,TravellingMerchant,Angler,DukeFishron,DetonatingBubble,Sharkron,Sharkron2,TruffleWorm,TruffleWormDigger,SleepingAngler,Grasshopper,ChatteringTeethBomb,CultistArcherBlue,CultistArcherWhite,BrainScrambler,RayGunner,MartianOfficer,ForceBubble,GrayGrunt,MartianEngineer,MartianTurret,MartianDrone,GigaZapper,ScutlixRider,Scutlix,MartianSaucer,MartianSaucerTurret,MartianSaucerCannon,MartianSaucerCore,MoonLordHead,MoonLordHand,MoonLordCore,MartianProbe,MoonLordFreeEye,MoonLordLeechBlob,StardustWormHead,StardustWormBody,StardustWormTail,StardustCellBig,StardustCellSmall,StardustJellyfishBig,StardustJellyfishSmall,StardustSpiderBig,StardustSpiderSmall,StardustSoldier,SolarCrawltipedeHead,SolarCrawltipedeBody,SolarCrawltipedeTail,SolarDrakomire,SolarDrakomireRider,SolarSroller,SolarCorite,SolarSolenian,NebulaBrain,NebulaHeadcrab,NebulaBeast,NebulaSoldier,VortexRifleman,VortexHornetQueen,VortexHornet,VortexLarva,VortexSoldier,ArmedZombie,ArmedZombieEskimo,ArmedZombiePincussion,ArmedZombieSlimed,ArmedZombieSwamp,ArmedZombieTwiggy,ArmedZombieCenx,CultistTablet,CultistDevote,CultistBoss,CultistBossClone,GoldBird,GoldBunny,GoldButterfly,GoldFrog,GoldGrasshopper,GoldMouse,GoldWorm,BoneThrowingSkeleton,BoneThrowingSkeleton2,BoneThrowingSkeleton3,BoneThrowingSkeleton4,SkeletonMerchant,CultistDragonHead,CultistDragonBody1,CultistDragonBody2,CultistDragonBody3,CultistDragonBody4,CultistDragonTail,Butcher,CreatureFromTheDeep,Fritz,Nailhead,CrimsonBunny,CrimsonGoldfish,Psycho,DeadlySphere,DrManFly,ThePossessed,CrimsonPenguin,GoblinSummoner,ShadowFlameApparition,BigMimicCorruption,BigMimicCrimson,BigMimicHallow,BigMimicJungle,Mothron,MothronEgg,MothronSpawn,Medusa,GreekSkeleton,GraniteGolem,GraniteFlyer,EnchantedNightcrawler,Grubby,Sluggy,Buggy,TargetDummy,BloodZombie,Drippler,PirateShip,PirateShipCannon,LunarTowerStardust,Crawdad,Crawdad2,GiantShelly,GiantShelly2,Salamander,Salamander2,Salamander3,Salamander4,Salamander5,Salamander6,Salamander7,Salamander8,Salamander9,LunarTowerNebula,LunarTowerVortex,TaxCollector,GiantWalkingAntlion,GiantFlyingAntlion,DuneSplicerHead,DuneSplicerBody,DuneSplicerTail,TombCrawlerHead,TombCrawlerBody,TombCrawlerTail,SolarFlare,LunarTowerSolar,SolarSpearman,SolarGoop,MartianWalker,AncientCultistSquidhead,AncientLight,AncientDoom,DesertGhoul,DesertGhoulCorruption,DesertGhoulCrimson,DesertGhoulHallow,DesertLamiaLight,DesertLamiaDark,DesertScorpionWalk,DesertScorpionWall,DesertBeast,DesertDjinn,DemonTaxCollector,SlimeSpiked,TheBride,SandSlime,SquirrelRed,SquirrelGold,PartyBunny,SandElemental,SandShark,SandsharkCorrupt,SandsharkCrimson,SandsharkHallow,Tumbleweed,DD2AttackerTest,DD2EterniaCrystal,DD2LanePortal,DD2Bartender,DD2Betsy,DD2GoblinT1,DD2GoblinT2,DD2GoblinT3,DD2GoblinBomberT1,DD2GoblinBomberT2,DD2GoblinBomberT3,DD2WyvernT1,DD2WyvernT2,DD2WyvernT3,DD2JavelinstT1,DD2JavelinstT2,DD2JavelinstT3,DD2DarkMageT1,DD2DarkMageT3,DD2SkeletonT1,DD2SkeletonT3,DD2WitherBeastT2,DD2WitherBeastT3,DD2DrakinT2,DD2DrakinT3,DD2KoboldWalkerT2,DD2KoboldWalkerT3,DD2KoboldFlyerT2,DD2KoboldFlyerT3,DD2OgreT2,DD2OgreT3,DD2LightningBugT3,BartenderUnconscious,WalkingAntlion,FlyingAntlion,LarvaeAntlion,FairyCritterPink,FairyCritterGreen,FairyCritterBlue,ZombieMerman,EyeballFlyingFish,Golfer,GolferRescue,TorchZombie,ArmedTorchZombie,GoldGoldfish,GoldGoldfishWalker,WindyBalloon,BlackDragonfly,BlueDragonfly,GreenDragonfly,OrangeDragonfly,RedDragonfly,YellowDragonfly,GoldDragonfly,Seagull,Seagull2,LadyBug,GoldLadyBug,Maggot,Pupfish,Grebe,Grebe2,Rat,Owl,WaterStrider,GoldWaterStrider,ExplosiveBunny,Dolphin,Turtle,TurtleJungle,BloodNautilus,BloodSquid,GoblinShark,BloodEelHead,BloodEelBody,BloodEelTail,Gnome,SeaTurtle,Seahorse,GoldSeahorse,Dandelion,IceMimic,BloodMummy,RockGolem,MaggotZombie,BestiaryGirl,SporeBat,SporeSkeleton,HallowBoss,TownCat,TownDog,GemSquirrelAmethyst,GemSquirrelTopaz,GemSquirrelSapphire,GemSquirrelEmerald,GemSquirrelRuby,GemSquirrelDiamond,GemSquirrelAmber,GemBunnyAmethyst,GemBunnyTopaz,GemBunnySapphire,GemBunnyEmerald,GemBunnyRuby,GemBunnyDiamond,GemBunnyAmber,HellButterfly,Lavafly,MagmaSnail,TownBunny,QueenSlimeBoss,QueenSlimeMinionBlue,QueenSlimeMinionPink,QueenSlimeMinionPurple,EmpressButterfly,PirateGhost,Princess,TorchGod,ChaosBallTim,VileSpitEaterOfWorlds,GoldenSlime";
+            var BestiaryKilledIDs = BestiaryKilledData.Split(',').Reverse().ToList<string>();
+            foreach (string line in BestiaryKilledIDs)
+            {
+                try // Import Total Kills
+                {
+                    world.Bestiary.NPCKills.Add(line, 50);
+                }
+                catch (Exception)
+                {
+                }
+            }
+            foreach (string line in BestiaryTalkedIDs)
+            {
+                try // Import NPCs Talked Too
+                {
+                    world.Bestiary.NPCChat.Add(line);
+                }
+                catch (Exception)
+                {
+                }
+            }
+            foreach (string line in BestiaryNearIDs)
+            {
+                try // Import Was Near Critters
+                {
+                    world.Bestiary.NPCNear.Add(line);
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
 
         public static void ImportKillsAndBestiary(World world, string worldFileName)
         {
@@ -109,9 +151,7 @@ namespace TEdit.Terraria
             sectionPointers[0] = SaveSectionHeader(world, bw);
             sectionPointers[1] = SaveHeaderFlags(world, bw);
             OnProgressChanged(null, new ProgressChangedEventArgs(0, "Save Tiles..."));
-
-            var frames = SaveConfiguration.SaveVersions[(int)world.Version].GetFrames();
-            sectionPointers[2] = SaveTiles(world.Tiles, (int)world.Version, world.TilesWide, world.TilesHigh, bw, frames);
+            sectionPointers[2] = SaveTiles(world.Tiles, (int)world.Version, world.TilesWide, world.TilesHigh, bw, world.TileFrameImportant);
 
             OnProgressChanged(null, new ProgressChangedEventArgs(91, "Save Chests..."));
             sectionPointers[3] = SaveChests(world.Chests, bw, world.Version < 226);
@@ -550,7 +590,7 @@ namespace TEdit.Terraria
             }
 
             // write bitpacked tile frame importance
-            WriteBitArray(bw, SaveConfiguration.SaveVersions[(int)world.Version].GetFrames());
+            WriteBitArray(bw, world.TileFrameImportant);
 
             return (int)bw.BaseStream.Position;
         }

--- a/src/TEdit/View/KillTallyView.xaml
+++ b/src/TEdit/View/KillTallyView.xaml
@@ -17,6 +17,7 @@
             <TextBlock Grid.Column="0" Text="{x:Static p:Language.tool_bestiary_title}" Foreground="{DynamicResource TextBrush}" Margin="2" FontWeight="Bold" />
             <Button Grid.Column="1" Margin="2" Width="75" Content="{x:Static p:Language.tool_bestiary_scan}"  Command="{Binding LoadTallyCommand}" />
             <Button Grid.Column="2" Margin="2" Width="75" Content="{x:Static p:Language.tool_bestiary_import}"  Command="{Binding ImportBestiaryCommand}" />
+            <Button Grid.Column="3" Margin="2" Width="75" Content="{x:Static p:Language.tool_bestiary_complete}"  Command="{Binding CompleteBestiaryCommand}" />
         </StackPanel>
 
         <TextBox Grid.Row="1" Text="{Binding TallyCount}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" MinHeight="150"

--- a/src/TEdit/ViewModel/WorldViewModel.Commands.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Commands.cs
@@ -477,8 +477,8 @@ namespace TEdit.ViewModel
         public void CompleteBestiary()
         {
             if (MessageBox.Show(
-                "This will completely replace your currently loaded world Bestiary and Kill Tally with selected file's bestiary. Continue?",
-                "Load Bestiary?",
+                "This will completely replace your currently loaded world Bestiary and Kill Tally with a completed bestiary. Continue?",
+                "Complete Bestiary?",
                 MessageBoxButton.YesNo,
                 MessageBoxImage.Question,
                 MessageBoxResult.Yes) != MessageBoxResult.Yes)

--- a/src/TEdit/ViewModel/WorldViewModel.Commands.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Commands.cs
@@ -42,6 +42,8 @@ namespace TEdit.ViewModel
         private ICommand _saveRackCommand;
         private ICommand _npcRemoveCommand;
         private ICommand _importBestiaryCommand;
+        private ICommand _completeBestiaryCommand;
+
         private ICommand _npcAddCommand;
         private ICommand _requestZoomCommand;
         private ICommand _requestScrollCommand;
@@ -152,6 +154,11 @@ namespace TEdit.ViewModel
         public ICommand ImportBestiaryCommand
         {
             get { return _importBestiaryCommand ?? (_importBestiaryCommand = new RelayCommand(ImportKillsAndBestiary)); }
+        }
+
+        public ICommand CompleteBestiaryCommand
+        {
+            get { return _completeBestiaryCommand ?? (_completeBestiaryCommand = new RelayCommand(CompleteBestiary)); }
         }
 
         private void SaveTileEntity(bool save)
@@ -465,6 +472,38 @@ namespace TEdit.ViewModel
         {
             _clipboard.Buffer = item;
             EditPaste();
+        }
+
+        public void CompleteBestiary()
+        {
+            if (MessageBox.Show(
+                "This will completely replace your currently loaded world Bestiary and Kill Tally with selected file's bestiary. Continue?",
+                "Load Bestiary?",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question,
+                MessageBoxResult.Yes) != MessageBoxResult.Yes)
+                return;
+
+            var world = CurrentWorld;
+
+            // make a backup
+            var bestiary = world.Bestiary.Copy(CurrentWorld.Version);
+            var killTally = world.KilledMobs.ToArray();
+            try
+            {
+                ErrorLogging.TelemetryClient?.TrackEvent(nameof(CompleteBestiary));
+
+                World.CompleteBestiary(world);
+                TallyCount = KillTally.LoadTally(CurrentWorld);
+            }
+            catch (Exception ex)
+            {
+                world.Bestiary = bestiary;
+                world.KilledMobs.Clear();
+                world.KilledMobs.AddRange(killTally);
+                MessageBox.Show($"Error completing Bestiary data. Your current bestiary has been restored.\r\n{ex.Message}");
+
+            }
         }
 
         private void ImportKillsAndBestiary()


### PR DESCRIPTION

![100%](https://user-images.githubusercontent.com/33048298/137244821-292fb143-e230-481d-a69d-20d9dff3f101.PNG)

This change will add the option inside of Tally to complete the entire Bestiary index along with the kill tallies. 

![newadd](https://user-images.githubusercontent.com/33048298/137244806-1b71534c-337d-44b0-b82a-1dc87ffa1f47.PNG)

I have included a proper message box such as the import Bestiary option has already. This will ensure that users do not accidentally overwrite their existing Bestiary on mistake.

![01](https://user-images.githubusercontent.com/33048298/137244966-4b5459fe-0d30-4c0c-99c5-853d6d1d143a.PNG)

In the future, a more dynamic method for gathering the indexes will need to be added for if the game adds more NPCs/Mobs.
