### PR TITLE
Added Support For Wire Replacement

### DIFF
--- a/src/TEdit/Editor/PaintMode.cs
+++ b/src/TEdit/Editor/PaintMode.cs
@@ -38,4 +38,48 @@ namespace TEdit.Editor
         [Description("Right Facing")]
         Right = 36
     }
+    public enum WireReplaceModeOne
+    {
+        [Description("Red")]
+        Red,
+        [Description("Blue")]
+        Blue,
+        [Description("Green")]
+        Green,
+        [Description("Yellow")]
+        Yellow
+    }
+    public enum WireReplaceModeTwo
+    {
+        [Description("Red")]
+        Red,
+        [Description("Blue")]
+        Blue,
+        [Description("Green")]
+        Green,
+        [Description("Yellow")]
+        Yellow
+    }
+    public enum WireReplaceModeThree
+    {
+        [Description("Red")]
+        Red,
+        [Description("Blue")]
+        Blue,
+        [Description("Green")]
+        Green,
+        [Description("Yellow")]
+        Yellow
+    }
+    public enum WireReplaceModeFour
+    {
+        [Description("Red")]
+        Red,
+        [Description("Blue")]
+        Blue,
+        [Description("Green")]
+        Green,
+        [Description("Yellow")]
+        Yellow
+    }
 }

--- a/src/TEdit/Editor/TilePicker.cs
+++ b/src/TEdit/Editor/TilePicker.cs
@@ -36,6 +36,10 @@ namespace TEdit.Editor
         private bool _wallStyleActive = ToolDefaultData.PaintWallActive;
         private TrackMode _trackMode = TrackMode.Track;
         private JunctionBoxMode _junctionboxMode = JunctionBoxMode.None;
+        private WireReplaceModeOne _wireReplaceModeOne = WireReplaceModeOne.Red;
+        private WireReplaceModeTwo _wireReplaceModeTwo = WireReplaceModeTwo.Blue;
+        private WireReplaceModeThree _wireReplaceModeThree = WireReplaceModeThree.Green;
+        private WireReplaceModeFour _wireReplaceModeFour = WireReplaceModeFour.Yellow;
 
         private BrickStyle _brickStyle = BrickStyle.Full;
         public BrickStyle BrickStyle
@@ -54,6 +58,26 @@ namespace TEdit.Editor
         {
             get { return _junctionboxMode; }
             set { Set(nameof(JunctionBoxMode), ref _junctionboxMode, value); }
+        }
+        public WireReplaceModeOne WireReplaceModeOne
+        {
+            get { return _wireReplaceModeOne; }
+            set { Set(nameof(WireReplaceModeOne), ref _wireReplaceModeOne, value); }
+        }
+        public WireReplaceModeTwo WireReplaceModeTwo
+        {
+            get { return _wireReplaceModeTwo; }
+            set { Set(nameof(WireReplaceModeTwo), ref _wireReplaceModeTwo, value); }
+        }
+        public WireReplaceModeThree WireReplaceModeThree
+        {
+            get { return _wireReplaceModeThree; }
+            set { Set(nameof(WireReplaceModeThree), ref _wireReplaceModeThree, value); }
+        }
+        public WireReplaceModeFour WireReplaceModeFour
+        {
+            get { return _wireReplaceModeFour; }
+            set { Set(nameof(WireReplaceModeFour), ref _wireReplaceModeFour, value); }
         }
 
         //private bool _isLava;
@@ -96,7 +120,6 @@ namespace TEdit.Editor
             get { return _wallpaintActive; }
             set { Set(nameof(WallPaintActive), ref _wallpaintActive, value); }
         }
-
 
         private bool _brickStyleActive;
         public bool BrickStyleActive

