### PR TITLE
Added Wire Transparency Toggle & Fixed Single Wire Layers

### DIFF
--- a/src/TEdit/MainWindow.xaml
+++ b/src/TEdit/MainWindow.xaml
@@ -110,6 +110,7 @@
                     <MenuItem Header="{x:Static p:Language.menu_layers_wire_blue}" IsCheckable="True" IsChecked="{Binding ShowBlueWires}" />
                     <MenuItem Header="{x:Static p:Language.menu_layers_wire_green}" IsCheckable="True" IsChecked="{Binding ShowGreenWires}" />
                     <MenuItem Header="{x:Static p:Language.menu_layers_wire_yellow}" IsCheckable="True" IsChecked="{Binding ShowYellowWires}" />
+                    <MenuItem Header="{x:Static p:Language.menu_layers_wire_transparency}" IsCheckable="True" IsChecked="{Binding ShowWireTransparency}" />
                     <Separator Margin="1" />
                     <MenuItem Header="{x:Static p:Language.menu_layers_points}" IsCheckable="True" IsChecked="{Binding ShowPoints}" />
                     <Separator Margin="1" />

--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -19,7 +19,7 @@ namespace TEdit.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Language {
@@ -888,7 +888,18 @@ namespace TEdit.Properties {
                 return ResourceManager.GetString("menu_layers_wire_yellow", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Wire Transparency.
+        /// </summary>
+        public static string menu_layers_wire_transparency
+        {
+            get
+            {
+                return ResourceManager.GetString("menu_layers_wire_transparency", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Plugins.
         /// </summary>

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -1170,4 +1170,7 @@
   <data name="bestiary_load" xml:space="preserve">
     <value>حمل</value>
   </data>
+  <data name="menu_layers_wire_transparency" xml:space="preserve">
+    <value>شفافية الأسلاك</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -1170,4 +1170,7 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="bestiary_load" xml:space="preserve">
     <value>Last</value>
   </data>
+  <data name="menu_layers_wire_transparency" xml:space="preserve">
+    <value>Drahttransparenz</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -1170,4 +1170,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="bestiary_load" xml:space="preserve">
     <value>Load</value>
   </data>
+  <data name="menu_layers_wire_transparency" xml:space="preserve">
+    <value>Wire Transparency</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -1170,4 +1170,7 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="bestiary_load" xml:space="preserve">
     <value>Ładunek</value>
   </data>
+  <data name="menu_layers_wire_transparency" xml:space="preserve">
+    <value>Przezroczystość przewodu</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -1170,4 +1170,7 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="bestiary_load" xml:space="preserve">
     <value>Carga</value>
   </data>
+  <data name="menu_layers_wire_transparency" xml:space="preserve">
+    <value>Transparência aramada</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -1170,4 +1170,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="tool_clipboard_ispastesprite" xml:space="preserve">
     <value>Paste Sprites</value>
   </data>
+  <data name="menu_layers_wire_transparency" xml:space="preserve">
+    <value>Wire Transparency</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -1170,4 +1170,7 @@
   <data name="bestiary_load" xml:space="preserve">
     <value>Загрузить</value>
   </data>
+  <data name="menu_layers_wire_transparency" xml:space="preserve">
+    <value>Прозрачность проводов</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1170,4 +1170,7 @@
   <data name="bestiary_load" xml:space="preserve">
     <value>负荷</value>
   </data>
+  <data name="menu_layers_wire_transparency" xml:space="preserve">
+    <value>电线透明度</value>
+  </data>
 </root>

--- a/src/TEdit/View/WorldRenderXna.xaml.cs
+++ b/src/TEdit/View/WorldRenderXna.xaml.cs
@@ -2386,7 +2386,7 @@ namespace TEdit.View
                                     source.X = state * 18;
                                     source.Y = 36 + voffset;
 
-                                    var color = (!_wvm.ShowWireTransparency) ? Color.White : (curtile.WireRed || curtile.WireBlue && (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowYellowWires)) ? Translucent : Color.White;
+                                    var color = (!_wvm.ShowWireTransparency) ? Color.White : ((curtile.WireRed || curtile.WireBlue) && (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowYellowWires)) ? Translucent : Color.White;
                                     _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerGreenWires);
                                 }
                                 if (curtile.WireYellow && _wvm.ShowYellowWires)
@@ -2402,7 +2402,7 @@ namespace TEdit.View
                                     source.X = state * 18;
                                     source.Y = 54 + voffset;
 
-                                    var color = (!_wvm.ShowWireTransparency) ? Color.White : (curtile.WireRed || curtile.WireBlue || curtile.WireGreen && (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowGreenWires)) ? Translucent : Color.White;
+                                    var color = (!_wvm.ShowWireTransparency) ? Color.White : ((curtile.WireRed || curtile.WireBlue || curtile.WireGreen) && (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowGreenWires)) ? Translucent : Color.White;
                                     _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerYellowWires);
                                 }
                             }

--- a/src/TEdit/View/WorldRenderXna.xaml.cs
+++ b/src/TEdit/View/WorldRenderXna.xaml.cs
@@ -2330,8 +2330,6 @@ namespace TEdit.View
                         neighborTile[w] = (x - 1) > 0 ? _wvm.CurrentWorld.Tiles[x - 1, y] : null;
                         neighborTile[s] = (y + 1) < height ? _wvm.CurrentWorld.Tiles[x, y + 1] : null;
 
-
-
                         if (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowGreenWires || _wvm.ShowYellowWires)
                         {
                             var tileTex = (Texture2D)_textureDictionary.GetMisc("WiresNew");
@@ -2355,7 +2353,7 @@ namespace TEdit.View
                                     source.X = state * 18;
                                     source.Y = voffset;
 
-                                    var color = curtile.Type == (int)TileType.JunctionBox ? Translucent : Color.White;
+                                    var color = (!_wvm.ShowWireTransparency) ? Color.White : (curtile.WireRed && (_wvm.ShowBlueWires || _wvm.ShowGreenWires || _wvm.ShowYellowWires)) ? Translucent : Color.White;
 
                                     _spriteBatch.Draw(tileTex, dest, source, Color.White, 0f, default, SpriteEffects.None, LayerRedWires);
                                 }
@@ -2372,7 +2370,7 @@ namespace TEdit.View
                                     source.X = state * 18;
                                     source.Y = 18 + voffset;
 
-                                    var color = curtile.Type == (int)TileType.JunctionBox || curtile.WireRed ? Translucent : Color.White;
+                                    var color = (!_wvm.ShowWireTransparency) ? Color.White : (curtile.WireRed && (_wvm.ShowRedWires || _wvm.ShowGreenWires || _wvm.ShowYellowWires)) ? Translucent : Color.White;
                                     _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerBlueWires);
                                 }
                                 if (curtile.WireGreen && _wvm.ShowGreenWires)
