### PR TITLE
Simple "Find Block or Wall" plugin. Revision v2

### DIFF
--- a/src/TEdit/Editor/Plugins/FindLocationResultView.xaml
+++ b/src/TEdit/Editor/Plugins/FindLocationResultView.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:view="clr-namespace:TEdit.View" 
         SizeToContent="WidthAndHeight"
-        Title="FindWithPlugin"
+        Title="FindChestWithPlugin"
         ResizeMode="CanResizeWithGrip" 
         WindowStartupLocation="CenterOwner"
         Icon="/TEdit;component/Images/tedit.ico" 

--- a/src/TEdit/Editor/Plugins/FindLocationResultView.xaml
+++ b/src/TEdit/Editor/Plugins/FindLocationResultView.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:view="clr-namespace:TEdit.View" 
         SizeToContent="WidthAndHeight"
-        Title="FindChestWithPlugin"
+        Title="FindWithPlugin"
         ResizeMode="CanResizeWithGrip" 
         WindowStartupLocation="CenterOwner"
         Icon="/TEdit;component/Images/tedit.ico" 

--- a/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml
+++ b/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml
@@ -1,0 +1,26 @@
+﻿<Window x:Class="TEdit.Editor.Plugins.FindTileLocationResultView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="clr-namespace:TEdit.View" 
+        SizeToContent="WidthAndHeight"
+        Title="FindTileWithPlugin"
+        ResizeMode="CanResizeWithGrip" 
+        WindowStartupLocation="CenterOwner"
+        Icon="/TEdit;component/Images/tedit.ico" 
+        Topmost="True" 
+        Background="{StaticResource ControlBackgroundBrush}">
+    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="25*"/>
+            <ColumnDefinition Width="36*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"></RowDefinition>
+            <RowDefinition Height="*" MinHeight="150"></RowDefinition>
+            <RowDefinition Height="30"></RowDefinition>
+        </Grid.RowDefinitions>
+        <TextBlock Text="These location could be found." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Center" Foreground="{StaticResource TextBrush}" Grid.Row="0" Grid.ColumnSpan="2"/>
+        <ListBox Name="LocationList" MouseDoubleClick="ListBoxMouseDoubleClick" Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Grid.ColumnSpan="2"/>
+        <Button Margin="57,5" Content="Close" HorizontalAlignment="Center" Padding="20, 3" Click="CloseButtonClick" Grid.Row="2" Grid.ColumnSpan="2"/>
+    </Grid>
+</Window>