--- a/src/TEdit/Themes/Templates.xaml
+++ b/src/TEdit/Themes/Templates.xaml
@@ -13,7 +13,10 @@
     <enum:EnumItemList x:Key="HalfBlockMode" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:HalfBlockMode}" x:Shared="false" SortBy="Value" />
     <enum:EnumItemList x:Key="BrickStyle" ResourceType="{x:Type p:Language}" EnumType="{x:Type Terraria:BrickStyle}" x:Shared="false" SortBy="Value" />
     <enum:EnumItemList x:Key="LiquidType" ResourceType="{x:Type p:Language}" EnumType="{x:Type Terraria:LiquidType}" x:Shared="false" SortBy="Value" />
-    
+    <enum:EnumItemList x:Key="WireReplaceModeOneEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:WireReplaceModeOne}" SortBy="Value"  />
+    <enum:EnumItemList x:Key="WireReplaceModeTwoEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:WireReplaceModeTwo}" SortBy="Value"  />
+    <enum:EnumItemList x:Key="WireReplaceModeThreeEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:WireReplaceModeThree}" SortBy="Value"  />
+    <enum:EnumItemList x:Key="WireReplaceModeFourEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:WireReplaceModeFour}" SortBy="Value"  />
 
     <DataTemplate x:Key="ColorPickerTemplate" >
         <DockPanel LastChildFill="True">

--- a/src/TEdit/View/PaintModeView.xaml
+++ b/src/TEdit/View/PaintModeView.xaml
@@ -228,6 +228,38 @@
                     </StackPanel>
                 </StackPanel>
             </GroupBox>
+            <GroupBox Header="Wire Replacement" Style="{StaticResource WireStyle}">
+            <StackPanel Orientation="Horizontal">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="{x:Static p:Language.menu_layers_wire_red}" />
+                    <TextBlock Text="{x:Static p:Language.menu_layers_wire_blue}" />
+                </StackPanel>
+                <StackPanel Orientation="Vertical">
+                    <ComboBox ItemsSource="{StaticResource WireReplaceModeOneEnum}" 
+                          SelectedValue="{Binding TilePicker.WireReplaceModeOne}" 
+                          SelectedValuePath="Value" Width="100"
+                          ItemTemplate="{StaticResource EnumTemplate}" />
+                    <ComboBox ItemsSource="{StaticResource WireReplaceModeTwoEnum}" 
+                          SelectedValue="{Binding TilePicker.WireReplaceModeTwo}" 
+                          SelectedValuePath="Value" Width="100"
+                          ItemTemplate="{StaticResource EnumTemplate}" />
+                </StackPanel>
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="{x:Static p:Language.menu_layers_wire_green}" />
+                    <TextBlock Text="{x:Static p:Language.menu_layers_wire_yellow}" />
+                </StackPanel>
+                <StackPanel Orientation="Vertical">
+                    <ComboBox ItemsSource="{StaticResource WireReplaceModeThreeEnum}" 
+                          SelectedValue="{Binding TilePicker.WireReplaceModeThree}" 
+                          SelectedValuePath="Value" Width="100"
+                          ItemTemplate="{StaticResource EnumTemplate}" />
+                    <ComboBox ItemsSource="{StaticResource WireReplaceModeFourEnum}" 
+                          SelectedValue="{Binding TilePicker.WireReplaceModeFour}" 
+                          SelectedValuePath="Value" Width="100"
+                          ItemTemplate="{StaticResource EnumTemplate}" />
+                </StackPanel>
+            </StackPanel>
+            </GroupBox>
             <GroupBox Header="Minecart Track" Style="{StaticResource TrackStyle}">
                 <StackPanel Orientation="Vertical" >
                     <ComboBox ItemsSource="{StaticResource TrackModeEnum}" 

--- a/src/TEdit/ViewModel/WorldViewModel.Editor.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Editor.cs
@@ -358,13 +358,161 @@ namespace TEdit.ViewModel
                     break;
                 case PaintMode.Wire:
 
