### PR TITLE
Simple "Find Block or Wall" plugin.

### DIFF
--- a/src/TEdit/Editor/Plugins/FindLocationResultView.xaml
+++ b/src/TEdit/Editor/Plugins/FindLocationResultView.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:view="clr-namespace:TEdit.View" 
         SizeToContent="WidthAndHeight"
-        Title="FindChestWithPlugin"
+        Title="FindWithPlugin"
         ResizeMode="CanResizeWithGrip" 
         WindowStartupLocation="CenterOwner"
         Icon="/TEdit;component/Images/tedit.ico" 

--- a/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
+++ b/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using TEdit.Terraria;
+using TEdit.ViewModel;
+
+namespace TEdit.Editor.Plugins
+{
+    public class FindTileWithPlugin : BasePlugin
+    {
+        public FindTileWithPlugin(WorldViewModel worldViewModel)
+            : base(worldViewModel)
+        {
+            Name = "Find Block or Wall";
+        }
+
+        public override void Execute()
+        {
+            if (_wvm.CurrentWorld == null) return;
+
+            FindTileWithPluginView view = new FindTileWithPluginView();
+            if (view.ShowDialog() == false)
+            {
+                return;
+            }
+
+            string tileName = view.TileToFind.ToLower();
+            List<Vector2> locations = new List<Vector2>();
+
+            for (int x = (_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.X : 0; x < ((_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.X + _wvm.Selection.SelectionArea.Width : _wvm.CurrentWorld.TilesWide); x++)
+            {
+                for (int y = (_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.Y : 0; y < ((_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.Y + _wvm.Selection.SelectionArea.Height : _wvm.CurrentWorld.TilesHigh); y++)
+                {
+                    Tile curTile = _wvm.CurrentWorld.Tiles[x, y];
+                    TEdit.Terraria.Objects.TileProperty tileProperty = World.TileProperties[curTile.Type];
+                    TEdit.Terraria.Objects.WallProperty wallProperty = World.WallProperties[curTile.Wall];
+                    if (tileProperty.Name.ToLower().Contains(tileName) || wallProperty.Name.ToLower().Contains(tileName))
+                    {
+                        locations.Add(new Vector2(x, y));
+                    }
+                }
+            }
+
+            // show the result view with the list of locations
+            FindLocationResultView resultView = new FindLocationResultView(locations);
+            resultView.Show();
+        }
+    }
+}

--- a/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
+++ b/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
@@ -1,0 +1,14 @@
+﻿<Window x:Class="TEdit.Editor.Plugins.FindTileWithPluginView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="clr-namespace:TEdit.View" SizeToContent="WidthAndHeight"
+        Title="FindTileWithPlugin" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico">
+    <StackPanel Background="{StaticResource ControlBackgroundBrush}" >
+        <TextBlock Text="Enter the name of the tile you are looking for." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
+        <TextBox x:Name="TileLookup"></TextBox>
+        <Grid>
+            <Button Margin="5" Content="Cancel" HorizontalAlignment="Left" Padding="20, 3" VerticalAlignment="Center" Click="CancelButtonClick" />
+            <Button Margin="5" Content="Search" HorizontalAlignment="Right" Padding="20, 3" VerticalAlignment="Center" Click="SearchButtonClick" />
+        </Grid>
+    </StackPanel>
+</Window>

--- a/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System.Windows;
+
+namespace TEdit.Editor.Plugins
+{
+    /// <summary>
+    /// Interaction logic for ReplaceAllPlugin.xaml
+    /// </summary>
+    public partial class FindTileWithPluginView : Window
+    {
+        public string TileToFind { get; private set; }
+        public FindTileWithPluginView()
+        {
+            InitializeComponent();
+        }
+
+        private void CancelButtonClick(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        private void SearchButtonClick(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            TileToFind = TileLookup.Text;
+            Close();
+        }
+    }
+}

--- a/src/TEdit/ViewModel/ViewModelLocator.cs
+++ b/src/TEdit/ViewModel/ViewModelLocator.cs
@@ -52,6 +52,7 @@ namespace TEdit.ViewModel
             wvm.Plugins.Add(new FindChestWithPlugin(wvm));
             wvm.Plugins.Add(new FindPlanteraBulbPlugin(wvm));
             wvm.Plugins.Add(new HouseGenPlugin(wvm));
+            wvm.Plugins.Add(new FindTileWithPlugin(wvm));
             return wvm;
         }
     }


### PR DESCRIPTION
So I have been getting a ton of requests for an **Find Block** feature / plugin such as the one [TerraMap](https://github.com/TerraMap/windows) has... Similar to the function of _FindChest_ plugin is basically close to what would be needed. 

### Added to the plugins tab.
![01](https://user-images.githubusercontent.com/33048298/147003224-04733668-3611-43bd-ad71-47bc38c8dcba.PNG)

### To use, type the name of the desired block.
![02](https://user-images.githubusercontent.com/33048298/147003255-2e007d6a-9582-46f6-8e80-ec5c8b9fd045.PNG)

### Clicking search will open another window with locations. Clicking a location will show the block in the editor.
![03](https://user-images.githubusercontent.com/33048298/147003279-9faefdb4-4a9b-46c1-a8cb-3e1f55247493.PNG)