--- a/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Microsoft.Xna.Framework;
+
+namespace TEdit.Editor.Plugins
+{
+    /// <summary>
+    /// Interaction logic for ReplaceAllPlugin.xaml
+    /// </summary>
+    public partial class FindTileLocationResultView : Window
+    {
+        private char[] splitters = new char[] { ',' };
+        public FindTileLocationResultView(List<Tuple<string, Vector2>> locations)
+        {
+            InitializeComponent();
+            foreach (var location in locations)
+            {
+                LocationList.Items.Add($"{location.Item1}{location.Item2.X}, {location.Item2.Y}");
+            }
+        }
+
+        public void CloseButtonClick(object sender, RoutedEventArgs routedEventArgs)
+        {
+            Close();
+        }
+
+        private void ListBoxMouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if ( e.OriginalSource is TextBlock )
+            {
+                TextBlock item = e.OriginalSource as TextBlock;
+                if ( !string.IsNullOrEmpty(item.Text) )
+                {
+                    string[] positions = item.Text.Split(':')[1].Trim().Split(splitters);
+                    if (positions.Length == 2)
+                    {
+                        int x = 0;
+                        int y = 0;
+
+                        if (int.TryParse(positions[0].Trim(), out x) && int.TryParse(positions[1].Trim(), out y))
+                        {
+                            MainWindow mainwin = Application.Current.MainWindow as MainWindow;
+                            if (mainwin != null)
+                            {
+                                mainwin.ZoomFocus(x, y);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
+++ b/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Xna.Framework;
 using TEdit.Terraria;
 using TEdit.ViewModel;
+using System;
 
 namespace TEdit.Editor.Plugins
 {
@@ -24,26 +24,40 @@ namespace TEdit.Editor.Plugins
                 return;
             }
 
-            string tileName = view.TileToFind.ToLower();
-            List<Vector2> locations = new List<Vector2>();
+            string blockName = view.BlockToFind.ToLower();
+            string wallName = view.WallToFind.ToLower();
+            List<Tuple<string, Vector2>> locations = new List<Tuple<string, Vector2>>();
 
             for (int x = (_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.X : 0; x < ((_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.X + _wvm.Selection.SelectionArea.Width : _wvm.CurrentWorld.TilesWide); x++)
             {
                 for (int y = (_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.Y : 0; y < ((_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.Y + _wvm.Selection.SelectionArea.Height : _wvm.CurrentWorld.TilesHigh); y++)
                 {
-                    Tile curTile = _wvm.CurrentWorld.Tiles[x, y];
-                    TEdit.Terraria.Objects.TileProperty tileProperty = World.TileProperties[curTile.Type];
-                    TEdit.Terraria.Objects.WallProperty wallProperty = World.WallProperties[curTile.Wall];
-                    if (tileProperty.Name.ToLower().Contains(tileName) || wallProperty.Name.ToLower().Contains(tileName))
+                    if (locations.Count > 10000)
                     {
-                        locations.Add(new Vector2(x, y));
+                        locations.Add(new Tuple<string, Vector2>("HALTING! Too Many Entrees!: ", new Vector2(0, 0)));
+                        FindTileLocationResultView resultView0 = new FindTileLocationResultView(locations);
+                        resultView0.Show();
+                        return;
+                    }
+
+                    Tile curTile = _wvm.CurrentWorld.Tiles[x, y];
+                    TEdit.Terraria.Objects.TileProperty blockProperty = World.TileProperties[curTile.Type];
+                    TEdit.Terraria.Objects.WallProperty wallProperty = World.WallProperties[curTile.Wall];
+
+                    if (blockName != "" && blockProperty.Name.ToLower().Contains(blockName))
+                    {
+                        locations.Add(new Tuple<string, Vector2>(blockProperty.Name.ToLower() + ": ", new Vector2(x, y)));
+                    }
+                    if (wallName != "" && wallProperty.Name.ToLower().Contains(wallName))
+                    {
+                        locations.Add(new Tuple<string, Vector2>(wallProperty.Name.ToLower() + ": ", new Vector2(x, y)));
                     }
                 }
             }
 
             // show the result view with the list of locations
-            FindLocationResultView resultView = new FindLocationResultView(locations);
-            resultView.Show();
+            FindTileLocationResultView resultView1 = new FindTileLocationResultView(locations);
+            resultView1.Show();
         }
     }
 }

--- a/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
+++ b/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using TEdit.Terraria;
+using TEdit.ViewModel;
+
+namespace TEdit.Editor.Plugins
+{
+    public class FindTileWithPlugin : BasePlugin
+    {
+        public FindTileWithPlugin(WorldViewModel worldViewModel)
+            : base(worldViewModel)
+        {
+            Name = "Find Block or Wall";
+        }
+
+        public override void Execute()
+        {
+            if (_wvm.CurrentWorld == null) return;
+
+            FindTileWithPluginView view = new FindTileWithPluginView();
+            if (view.ShowDialog() == false)
+            {
+                return;
+            }
+
+            string tileName = view.TileToFind.ToLower();
+            List<Vector2> locations = new List<Vector2>();
+
+            for (int x = (_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.X : 0; x < ((_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.X + _wvm.Selection.SelectionArea.Width : _wvm.CurrentWorld.TilesWide); x++)
+            {
+                for (int y = (_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.Y : 0; y < ((_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.Y + _wvm.Selection.SelectionArea.Height : _wvm.CurrentWorld.TilesHigh); y++)
+                {
+                    Tile curTile = _wvm.CurrentWorld.Tiles[x, y];
+                    TEdit.Terraria.Objects.TileProperty tileProperty = World.TileProperties[curTile.Type];
+                    TEdit.Terraria.Objects.WallProperty wallProperty = World.WallProperties[curTile.Wall];
+                    if (tileProperty.Name.ToLower().Contains(tileName) || wallProperty.Name.ToLower().Contains(tileName))
+                    {
+                        locations.Add(new Vector2(x, y));
+                    }
+                }
+            }
+
+            // show the result view with the list of locations
+            FindLocationResultView resultView = new FindLocationResultView(locations);
+            resultView.Show();
+        }
+    }
+}

--- a/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
+++ b/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
@@ -32,7 +32,7 @@ namespace TEdit.Editor.Plugins
             {
                 for (int y = (_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.Y : 0; y < ((_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.Y + _wvm.Selection.SelectionArea.Height : _wvm.CurrentWorld.TilesHigh); y++)
                 {
-                    if (locations.Count > 10000)
+                    if (locations.Count > view.MaxVolumeLimit - 1)
                     {
                         locations.Add(new Tuple<string, Vector2>("HALTING! Too Many Entrees!: ", new Vector2(0, 0)));
                         FindTileLocationResultView resultView0 = new FindTileLocationResultView(locations);

--- a/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
+++ b/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
@@ -8,7 +8,7 @@
         <TextBox x:Name="BlockLookup"></TextBox>
         <TextBlock Text="Enter the name of the wall you are looking for." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
         <TextBox x:Name="WallLookup"></TextBox>
-        <TextBlock Text="Enter the max overflow for the search. Use at own risk." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
+        <TextBlock Text="Enter the max results for the search." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />

--- a/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
+++ b/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
@@ -8,6 +8,20 @@
         <TextBox x:Name="BlockLookup"></TextBox>
         <TextBlock Text="Enter the name of the wall you are looking for." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
         <TextBox x:Name="WallLookup"></TextBox>
+        <TextBlock Text="Enter the max overflow for the search. Use at own risk." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="13" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="13" />
+                <RowDefinition Height="13" />
+            </Grid.RowDefinitions>
+            <TextBox Name="NUDTextBox"  Grid.Column="0" Grid.Row="0" Grid.RowSpan="2" TextAlignment="Right" TextChanged="NUDTextBox_TextChanged"/>
+            <RepeatButton Name="NUDButtonUP"  Grid.Column="1" Grid.Row="0" FontSize="8" FontFamily="Marlett" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Click="NUDButtonUP_Click">5</RepeatButton>
+            <RepeatButton Name="NUDButtonDown"  Grid.Column="1" Grid.Row="1" FontSize="8"  FontFamily="Marlett" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Height="13" VerticalAlignment="Bottom" Click="NUDButtonDown_Click">6</RepeatButton>
+        </Grid>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="74*"/>

--- a/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
+++ b/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
@@ -1,0 +1,14 @@
+﻿<Window x:Class="TEdit.Editor.Plugins.FindTileWithPluginView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="clr-namespace:TEdit.View" SizeToContent="WidthAndHeight"
+        Title="FindTileWithPlugin" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico">
+    <StackPanel Background="{StaticResource ControlBackgroundBrush}" >
+        <TextBlock Text="Enter the name of the tile you are looking for." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
+        <TextBox x:Name="TileLookup"></TextBox>
+        <Grid>
+            <Button Margin="5" Content="Cancel" HorizontalAlignment="Left" Padding="20, 3" VerticalAlignment="Center" Click="CancelButtonClick" />
+            <Button Margin="5" Content="Search" HorizontalAlignment="Right" Padding="20, 3" VerticalAlignment="Center" Click="SearchButtonClick" />
+        </Grid>
+    </StackPanel>
+</Window>

--- a/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
+++ b/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml
@@ -2,13 +2,19 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:view="clr-namespace:TEdit.View" SizeToContent="WidthAndHeight"
-        Title="FindTileWithPlugin" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico">
+        Title="FindTileWithPlugin" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico" Height="185.333">
     <StackPanel Background="{StaticResource ControlBackgroundBrush}" >
-        <TextBlock Text="Enter the name of the tile you are looking for." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
-        <TextBox x:Name="TileLookup"></TextBox>
+        <TextBlock Text="Enter the name of the block you are looking for." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
+        <TextBox x:Name="BlockLookup"></TextBox>
+        <TextBlock Text="Enter the name of the wall you are looking for." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Stretch" Foreground="{StaticResource TextBrush}"/>
+        <TextBox x:Name="WallLookup"></TextBox>
         <Grid>
-            <Button Margin="5" Content="Cancel" HorizontalAlignment="Left" Padding="20, 3" VerticalAlignment="Center" Click="CancelButtonClick" />
-            <Button Margin="5" Content="Search" HorizontalAlignment="Right" Padding="20, 3" VerticalAlignment="Center" Click="SearchButtonClick" />
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="74*"/>
+                <ColumnDefinition Width="187*"/>
+            </Grid.ColumnDefinitions>
+            <Button Margin="5,5,0,5" Content="Cancel" HorizontalAlignment="Left" Padding="20, 3" VerticalAlignment="Center" Click="CancelButtonClick" Grid.ColumnSpan="2" />
+            <Button Margin="0,5,5,5" Content="Search" HorizontalAlignment="Right" Padding="20, 3" VerticalAlignment="Center" Click="SearchButtonClick" Grid.Column="1" />
         </Grid>
     </StackPanel>
 </Window>

--- a/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml.cs
@@ -7,7 +7,9 @@ namespace TEdit.Editor.Plugins
     /// </summary>
     public partial class FindTileWithPluginView : Window
     {
-        public string TileToFind { get; private set; }
+        public string BlockToFind { get; private set; }
+        public string WallToFind { get; private set; }
+        public string SpriteToFind { get; private set; }
         public FindTileWithPluginView()
         {
             InitializeComponent();
@@ -22,7 +24,8 @@ namespace TEdit.Editor.Plugins
         private void SearchButtonClick(object sender, RoutedEventArgs e)
         {
             DialogResult = true;
-            TileToFind = TileLookup.Text;
+            BlockToFind = BlockLookup.Text;
+            WallToFind = WallLookup.Text;
             Close();
         }
     }

--- a/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows;
+﻿using System;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Forms;
 
 namespace TEdit.Editor.Plugins
 {
@@ -10,9 +14,11 @@ namespace TEdit.Editor.Plugins
         public string BlockToFind { get; private set; }
         public string WallToFind { get; private set; }
         public string SpriteToFind { get; private set; }
+        public int MaxVolumeLimit { get; private set; }
         public FindTileWithPluginView()
         {
             InitializeComponent();
+            NUDTextBox.Text = startvalue.ToString();
         }
 
         private void CancelButtonClick(object sender, RoutedEventArgs e)
@@ -26,7 +32,41 @@ namespace TEdit.Editor.Plugins
             DialogResult = true;
             BlockToFind = BlockLookup.Text;
             WallToFind = WallLookup.Text;
+            MaxVolumeLimit = int.Parse(NUDTextBox.Text);
             Close();
+        }
+
+        int minvalue = 1,
+        maxvalue = 80640000,
+        startvalue = 500;
+
+        private void NUDButtonUP_Click(object sender, RoutedEventArgs e)
+        {
+            int number;
+            if (NUDTextBox.Text != "") number = Convert.ToInt32(NUDTextBox.Text);
+            else number = 0;
+            if (number < maxvalue)
+                NUDTextBox.Text = Convert.ToString(number + 1);
+        }
+
+        private void NUDButtonDown_Click(object sender, RoutedEventArgs e)
+        {
+            int number;
+            if (NUDTextBox.Text != "") number = Convert.ToInt32(NUDTextBox.Text);
+            else number = 0;
+            if (number > minvalue)
+                NUDTextBox.Text = Convert.ToString(number - 1);
+        }
+
+        private void NUDTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            int number = 0;
+            if (NUDTextBox.Text != "")
+                if (!int.TryParse(NUDTextBox.Text, out number)) NUDTextBox.Text = startvalue.ToString();
+            if (number > maxvalue) NUDTextBox.Text = maxvalue.ToString();
+            if (number < minvalue) NUDTextBox.Text = minvalue.ToString();
+            NUDTextBox.SelectionStart = NUDTextBox.Text.Length;
+
         }
     }
 }

--- a/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/FindTileWithPluginView.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System.Windows;
+
+namespace TEdit.Editor.Plugins
+{
+    /// <summary>
+    /// Interaction logic for ReplaceAllPlugin.xaml
+    /// </summary>
+    public partial class FindTileWithPluginView : Window
+    {
+        public string TileToFind { get; private set; }
+        public FindTileWithPluginView()
+        {
+            InitializeComponent();
+        }
+
+        private void CancelButtonClick(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        private void SearchButtonClick(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            TileToFind = TileLookup.Text;
+            Close();
+        }
+    }
+}

--- a/src/TEdit/ViewModel/ViewModelLocator.cs
+++ b/src/TEdit/ViewModel/ViewModelLocator.cs
@@ -52,6 +52,7 @@ namespace TEdit.ViewModel
             wvm.Plugins.Add(new FindChestWithPlugin(wvm));
             wvm.Plugins.Add(new FindPlanteraBulbPlugin(wvm));
             wvm.Plugins.Add(new HouseGenPlugin(wvm));
+            wvm.Plugins.Add(new FindTileWithPlugin(wvm));
             return wvm;
         }
     }


### PR DESCRIPTION
So I have been getting a ton of requests for an **Find Block** feature / plugin such as the one [TerraMap](https://github.com/TerraMap/windows) has... Similar to the function of _FindChest_ plugin is basically close to what would be needed. In my previous push there where some issues as pointed out.

**Bellow is an image of the plugin within the plugins tab of the GUI.**
![01](https://user-images.githubusercontent.com/33048298/147042715-9ec8064f-2538-4688-81b4-29a5b246adc3.PNG)

**The next image if the window that will popup after clicking the plugin. This is where you can see similarities from the _FindChest_ plugin GUI. As stated in the last revision, we needed a control way to limit the amount of blocks or walls being searched. I have added a numericupdown control for this. The code for this control was barrowed from this [link](https://stackoverflow.com/a/5321605).**
![02](https://user-images.githubusercontent.com/33048298/147042820-031774d7-7fa6-4b09-9384-91d1df864380.PNG)

**In the image bellow, we showcase how the search command will now display the item found next to it's XY value. There is a very unique class called [Tuple](https://docs.microsoft.com/en-us/dotnet/api/system.tuple?redirectedfrom=MSDN&view=net-6.0). This will allow you to create a List that acts as a multi key dictionary.**

For instance, we can convert a basic `List` into `List<Tuple<string, Vector2>> locations = new List<Tuple<string, Vector2>>();`
This can be broken down and called by items `Item1`, `Item2`, Exc.
```
public FindTileLocationResultView(List<Tuple<string, Vector2>> locations)
{
    InitializeComponent();
    foreach (var location in locations)
    {
        LocationList.Items.Add($"{location.Item1}{location.Item2.X}, {location.Item2.Y}");
    }
}
```
![03](https://user-images.githubusercontent.com/33048298/147043107-410a6437-e032-4010-9082-b2bcf370035c.PNG)

**Not only can you search for Blocks and Walls simultaneously, but the plugin will also display the block / wall for the same XY. It also now has complete with a "Max Overflow" feature to display preset limits using an NumericUpDown. Refer to image two for this. Once the limit is reached it displays the XY's and returns out of the loop. Saving massive performance.** 
![04](https://user-images.githubusercontent.com/33048298/147043761-f4f5d1a3-b9c5-4052-862e-89d821e67dd1.PNG)

**This last image showcases the double click feature similar to the _FindChest_ plugin, where double clicking an XY entrée will teleport the screen to the area of the block / wall.**
![05](https://user-images.githubusercontent.com/33048298/147044082-a4411bc1-382f-4b80-a369-b0c6bc1dd178.PNG)