### PR TITLE
Fix for issue #1525 - Can't draw liquids over certain vine/rope tiles

### DIFF
--- a/src/TEdit/ViewModel/WorldViewModel.Editor.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Editor.cs
@@ -625,7 +625,9 @@ namespace TEdit.ViewModel
 
             if (curTile.IsActive)
                 if (World.TileProperties[curTile.Type].IsSolid && !curTile.InActive && !World.TileProperties[curTile.Type].IsPlatform)
-                    curTile.LiquidAmount = 0;
+                    // Exclude Vines, Jungle Vines, Hallowed Vines, Crimson Vines, Vine Rope, Vine Flowers, Silk Rope, Web Rope
+                    if (curTile.Type != 52 && curTile.Type != 62 && curTile.Type != 115 && curTile.Type != 205 && curTile.Type != 353 && curTile.Type != 382 && curTile.Type != 365 && curTile.Type != 366)
+                        curTile.LiquidAmount = 0;
         }
 
         private PixelMapManager RenderEntireWorld()

--- a/src/TEdit/ViewModel/WorldViewModel.Editor.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Editor.cs
@@ -623,11 +623,24 @@ namespace TEdit.ViewModel
                 }
             }
 
-            if (curTile.IsActive)
-                if (World.TileProperties[curTile.Type].IsSolid && !curTile.InActive && !World.TileProperties[curTile.Type].IsPlatform)
-                    // Exclude Vines, Jungle Vines, Hallowed Vines, Crimson Vines, Vine Rope, Vine Flowers, Silk Rope, Web Rope
-                    if (curTile.Type != 52 && curTile.Type != 62 && curTile.Type != 115 && curTile.Type != 205 && curTile.Type != 353 && curTile.Type != 382 && curTile.Type != 365 && curTile.Type != 366)
-                        curTile.LiquidAmount = 0;
+            // clear liquids for solid tiles
+            if (curTile.IsActive) 
+            {
+                if (World.TileProperties[curTile.Type].IsSolid && 
+                    !curTile.InActive && 
+                    !World.TileProperties[curTile.Type].IsPlatform &&
+                    curTile.Type != 52 && // Exclude Vines
+                    curTile.Type != 62 && // Exclude Jungle Vines
+                    curTile.Type != 115 && // Exclude Hallowed Vines, 
+                    curTile.Type != 205 && // Exclude Crimson Vines, 
+                    curTile.Type != 353 && // Exclude Vine Rope
+                    curTile.Type != 382 && // Exclude Vine Flowers
+                    curTile.Type != 365 && // Exclude Silk Rope
+                    curTile.Type != 366) // Exclude Web Rope
+                {
+                    curTile.LiquidAmount = 0;
+                }
+            }
         }
 
         private PixelMapManager RenderEntireWorld()


### PR DESCRIPTION
This is a simple exclusion to the `SetPixelAutomatic()` function.
I'm sure this liquid exclusion for tiles feature is still relevant, however without removing it entirely, a simple if exclusion was added.

**Affected tiles are:**
- Vines (52)
- Jungle Vines (62)
- Hallowed Vines (115)
- Crimson Vine (205)
- Vine Rope (353)
- Vine Flowers (382)
- Silk Rope (365)
- Web Rope (366)