### PR TITLE
Added TotalCount to the Find Block or Wall Plugin

### DIFF
--- a/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml
+++ b/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml
@@ -19,7 +19,7 @@
             <RowDefinition Height="*" MinHeight="150"></RowDefinition>
             <RowDefinition Height="30"></RowDefinition>
         </Grid.RowDefinitions>
-        <TextBlock Text="These location could be found." Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Center" Foreground="{StaticResource TextBrush}" Grid.Row="0" Grid.ColumnSpan="2"/>
+        <TextBlock Name="LocationText" Text="{Binding LocationText}" Margin="10 2" TextWrapping="Wrap" HorizontalAlignment="Center" Foreground="{StaticResource TextBrush}" Grid.Row="0" Grid.ColumnSpan="2"/>
         <ListBox Name="LocationList" MouseDoubleClick="ListBoxMouseDoubleClick" Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Grid.ColumnSpan="2"/>
         <Button Margin="57,5" Content="Close" HorizontalAlignment="Center" Padding="20, 3" Click="CloseButtonClick" Grid.Row="2" Grid.ColumnSpan="2"/>
     </Grid>

--- a/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml.cs
@@ -13,9 +13,10 @@ namespace TEdit.Editor.Plugins
     public partial class FindTileLocationResultView : Window
     {
         private char[] splitters = new char[] { ',' };
-        public FindTileLocationResultView(List<Tuple<string, Vector2>> locations)
+        public FindTileLocationResultView(List<Tuple<string, Vector2>> locations, string count)
         {
             InitializeComponent();
+            LocationText.Text = count + " locations could be found.";
             foreach (var location in locations)
             {
                 LocationList.Items.Add($"{location.Item1}{location.Item2.X}, {location.Item2.Y}");

--- a/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
+++ b/src/TEdit/Editor/Plugins/FindTileWithPlugin.cs
@@ -25,9 +25,7 @@ namespace TEdit.Editor.Plugins
             }
 
             string blockName = view.BlockToFind.ToLower();
-
             string wallName = view.WallToFind.ToLower();
-
 
             Dictionary<ushort, string> tileIds = new Dictionary<ushort, string>();
             Dictionary<ushort, Dictionary<Vector2Short, string>> spriteIds = new Dictionary<ushort, Dictionary<Vector2Short, string>>();
@@ -79,8 +77,8 @@ namespace TEdit.Editor.Plugins
                 }
             }
 
-
             List<Tuple<string, Vector2>> locations = new List<Tuple<string, Vector2>>();
+            int ItemsFound = 0;
 
             for (int x = (_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.X : 0; x < ((_wvm.Selection.IsActive) ? _wvm.Selection.SelectionArea.X + _wvm.Selection.SelectionArea.Width : _wvm.CurrentWorld.TilesWide); x++)
             {
@@ -89,7 +87,7 @@ namespace TEdit.Editor.Plugins
                     if (locations.Count > view.MaxVolumeLimit - 1)
                     {
                         locations.Add(new Tuple<string, Vector2>("HALTING! Too Many Entrees!: ", new Vector2(0, 0)));
-                        FindTileLocationResultView resultView0 = new FindTileLocationResultView(locations);
+                        FindTileLocationResultView resultView0 = new FindTileLocationResultView(locations, ItemsFound + "+");
                         resultView0.Show();
                         return;
                     }
@@ -101,6 +99,7 @@ namespace TEdit.Editor.Plugins
                     if (tileIds.TryGetValue(curTile.Type, out var foundTileName))
                     {
                         locations.Add(new Tuple<string, Vector2>(foundTileName + ": ", new Vector2(x, y)));
+                        ItemsFound++;
                     }
 
                     // Search for sprite tile
@@ -110,6 +109,7 @@ namespace TEdit.Editor.Plugins
                         if (frameList.TryGetValue(uv, out string spriteName))
                         {
                             locations.Add(new Tuple<string, Vector2>(spriteName + ": ", new Vector2(x, y)));
+                            ItemsFound++;
                         }
                     }
 
@@ -117,12 +117,13 @@ namespace TEdit.Editor.Plugins
                     if (wallIds.TryGetValue(curTile.Wall, out var foundWallName))
                     {
                         locations.Add(new Tuple<string, Vector2>(foundWallName + ": ", new Vector2(x, y)));
+                        ItemsFound++;
                     }
                 }
             }
 
             // show the result view with the list of locations
-            FindTileLocationResultView resultView1 = new FindTileLocationResultView(locations);
+            FindTileLocationResultView resultView1 = new FindTileLocationResultView(locations, ItemsFound.ToString());
             resultView1.Show();
         }
     }


### PR DESCRIPTION
This simply adds a count to the final search of the plugin.

**Before Changes:**
![01](https://user-images.githubusercontent.com/33048298/169707356-bb3e4c12-a953-46a0-a6b4-2c2d7a0dbd42.PNG)

**After Changes:**
![03](https://user-images.githubusercontent.com/33048298/169707361-1f09e688-37e4-4c3d-a0b6-d77202b31600.PNG)
![02](https://user-images.githubusercontent.com/33048298/169707404-03890058-daf6-48a9-a339-425af0f521ea.PNG)
