### PR TITLE
Fix For SaveAs Using Alternate World Versions

### DIFF
--- a/src/TEdit/TerrariaVersionTileData.json
+++ b/src/TEdit/TerrariaVersionTileData.json
@@ -1,10 +1,5 @@
 {
   "saveVersions": {
-    "0": {
-      "saveVersion": 0,
-      "gameVersion": "vBeta",
-      "framedTileIds": [ 3, 5, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 24, 26, 27, 28, 29, 31, 33, 34, 35, 36, 42, 50, 55, 61, 71, 72, 73, 74 ]
-    },
     "1": {
       "saveVersion": 1,
       "gameVersion": "v1.0",

--- a/src/TEdit/ViewModel/WorldViewModel.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.cs
@@ -1046,7 +1046,7 @@ namespace TEdit.ViewModel
                 {
                     try
                     {
-                        var name = sfd.Filter.Split('|')?[sfd.FilterIndex]?.Split(' ').LastOrDefault()?.Trim(' ', 'v', '.');
+                        var name = sfd.Filter.ToString().Replace("Terraria World File|", "").Replace("*.wld|Terraria v", "").Replace("*.wld", "").Split('|')[sfd.FilterIndex-2];
                         if (World.VersionToWorldVersion.TryGetValue(name, out uint versionOverride))
                         {
                             SaveWorldFile(versionOverride);


### PR DESCRIPTION
- Removed Beta Save Type. Rendered Useless As Beta Cannot Save/Load Worlds. Beta Equals v1.0 TileFrames Anyways.
- Tweaked SaveAs Filter Code Reading Custom Alternate World Versions.