-                    // paint all wires in one call
-                    SetPixelAutomatic(curTile,
-                        wire: TilePicker.RedWireActive ? !isErase : null,
-                        wire2: TilePicker.BlueWireActive ? !isErase : null,
-                        wire3: TilePicker.GreenWireActive ? !isErase : null,
-                        wire4: TilePicker.YellowWireActive ? !isErase : null
-                        );
+                    // Is Replace Mode Active?
+                    bool WireReplaceMode = ((TilePicker.WireReplaceModeOne != WireReplaceModeOne.Red) ? true : false) || ((TilePicker.WireReplaceModeTwo != WireReplaceModeTwo.Blue) ? true : false) || ((TilePicker.WireReplaceModeThree != WireReplaceModeThree.Green) ? true : false) || ((TilePicker.WireReplaceModeFour != WireReplaceModeFour.Yellow) ? true : false);
+                    bool ReplacedRed = false;
+                    bool ReplacedBlue = false;
+                    bool ReplacedGreen = false;
+                    bool ReplacedYellow = false;
+
+                HasMultiColor:
+                    if (!WireReplaceMode)
+                    {
+                        // paint all wires in one call
+                        SetPixelAutomatic(curTile,
+                            wire: TilePicker.RedWireActive ? !isErase : null,
+                            wire2: TilePicker.BlueWireActive ? !isErase : null,
+                            wire3: TilePicker.GreenWireActive ? !isErase : null,
+                            wire4: TilePicker.YellowWireActive ? !isErase : null
+                            );
+                    }
+                    else
+                    {
+                        if (curTile.WireRed && TilePicker.WireReplaceModeOne != WireReplaceModeOne.Red && !ReplacedRed)
+                        {
+                            // Does it have overlay?
+                            bool HasMiltiColor = (curTile.WireBlue || curTile.WireGreen || curTile.WireYellow);
+
+                            // Erase Red
+                            if (!HasMiltiColor)
+                                SetPixelAutomatic(curTile, wire: false);
+
+                            if (TilePicker.WireReplaceModeOne == WireReplaceModeOne.Blue && !ReplacedBlue)
+                            {
+                                if (!curTile.WireBlue) { SetPixelAutomatic(curTile, wire: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire2: true);
+                            }
+                            if (TilePicker.WireReplaceModeOne == WireReplaceModeOne.Green && !ReplacedGreen)
+                            {
+                                if (!curTile.WireGreen) { SetPixelAutomatic(curTile, wire: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire3: true);
+                            }
+                            if (TilePicker.WireReplaceModeOne == WireReplaceModeOne.Yellow && !ReplacedYellow)
+                            {
+                                if (!curTile.WireYellow) { SetPixelAutomatic(curTile, wire: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire4: true);
+                            }
+
+                            // Loop To Fix MultiColors
+                            if (HasMiltiColor)
+                            {
+                                ReplacedRed = true;
+                                goto HasMultiColor;
+                            }
+                        }
+                        else if (curTile.WireBlue && TilePicker.WireReplaceModeTwo != WireReplaceModeTwo.Blue && !ReplacedBlue)
+                        {
+                            // Does it have overlay?
+                            bool HasMiltiColor = (curTile.WireRed || curTile.WireGreen || curTile.WireYellow);
+
+                            // Erase Blue
+                            if (!HasMiltiColor)
+                                SetPixelAutomatic(curTile, wire2: false);
+
+                            if (TilePicker.WireReplaceModeTwo == WireReplaceModeTwo.Red && !ReplacedRed)
+                            {
+                                if (!curTile.WireRed) { SetPixelAutomatic(curTile, wire2: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire: true);
+                            }
+                            if (TilePicker.WireReplaceModeTwo == WireReplaceModeTwo.Green && !ReplacedGreen)
+                            {
+                                if (!curTile.WireGreen) { SetPixelAutomatic(curTile, wire2: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire3: true);
+                            }
+                            if (TilePicker.WireReplaceModeTwo == WireReplaceModeTwo.Yellow && !ReplacedYellow)
+                            {
+                                if (!curTile.WireYellow) { SetPixelAutomatic(curTile, wire2: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire4: true);
+                            }
+
+                            // Loop To Fix MultiColors
+                            if (HasMiltiColor)
+                            {
+                                ReplacedBlue = true;
+                                goto HasMultiColor;
+                            }
+                        }
+                        else if (curTile.WireGreen && TilePicker.WireReplaceModeThree != WireReplaceModeThree.Green && !ReplacedGreen)
+                        {
+                            // Does it have overlay?
+                            bool HasMiltiColor = (curTile.WireRed || curTile.WireBlue || curTile.WireYellow);
+
+                            // Erase Green
+                            if (!HasMiltiColor)
+                                SetPixelAutomatic(curTile, wire3: false);
+
+                            if (TilePicker.WireReplaceModeThree == WireReplaceModeThree.Red && !ReplacedRed)
+                            {
+                                if (!curTile.WireRed) { SetPixelAutomatic(curTile, wire3: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire: true);
+                            }
+                            if (TilePicker.WireReplaceModeThree == WireReplaceModeThree.Blue && !ReplacedBlue)
+                            {
+                                if (!curTile.WireBlue) { SetPixelAutomatic(curTile, wire3: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire2: true);
+                            }
+                            if (TilePicker.WireReplaceModeThree == WireReplaceModeThree.Yellow && !ReplacedYellow)
+                            {
+                                if (!curTile.WireYellow) { SetPixelAutomatic(curTile, wire3: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire4: true);
+                            }
+
+                            // Loop To Fix MultiColors
+                            if (HasMiltiColor)
+                            {
+
+
+                                ReplacedGreen = true;
+                                goto HasMultiColor;
+                            }
+                        }
+                        else if (curTile.WireYellow && TilePicker.WireReplaceModeFour != WireReplaceModeFour.Yellow && !ReplacedYellow)
+                        {
+                            // Does it have overlay?
+                            bool HasMiltiColor = (curTile.WireRed || curTile.WireBlue || curTile.WireGreen);
+
+                            // Erase Yellow
+                            if (!HasMiltiColor)
+                                SetPixelAutomatic(curTile, wire4: false);
+
+                            if (TilePicker.WireReplaceModeFour == WireReplaceModeFour.Red && !ReplacedRed)
+                            {
+                                if (!curTile.WireRed) { SetPixelAutomatic(curTile, wire4: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire: true);
+                            }
+                            if (TilePicker.WireReplaceModeFour == WireReplaceModeFour.Blue && !ReplacedBlue)
+                            {
+                                if (!curTile.WireBlue) { SetPixelAutomatic(curTile, wire4: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire2: true);
+                            }
+                            if (TilePicker.WireReplaceModeFour == WireReplaceModeFour.Green && !ReplacedGreen)
+                            {
+                                if (!curTile.WireGreen) { SetPixelAutomatic(curTile, wire4: false); } // Erase Old Wires
+                                SetPixelAutomatic(curTile, wire3: true);
+                            }
+
+                            // Loop To Fix MultiColors
+                            if (HasMiltiColor)
+                            {
+                                ReplacedYellow = true;
+                                goto HasMultiColor;
+                            }
+                        }
+
+                        // Remove 
+
+
+                    }
 
                     // stack on junction boxes
                     if (TilePicker.JunctionBoxMode != JunctionBoxMode.None)


### PR DESCRIPTION
### Wire Replacement

Before, when created circuits, wire colors had to be manually changed by hand. Now in this patch, you can adjust what colors you want to change via four drop downs.

When any of the four drop downs are active, TEdit will now switch to "Wire Replacement" Mode. Disregarding the place / erase modes. This saves from extra GUI clutter.

![WireReplacement2](https://user-images.githubusercontent.com/33048298/184810909-32bd0374-9947-4b25-b98d-f5769435b31f.gif)
