### PR TITLE
Added Junction Box Support Under Wire GUI + Added Picker Support

### DIFF
--- a/src/TEdit/Editor/PaintMode.cs
+++ b/src/TEdit/Editor/PaintMode.cs
@@ -24,6 +24,17 @@ namespace TEdit.Editor
         [Description("PressurePlate")]
         Pressure,
         [Description("Hammer")]
-        Hammer,
+        Hammer
+    }
+    public enum JunctionBoxMode
+    {
+        [Description("None")]
+        None,
+        [Description("Left Facing")]
+        LeftFacingBox,
+        [Description("Normal")]
+        NormalFacingBox,
+        [Description("Right Facing")]
+        RightFacingBox
     }
 }

--- a/src/TEdit/Editor/TilePicker.cs
+++ b/src/TEdit/Editor/TilePicker.cs
@@ -35,6 +35,7 @@ namespace TEdit.Editor
         private bool _tileStyleActive = ToolDefaultData.PaintTileActive;
         private bool _wallStyleActive = ToolDefaultData.PaintWallActive;
         private TrackMode _trackMode = TrackMode.Track;
+        private JunctionBoxMode _junctionboxMode = JunctionBoxMode.None;
 
         private BrickStyle _brickStyle = BrickStyle.Full;
         public BrickStyle BrickStyle
@@ -47,6 +48,12 @@ namespace TEdit.Editor
         {
             get { return _trackMode; }
             set { Set(nameof(TrackMode), ref _trackMode, value); }
+        }
+
+        public JunctionBoxMode JunctionBoxMode
+        {
+            get { return _junctionboxMode; }
+            set { Set(nameof(JunctionBoxMode), ref _junctionboxMode, value); }
         }
 
         //private bool _isLava;

--- a/src/TEdit/Editor/Tools/PickerTool.cs
+++ b/src/TEdit/Editor/Tools/PickerTool.cs
@@ -65,6 +65,24 @@ namespace TEdit.Editor.Tools
             _wvm.TilePicker.YellowWireActive = curTile.WireYellow;
             _wvm.TilePicker.Actuator = curTile.Actuator;
             _wvm.TilePicker.ActuatorInActive = curTile.InActive;
+
+            // Get Picker For JunctionBoxes
+            if (curTile.Type != 424)
+            {
+                _wvm.TilePicker.JunctionBoxMode = JunctionBoxMode.None;
+            }
+            if (curTile.Type == 424 && curTile.U == 18)
+            {
+                _wvm.TilePicker.JunctionBoxMode = JunctionBoxMode.LeftFacingBox;
+            }
+            if (curTile.Type == 424 && curTile.U == 0)
+            {
+                _wvm.TilePicker.JunctionBoxMode = JunctionBoxMode.NormalFacingBox;
+            }
+            if (curTile.Type == 424 && curTile.U == 36)
+            {
+                _wvm.TilePicker.JunctionBoxMode = JunctionBoxMode.RightFacingBox;
+            }
         }
 
         private void PickmaskTile(int x, int y)

