### PR TITLE
Fix For Issue #1572 - Picker tool on wires treats green as blue and vice versa

### DIFF
--- a/src/TEdit/Editor/Tools/PickerTool.cs
+++ b/src/TEdit/Editor/Tools/PickerTool.cs
@@ -60,8 +60,8 @@ namespace TEdit.Editor.Tools
             _wvm.TilePicker.LiquidType = curTile.LiquidType;
             _wvm.TilePicker.BrickStyle = curTile.BrickStyle;
             _wvm.TilePicker.RedWireActive = curTile.WireRed;
-            _wvm.TilePicker.BlueWireActive = curTile.WireGreen;
-            _wvm.TilePicker.GreenWireActive = curTile.WireBlue;
+            _wvm.TilePicker.BlueWireActive = curTile.WireBlue;
+            _wvm.TilePicker.GreenWireActive = curTile.WireGreen;
             _wvm.TilePicker.YellowWireActive = curTile.WireYellow;
             _wvm.TilePicker.Actuator = curTile.Actuator;
             _wvm.TilePicker.ActuatorInActive = curTile.InActive;


### PR DESCRIPTION
**• Before**
![01](https://user-images.githubusercontent.com/33048298/144148270-18e8fadb-13ae-45d0-bfe0-14e928500680.PNG)

**• After**
![02](https://user-images.githubusercontent.com/33048298/144148277-59e69969-c46c-4ba1-9d51-c96549088e13.PNG)