### PR TITLE
Added Drag + Drop To Open World File Functionality to TEdit

### DIFF
--- a/src/TEdit/MainWindow.xaml
+++ b/src/TEdit/MainWindow.xaml
@@ -8,6 +8,8 @@
         xmlns:p="clr-namespace:TEdit.Properties"
         xmlns:vm="clr-namespace:TEdit.ViewModel"
         xmlns:cv="clr-namespace:TEdit.Converters"
+        AllowDrop="True"
+        Drop="WorldFileDrop"
    >
     <Window.Resources>
         <Image x:Key="TB_LogIcon" x:Shared="false" Source="/Images/Toolbar/report_magnify.png" Height="16" Width="16" SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor"/>

--- a/src/TEdit/MainWindow.xaml.cs
+++ b/src/TEdit/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using TEdit.Editor;
 using TEdit.ViewModel;
 using TEdit.Properties;
 using TEdit.UI.Xaml;
+using System.IO;
 
 namespace TEdit
 {
@@ -252,6 +253,18 @@ namespace TEdit
             var mapPointY = (int)(clickLocation.Y * (TEdit.Render.RenderMiniMap.Resolution));
 
             this.MapView.ZoomFocus(mapPointX, mapPointY);
+        }
+
+        private void WorldFileDrop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+
+                string filelocation = Path.GetFullPath(files[0]);
+
+                _vm.LoadWorld(filelocation);
+            }
         }
     }
 }


### PR DESCRIPTION
-Added "AllowDrop" tag and "Drop" event handler to the <Window>

-Implemented the "WorldFileDrop" Function that is called when "Drop" Event occurs on <Window>

Now when a file is dropped into the TEdit window, it will call the "LoadWorld" Function inside of the "WorldViewModel" class.
The file path of the dropped file is passed into that as a parameter. It appears to work the same as clicking on "File>Open" and selecting the file you want to open.