--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -19,7 +19,7 @@ namespace TEdit.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Language {
@@ -301,6 +301,51 @@ namespace TEdit.Properties {
         public static string HalfBlockMode_Solid {
             get {
                 return ResourceManager.GetString("HalfBlockMode_Solid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Junction Box:.
+        /// </summary>
+        public static string JunctionBox_Use {
+            get {
+                return ResourceManager.GetString("JunctionBox_Use", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left Facing.
+        /// </summary>
+        public static string JunctionBoxMode_Left_Facing {
+            get {
+                return ResourceManager.GetString("JunctionBoxMode_Left_Facing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to None.
+        /// </summary>
+        public static string JunctionBoxMode_None {
+            get {
+                return ResourceManager.GetString("JunctionBoxMode_None", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Normal.
+        /// </summary>
+        public static string JunctionBoxMode_Normal {
+            get {
+                return ResourceManager.GetString("JunctionBoxMode_Normal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right Facing.
+        /// </summary>
+        public static string JunctionBoxMode_Right_Facing {
+            get {
+                return ResourceManager.GetString("JunctionBoxMode_Right_Facing", resourceCulture);
             }
         }
         
@@ -1543,6 +1588,33 @@ namespace TEdit.Properties {
         public static string tool_paint_inactive {
             get {
                 return ResourceManager.GetString("tool_paint_inactive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add left facing intersection junction box..
+        /// </summary>
+        public static string tool_paint_junctionbox_left_tooltip {
+            get {
+                return ResourceManager.GetString("tool_paint_junctionbox_left_tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add defualt junction box..
+        /// </summary>
+        public static string tool_paint_junctionbox_normal_tooltip {
+            get {
+                return ResourceManager.GetString("tool_paint_junctionbox_normal_tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add right facing intersection junction box..
+        /// </summary>
+        public static string tool_paint_junctionbox_right_tooltip {
+            get {
+                return ResourceManager.GetString("tool_paint_junctionbox_right_tooltip", resourceCulture);
             }
         }
         

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -1110,4 +1110,28 @@
   <data name="tool_wp_notthebees" xml:space="preserve">
     <value>ليس عالم النحل</value>
   </data>
+  <data name="JunctionBoxMode_Left_Facing" xml:space="preserve">
+    <value>مواجهة اليسار</value>
+  </data>
+  <data name="JunctionBoxMode_None" xml:space="preserve">
+    <value>لا أحد</value>
+  </data>
+  <data name="JunctionBoxMode_Normal" xml:space="preserve">
+    <value>طبيعي</value>
+  </data>
+  <data name="JunctionBoxMode_Right_Facing" xml:space="preserve">
+    <value>المواجهة اليمنى</value>
+  </data>
+  <data name="tool_paint_junctionbox_left_tooltip" xml:space="preserve">
+    <value>إضافة مربع تقاطع تواجه اليسار.</value>
+  </data>
+  <data name="tool_paint_junctionbox_normal_tooltip" xml:space="preserve">
+    <value>إضافة مربع تقاطع افتراضي.</value>
+  </data>
+  <data name="tool_paint_junctionbox_right_tooltip" xml:space="preserve">
+    <value>أضف مربع تقاطع المواجهة اليمنى.</value>
+  </data>
+  <data name="JunctionBox_Use" xml:space="preserve">
+    <value>مربع تقاطع:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -1110,4 +1110,28 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="tool_wp_notthebees" xml:space="preserve">
     <value>Nicht die Bienenwelt</value>
   </data>
+  <data name="JunctionBoxMode_Left_Facing" xml:space="preserve">
+    <value>Nach links gerichtet</value>
+  </data>
+  <data name="JunctionBoxMode_None" xml:space="preserve">
+    <value>Keiner</value>
+  </data>
+  <data name="JunctionBoxMode_Normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="JunctionBoxMode_Right_Facing" xml:space="preserve">
+    <value>Nach rechts gerichtet</value>
+  </data>
+  <data name="tool_paint_junctionbox_left_tooltip" xml:space="preserve">
+    <value>Fügen Sie eine nach links gerichtete Kreuzungsdose hinzu.</value>
+  </data>
+  <data name="tool_paint_junctionbox_normal_tooltip" xml:space="preserve">
+    <value>Standardanschlussdose hinzufügen.</value>
+  </data>
+  <data name="tool_paint_junctionbox_right_tooltip" xml:space="preserve">
+    <value>Fügen Sie eine nach rechts gerichtete Kreuzungsdose hinzu.</value>
+  </data>
+  <data name="JunctionBox_Use" xml:space="preserve">
+    <value>Anschlussdose:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -1110,4 +1110,28 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="tool_wp_notthebees" xml:space="preserve">
     <value>Not The Bees World</value>
   </data>
+  <data name="JunctionBoxMode_Left_Facing" xml:space="preserve">
+    <value>Left Facing</value>
+  </data>
+  <data name="JunctionBoxMode_None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="JunctionBoxMode_Normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="JunctionBoxMode_Right_Facing" xml:space="preserve">
+    <value>Right Facing</value>
+  </data>
+  <data name="tool_paint_junctionbox_left_tooltip" xml:space="preserve">
+    <value>Add left facing intersection junction box.</value>
+  </data>
+  <data name="tool_paint_junctionbox_normal_tooltip" xml:space="preserve">
+    <value>Add defualt junction box.</value>
+  </data>
+  <data name="tool_paint_junctionbox_right_tooltip" xml:space="preserve">
+    <value>Add right facing intersection junction box.</value>
+  </data>
+  <data name="JunctionBox_Use" xml:space="preserve">
+    <value>Junction Box:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -1110,4 +1110,28 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="tool_wp_notthebees" xml:space="preserve">
     <value>Nie świat pszczół</value>
   </data>
+  <data name="JunctionBoxMode_Left_Facing" xml:space="preserve">
+    <value>Lewa strona</value>
+  </data>
+  <data name="JunctionBoxMode_None" xml:space="preserve">
+    <value>Nic</value>
+  </data>
+  <data name="JunctionBoxMode_Normal" xml:space="preserve">
+    <value>Normalna</value>
+  </data>
+  <data name="JunctionBoxMode_Right_Facing" xml:space="preserve">
+    <value>Prawo skierowane</value>
+  </data>
+  <data name="tool_paint_junctionbox_left_tooltip" xml:space="preserve">
+    <value>Dodaj lewą skrzynkę połączeniową skrzyżowania.</value>
+  </data>
+  <data name="tool_paint_junctionbox_normal_tooltip" xml:space="preserve">
+    <value>Dodaj domyślną skrzynkę przyłączeniową.</value>
+  </data>
+  <data name="tool_paint_junctionbox_right_tooltip" xml:space="preserve">
+    <value>Dodaj prawą skrzynkę przyłączeniową skrzyżowania.</value>
+  </data>
+  <data name="JunctionBox_Use" xml:space="preserve">
+    <value>Skrzynka przyłączeniowa:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -1110,4 +1110,28 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="tool_wp_notthebees" xml:space="preserve">
     <value>Não o Mundo das Abelhas</value>
   </data>
+  <data name="JunctionBoxMode_Left_Facing" xml:space="preserve">
+    <value>Voltado para a esquerda</value>
+  </data>
+  <data name="JunctionBoxMode_None" xml:space="preserve">
+    <value>Nenhum</value>
+  </data>
+  <data name="JunctionBoxMode_Normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="JunctionBoxMode_Right_Facing" xml:space="preserve">
+    <value>Voltado para a direita</value>
+  </data>
+  <data name="tool_paint_junctionbox_left_tooltip" xml:space="preserve">
+    <value>Adicione uma caixa de junção de interseção voltada para a esquerda.</value>
+  </data>
+  <data name="tool_paint_junctionbox_normal_tooltip" xml:space="preserve">
+    <value>Adicionar caixa de junção padrão.</value>
+  </data>
+  <data name="tool_paint_junctionbox_right_tooltip" xml:space="preserve">
+    <value>Adicione uma caixa de junção de interseção voltada para a direita.</value>
+  </data>
+  <data name="JunctionBox_Use" xml:space="preserve">
+    <value>Caixa de junção:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -1110,4 +1110,28 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="tool_wp_notthebees" xml:space="preserve">
     <value>Not The Bees World</value>
   </data>
+  <data name="JunctionBoxMode_Left_Facing" xml:space="preserve">
+    <value>Left Facing</value>
+  </data>
+  <data name="JunctionBoxMode_None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="JunctionBoxMode_Normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="JunctionBoxMode_Right_Facing" xml:space="preserve">
+    <value>Right Facing</value>
+  </data>
+  <data name="tool_paint_junctionbox_left_tooltip" xml:space="preserve">
+    <value>Add left facing intersection junction box.</value>
+  </data>
+  <data name="tool_paint_junctionbox_normal_tooltip" xml:space="preserve">
+    <value>Add defualt junction box.</value>
+  </data>
+  <data name="tool_paint_junctionbox_right_tooltip" xml:space="preserve">
+    <value>Add right facing intersection junction box.</value>
+  </data>
+  <data name="JunctionBox_Use" xml:space="preserve">
+    <value>Junction Box:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -1110,4 +1110,28 @@
   <data name="tool_wp_notthebees" xml:space="preserve">
     <value>Не мир пчел</value>
   </data>
+  <data name="JunctionBoxMode_Left_Facing" xml:space="preserve">
+    <value>Лицом влево</value>
+  </data>
+  <data name="JunctionBoxMode_None" xml:space="preserve">
+    <value>Никто</value>
+  </data>
+  <data name="JunctionBoxMode_Normal" xml:space="preserve">
+    <value>Обычный</value>
+  </data>
+  <data name="JunctionBoxMode_Right_Facing" xml:space="preserve">
+    <value>Право лицом</value>
+  </data>
+  <data name="tool_paint_junctionbox_left_tooltip" xml:space="preserve">
+    <value>Добавьте соединительную коробку на перекрестке, обращенную влево.</value>
+  </data>
+  <data name="tool_paint_junctionbox_normal_tooltip" xml:space="preserve">
+    <value>Добавить распределительную коробку по умолчанию.</value>
+  </data>
+  <data name="tool_paint_junctionbox_right_tooltip" xml:space="preserve">
+    <value>Добавьте соединительную коробку на перекрестке, обращенную вправо.</value>
+  </data>
+  <data name="JunctionBox_Use" xml:space="preserve">
+    <value>Распределительная коробка:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1110,4 +1110,28 @@
   <data name="tool_wp_notthebees" xml:space="preserve">
     <value>怎么会是蜜蜂</value>
   </data>
+  <data name="JunctionBoxMode_Left_Facing" xml:space="preserve">
+    <value>朝左</value>
+  </data>
+  <data name="JunctionBoxMode_None" xml:space="preserve">
+    <value>没有任何</value>
+  </data>
+  <data name="JunctionBoxMode_Normal" xml:space="preserve">
+    <value>普通的</value>
+  </data>
+  <data name="JunctionBoxMode_Right_Facing" xml:space="preserve">
+    <value>右脸</value>
+  </data>
+  <data name="tool_paint_junctionbox_left_tooltip" xml:space="preserve">
+    <value>添加朝左的交叉路口接线盒。</value>
+  </data>
+  <data name="tool_paint_junctionbox_normal_tooltip" xml:space="preserve">
+    <value>添加默认接线盒。</value>
+  </data>
+  <data name="tool_paint_junctionbox_right_tooltip" xml:space="preserve">
+    <value>添加朝右的交叉路口接线盒。</value>
+  </data>
+  <data name="JunctionBox_Use" xml:space="preserve">
+    <value>接线盒：</value>
+  </data>
 </root>

--- a/src/TEdit/Themes/Templates.xaml
+++ b/src/TEdit/Themes/Templates.xaml
@@ -8,6 +8,7 @@
                     xmlns:enum="clr-namespace:TEdit.UI.Xaml.Enum">
     <enum:EnumItemList x:Key="PaintModeEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:PaintMode}" SortBy="Value"  />
     <enum:EnumItemList x:Key="TrackModeEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:TrackMode}" SortBy="Value"  />
+    <enum:EnumItemList x:Key="JunctionBoxEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:JunctionBoxMode}" SortBy="Value"  />
     <enum:EnumItemList x:Key="MaskModeEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:MaskMode}" x:Shared="false" SortBy="Value" />
     <enum:EnumItemList x:Key="HalfBlockMode" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:HalfBlockMode}" x:Shared="false" SortBy="Value" />
     <enum:EnumItemList x:Key="BrickStyle" ResourceType="{x:Type p:Language}" EnumType="{x:Type Terraria:BrickStyle}" x:Shared="false" SortBy="Value" />

--- a/src/TEdit/View/PaintModeView.xaml
+++ b/src/TEdit/View/PaintModeView.xaml
@@ -216,10 +216,15 @@
                     <StackPanel Orientation="Vertical">
                         <CheckBox IsChecked="{Binding TilePicker.RedWireActive}" Content="{x:Static p:Language.tool_paint_wire_red}" Width="75" VerticalAlignment="Center" Height="22"/>
                         <CheckBox IsChecked="{Binding TilePicker.BlueWireActive}" Content="{x:Static p:Language.tool_paint_wire_blue}" Width="75" VerticalAlignment="Center" Height="22"/>
+                        <TextBlock Text="{x:Static p:Language.JunctionBox_Use}" />
                     </StackPanel>
                     <StackPanel Orientation="Vertical">
                         <CheckBox IsChecked="{Binding TilePicker.GreenWireActive}" Content="{x:Static p:Language.tool_paint_wire_green}" Width="75" VerticalAlignment="Center" Height="22"/>
                         <CheckBox IsChecked="{Binding TilePicker.YellowWireActive}" Content="{x:Static p:Language.tool_paint_wire_yellow}" Width="75" VerticalAlignment="Center" Height="22"/>
+                        <ComboBox ItemsSource="{StaticResource JunctionBoxEnum}" 
+                          SelectedValue="{Binding TilePicker.JunctionBoxMode}" 
+                          SelectedValuePath="Value" Width="100"
+                          ItemTemplate="{StaticResource EnumTemplate}" />
                     </StackPanel>
                 </StackPanel>
             </GroupBox>

--- a/src/TEdit/ViewModel/WorldViewModel.Editor.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Editor.cs
@@ -81,32 +81,88 @@ namespace TEdit.ViewModel
             switch (curMode)
             {
                 case PaintMode.Sprites:
-                    if (CurrentWorld.TileFrameImportant[curTile.Type])
-                        SetTile(curTile, isErase);
+                    if (curTile.Type != 424)
+                    {
+                        if (CurrentWorld.TileFrameImportant[curTile.Type])
+                            SetTile(curTile, isErase);
+                    }
                     break;
                 case PaintMode.TileAndWall:
-                    if (TilePicker.TileStyleActive)
-                        SetTile(curTile, isErase);
-                    if (TilePicker.WallStyleActive)
-                        SetWall(curTile, isErase);
-                    if (TilePicker.BrickStyleActive && TilePicker.ExtrasActive)
-                        SetPixelAutomatic(curTile, brickStyle: TilePicker.BrickStyle);
-                    if (TilePicker.TilePaintActive)
-                        SetPixelAutomatic(curTile, tileColor: isErase ? 0 : TilePicker.TileColor);
-                    if (TilePicker.WallPaintActive)
-                        SetPixelAutomatic(curTile, wallColor: isErase ? 0 : TilePicker.WallColor);
-                    if (TilePicker.ExtrasActive)
-                        SetPixelAutomatic(curTile, actuator: isErase ? false : TilePicker.Actuator, actuatorInActive: isErase ? false : TilePicker.ActuatorInActive);
+                    if (curTile.Type != 424)
+                    {
+                        if (TilePicker.TileStyleActive)
+                            SetTile(curTile, isErase);
+                        if (TilePicker.WallStyleActive)
+                            SetWall(curTile, isErase);
+                        if (TilePicker.BrickStyleActive && TilePicker.ExtrasActive)
+                            SetPixelAutomatic(curTile, brickStyle: TilePicker.BrickStyle);
+                        if (TilePicker.TilePaintActive)
+                            SetPixelAutomatic(curTile, tileColor: isErase ? 0 : TilePicker.TileColor);
+                        if (TilePicker.WallPaintActive)
+                            SetPixelAutomatic(curTile, wallColor: isErase ? 0 : TilePicker.WallColor);
+                        if (TilePicker.ExtrasActive)
+                            SetPixelAutomatic(curTile, actuator: isErase ? false : TilePicker.Actuator, actuatorInActive: isErase ? false : TilePicker.ActuatorInActive);
+                    }
                     break;
                 case PaintMode.Wire:
                     if (TilePicker.RedWireActive)
+                    {
                         SetPixelAutomatic(curTile, wire: !isErase);
+                    }
                     if (TilePicker.BlueWireActive)
+                    {
                         SetPixelAutomatic(curTile, wire2: !isErase);
+                    }
                     if (TilePicker.GreenWireActive)
+                    {
                         SetPixelAutomatic(curTile, wire3: !isErase);
+                    }
                     if (TilePicker.YellowWireActive)
+                    {
                         SetPixelAutomatic(curTile, wire4: !isErase);
+                    }
+                    if (TilePicker.JunctionBoxMode == JunctionBoxMode.LeftFacingBox)
+                    {
+                        if (isErase)
+                        {
+                            if (curTile.Type == 424 && curTile.U == 18)
+                            {
+                                SetTile(curTile, true);
+                            }
+                        }
+                        else
+                        {
+                            SetPixelAutomatic(curTile, tile: 424, u: 18);
+                        }
+                    }
+                    if (TilePicker.JunctionBoxMode == JunctionBoxMode.NormalFacingBox)
+                    {
+                        if (isErase)
+                        {
+                            if (curTile.Type == 424 && curTile.U == 0)
+                            {
+                                SetTile(curTile, true);
+                            }
+                        }
+                        else
+                        {
+                            SetPixelAutomatic(curTile, tile: 424, u: 0);
+                        }
+                    }
+                    if (TilePicker.JunctionBoxMode == JunctionBoxMode.RightFacingBox)
+                    {
+                        if (isErase)
+                        {
+                            if (curTile.Type == 424 && curTile.U == 36)
+                            {
+                                SetTile(curTile, true);
+                            }
+                        }
+                        else
+                        {
+                            SetPixelAutomatic(curTile, tile: 424, u: 36);
+                        }
+                    }
                     break;
                 case PaintMode.Liquid:
                     SetPixelAutomatic(
@@ -115,7 +171,10 @@ namespace TEdit.ViewModel
                         liquidType: TilePicker.LiquidType);
                     break;
                 case PaintMode.Track:
-                    SetTrack(x, y, curTile, isErase, (TilePicker.TrackMode == TrackMode.Hammer), true);
+                    if (curTile.Type != 424)
+                    {
+                        SetTrack(x, y, curTile, isErase, (TilePicker.TrackMode == TrackMode.Hammer), true);
+                    }
                     break;
             }
 


### PR DESCRIPTION
**Features Added:**
• You can now select left, right, and normal facing junction boxes from wire GUI.
• Full support for deleting / adding only selected facing junction boxes.
• Using the picker tool, it will select correct facing junction boxes along side wire types.
• Full Language Support.
![01](https://user-images.githubusercontent.com/33048298/144546491-945be0c9-ff80-4578-9857-49b098badcdb.PNG)
![02](https://user-images.githubusercontent.com/33048298/144546532-b14b070b-4db9-43e4-ad39-c463a64693eb.PNG)