@@ -2388,7 +2386,7 @@ namespace TEdit.View
                                     source.X = state * 18;
                                     source.Y = 36 + voffset;
 
-                                    var color = (curtile.Type == (int)TileType.JunctionBox || curtile.WireRed || curtile.WireBlue) ? Translucent : Color.White;
+                                    var color = (!_wvm.ShowWireTransparency) ? Color.White : (curtile.WireRed || curtile.WireBlue && (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowYellowWires)) ? Translucent : Color.White;
                                     _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerGreenWires);
                                 }
                                 if (curtile.WireYellow && _wvm.ShowYellowWires)
@@ -2404,7 +2402,7 @@ namespace TEdit.View
                                     source.X = state * 18;
                                     source.Y = 54 + voffset;
 
-                                    var color = (curtile.Type == (int)TileType.JunctionBox || curtile.WireRed || curtile.WireBlue || curtile.WireGreen) ? Translucent : Color.White;
+                                    var color = (!_wvm.ShowWireTransparency) ? Color.White : (curtile.WireRed || curtile.WireBlue || curtile.WireGreen && (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowGreenWires)) ? Translucent : Color.White;
                                     _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerYellowWires);
                                 }
                             }

--- a/src/TEdit/ViewModel/WorldViewModel.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.cs
@@ -89,6 +89,7 @@ namespace TEdit.ViewModel
         private bool _showBlueWires = true;
         private bool _showGreenWires = true;
         private bool _showYellowWires = true;
+        private bool _showWireTransparency = true;
         private string _spriteFilter;
         private ListCollectionView _spritesView;
         private ListCollectionView _spritesView2;
@@ -573,6 +574,16 @@ namespace TEdit.ViewModel
             set
             {
                 Set(nameof(ShowYellowWires), ref _showYellowWires, value);
+                UpdateRenderWorld();
+            }
+        }
+
+        public bool ShowWireTransparency
+        {
+            get { return _showWireTransparency; }
+            set
+            {
+                Set(nameof(ShowWireTransparency), ref _showWireTransparency, value);
                 UpdateRenderWorld();
             }
         }


### PR DESCRIPTION
### Single Wire Layers

When viewing a single layer of wire, there should not be any transparency happening to the wires. Even when multiple wire layers are enabled, all disabled layers should not be causing any transparency. This has been fixed as seen below.

**Before:**
![bluewire](https://user-images.githubusercontent.com/33048298/184080744-bab5fe61-e439-4cfd-a2a0-e1a69a4bfc88.PNG)

**After:**
![bluewireFixed](https://user-images.githubusercontent.com/33048298/184080756-d99d51f4-9ec9-4436-8fa7-162e3a2fa2fc.PNG)

### Transparency Toggle - Layers
![newlayer](https://user-images.githubusercontent.com/33048298/184080970-9d98432c-eb24-4abd-b800-f589f3a2414b.PNG)

A new layer option was added. This simply allows users to toggle on or off the ire merging feature.

**Enabled:**
![trans](https://user-images.githubusercontent.com/33048298/184081092-96940d2e-2657-416b-8633-d9339938c49f.PNG)

**Disabled:**
![notrans](https://user-images.githubusercontent.com/33048298/184081101-f44499a1-06b8-4de8-9525-5d7bc1aa2717.PNG)

### Junction Box Changes
I have removed the transparency from single wire junction boxes.
This change keeps it more cannon to the games view and it's interpretation of the junction boxes wiring logic.