### PR TITLE
Adds Future Automation To Updating Static "CompatibleVersion"

### DIFF
--- a/src/TEdit/Terraria/World.FileV2.cs
+++ b/src/TEdit/Terraria/World.FileV2.cs
@@ -14,7 +14,7 @@ namespace TEdit.Terraria
 
     public partial class World
     {
-        public const uint CompatibleVersion = 248; // Must be updated to the latest VersionToWorldVersion.Values
+        public static readonly uint CompatibleVersion;
         public const short TileCount = 623;
         public const short WallCount = 316;
 

--- a/src/TEdit/Terraria/World.Settings.cs
+++ b/src/TEdit/Terraria/World.Settings.cs
@@ -12,6 +12,7 @@ using XNA = Microsoft.Xna.Framework;
 using TEdit.Terraria.Objects;
 using Newtonsoft.Json;
 using TEdit.Configuration;
+using System.Linq;
 
 namespace TEdit.Terraria
 {
@@ -79,16 +80,10 @@ namespace TEdit.Terraria
             }
 
             var saveVersionPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TerrariaVersionTileData.json");
-			
-            // Used to dynamically update static CompatibleVersion
-            using (StreamReader file = File.OpenText(saveVersionPath))
-            using (JsonTextReader reader = new JsonTextReader(file))
-            {
-                JsonSerializer serializer = new JsonSerializer();
-                CompatibleVersion = uint.Parse(serializer.Deserialize<SaveConfiguration>(reader).SaveVersions.Keys.Last().ToString());
-            }
-			
             LoadSaveVersions(saveVersionPath);
+
+            // Used to dynamically update static CompatibleVersion
+            CompatibleVersion = (uint)SaveConfiguration.SaveVersions.Keys.Max();
         }
 
         private static IEnumerable<TOut> StringToList<TOut>(string xmlcsv)

--- a/src/TEdit/Terraria/World.Settings.cs
+++ b/src/TEdit/Terraria/World.Settings.cs
@@ -79,6 +79,15 @@ namespace TEdit.Terraria
             }
 
             var saveVersionPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TerrariaVersionTileData.json");
+			
+            // Used to dynamically update static CompatibleVersion
+            using (StreamReader file = File.OpenText(saveVersionPath))
+            using (JsonTextReader reader = new JsonTextReader(file))
+            {
+                JsonSerializer serializer = new JsonSerializer();
+                CompatibleVersion = uint.Parse(serializer.Deserialize<SaveConfiguration>(reader).SaveVersions.Keys.Last().ToString());
+            }
+			
             LoadSaveVersions(saveVersionPath);
         }
 


### PR DESCRIPTION
Changed the old static `public const uint CompatibleVersion = 248` to `public static readonly uint CompatibleVersion;` and addressed in upon the loading class that handles `TerrariaVersionTileData.json` while initializing.

Please review this before pushing. I want this to be a _STABLE_ solution not something that will cause later issues.

Bellow is the application displaying the proper latest version.
![Capture](https://user-images.githubusercontent.com/33048298/165995495-424d638b-c9fb-4304-983a-d9dd9363031e.PNG)
