### PR TITLE
Fix for World and Schematic Saving of Latest Versions.

### DIFF
--- a/src/TEdit/Editor/Clipboard/ClipboardBuffer.File.cs
+++ b/src/TEdit/Editor/Clipboard/ClipboardBuffer.File.cs
@@ -122,7 +122,24 @@ namespace TEdit.Editor.Clipboard
             bw.Write(Size.X);
             bw.Write(Size.Y);
 
-            var frames = World.SaveConfiguration.SaveVersions[(int)world.Version].GetFrames();
+            // Issues that need addressed. If the current game version does not exist
+            // within the TerrariaVersionTileData.json, then the frames feature breaks all
+            // together. I suggest using the max tileframe version per TEdit release and using
+            // that or not allowing saves above the max release not be allowed to be saved.
+
+            // Check if the version attemting to save exists.
+            var frames = new bool[0];
+            if ((int)world.Version <= World.CompatibleVersion) 
+            {
+                // World version is not a future release
+                frames = World.SaveConfiguration.SaveVersions[(int)world.Version].GetFrames();
+            }
+            else
+            {
+                // World version is a future release. Lets downgrade it some.
+                frames = World.SaveConfiguration.SaveVersions[(int)World.CompatibleVersion].GetFrames();
+            }
+            
             World.SaveTiles(Tiles, (int)version, Size.X, Size.Y, bw, frames);
             World.SaveChests(Chests, bw);
             World.SaveSigns(Signs, bw);

--- a/src/TEdit/Terraria/World.FileV2.cs
+++ b/src/TEdit/Terraria/World.FileV2.cs
@@ -80,10 +80,14 @@ namespace TEdit.Terraria
             ["1.4.2.3"] = 238,
             ["1.4.3"] = 242,
             ["1.4.3.1"] = 243,
-            ["1.4.3.2"] = 244
+            ["1.4.3.2"] = 244,
+            ["1.4.3.3"] = 245,
+            ["1.4.3.4"] = 246,
+            ["1.4.3.5"] = 247,
+            ["1.4.3.6"] = 248
         };
 
-        public const uint CompatibleVersion = 242;
+        public const uint CompatibleVersion = 248; // Must be updated to the latest VersionToWorldVersion.Values
         public const short GlobalSectionCount = 11;
         public const short TileCount = 623;
         public const short WallCount = 316;

--- a/src/TEdit/View/SaveAsVersion.xaml
+++ b/src/TEdit/View/SaveAsVersion.xaml
@@ -16,6 +16,12 @@
         <ScrollViewer Grid.ColumnSpan="2">
             <StackPanel>
                 <UniformGrid Rows="1" HorizontalAlignment="Stretch" Margin="5">
+                    <Button Content="1.4.3.6" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
+                    <Button Content="1.4.3.5" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
+                  </UniformGrid>
+                <UniformGrid Rows="1" HorizontalAlignment="Stretch" Margin="5">
+                    <Button Content="1.4.3.4" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
+                    <Button Content="1.4.3.3" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
                     <Button Content="1.4.3.2" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
                     <Button Content="1.4.3.1" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
                     <Button Content="1.4.3" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />


### PR DESCRIPTION
### Schematic Issues:
So it appears that many users have been launching tickets and complaints on discord that schematic exporting has comply broke. Upon further investigation I have confirmed this and have found that if the version attempting to be referenced from the _TerrariaVersionTileData.json_ does not exist or is of a later version then the programs hardcoded values, there is no stopping the reference of that index thus resulting in a null exception. 

To work around this I have added a saving check to check if the world file is not of a higher number then the coded in values for THIS version of the program. If it is, my workaround is to just simply use the highest version we have on code.

### Missing Data Issues:
Its VERY IMPORTANT to update _TerrariaVersionTileData.json_ & _WorldFileV2.cs_. 
Within _WorldFileV2.cs_ make sure that CompatibleVersion is also being updated.

Using `public uint CompatibleVersion = VersionToWorldVersion.Values.Last()` would be a nice automation but since its an const this cannot be done.

### Final Notes:
I have added some notes you can later remove from the code if you wish.