### PR TITLE
Fixed Some NPC Sprite Issues.

### DIFF
--- a/src/TEdit/View/WorldRenderXna.xaml.cs
+++ b/src/TEdit/View/WorldRenderXna.xaml.cs
@@ -2824,10 +2824,22 @@ namespace TEdit.View
                 {
 	                height = 39;
                 }
-				if (npc.SpriteId == 446 || npc.SpriteId == 448 || npc.SpriteId == 357 || npc.SpriteId == 377 || npc.SpriteId == 484 || npc.SpriteId == 485 || npc.SpriteId == 486 || npc.SpriteId == 487 || npc.SpriteId == 606) // Fix Texture For Buggy, Grubby, Sluggy, Worm, Gold Worm, Enchanted Nightcrawler, Grasshopper, Gold Grasshopper, And Maggot
+				if (npc.SpriteId == 485 || npc.SpriteId == 486 || npc.SpriteId == 487) // Fix Texture For Buggy, Grubby, And Sluggy
                 {
 	                height = 17;
                 }
+				if (npc.SpriteId == 357 || npc.SpriteId == 448 || npc.SpriteId == 606) // Fix Texture For Worm, Gold Worm, And Maggot
+				{
+					height = 7;
+				}
+				if (npc.SpriteId == 446 || npc.SpriteId == 377) // Fix Texture For Grasshopper, And Gold Grasshopper
+				{
+					height = 11;
+				}
+				if (npc.SpriteId == 484) // Fix Texture For Enchanted Nightcrawler
+				{
+					height = 9;
+				}
                 float scale = 1.0f * _zoom / 16;
                 if (scale < _minNpcScale)
                     scale = _minNpcScale;

--- a/src/TEdit/View/WorldRenderXna.xaml.cs
+++ b/src/TEdit/View/WorldRenderXna.xaml.cs
@@ -2824,6 +2824,10 @@ namespace TEdit.View
                 {
 	                height = 39;
                 }
+				if (npc.SpriteId == 446 || npc.SpriteId == 448 || npc.SpriteId == 357 || npc.SpriteId == 377 || npc.SpriteId == 484 || npc.SpriteId == 485 || npc.SpriteId == 486 || npc.SpriteId == 487 || npc.SpriteId == 606) // Fix Texture For Buggy, Grubby, Sluggy, Worm, Gold Worm, Enchanted Nightcrawler, Grasshopper, Gold Grasshopper, And Maggot
+                {
+	                height = 17;
+                }
                 float scale = 1.0f * _zoom / 16;
                 if (scale < _minNpcScale)
                     scale = _minNpcScale;


### PR DESCRIPTION
This is a fix for the Buggy, Grubby, Sluggy, Worm, Gold Worm, Enchanted Nightcrawler, Grasshopper, Gold Grasshopper, And Maggot sprites not showing/rendering properly.

Here is an example of the abnormal sprite drawling.
![broken](https://user-images.githubusercontent.com/33048298/142494089-6e790a15-fd13-443b-99d3-62f0abe31703.PNG)

Bellow is a corrected image of the sprite.
![fixed](https://user-images.githubusercontent.com/33048298/142494217-656cfd70-2a60-4733-ae45-e2188d3c3926.PNG)