### PR TITLE
Added "Allow Unsafe Values" For Cave Levels & Fixed 1.2.4.1

### DIFF
--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -881,6 +881,15 @@ namespace TEdit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Wire Transparency.
+        /// </summary>
+        public static string menu_layers_wire_transparency {
+            get {
+                return ResourceManager.GetString("menu_layers_wire_transparency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Yellow Wire.
         /// </summary>
         public static string menu_layers_wire_yellow {
@@ -888,18 +897,7 @@ namespace TEdit.Properties {
                 return ResourceManager.GetString("menu_layers_wire_yellow", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Wire Transparency.
-        /// </summary>
-        public static string menu_layers_wire_transparency
-        {
-            get
-            {
-                return ResourceManager.GetString("menu_layers_wire_transparency", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Plugins.
         /// </summary>
@@ -3138,6 +3136,15 @@ namespace TEdit.Properties {
         public static string tool_wp_time_sundial_cooldown {
             get {
                 return ResourceManager.GetString("tool_wp_time_sundial_cooldown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allow Unsafe Values.
+        /// </summary>
+        public static string tool_wp_unsafe_level {
+            get {
+                return ResourceManager.GetString("tool_wp_unsafe_level", resourceCulture);
             }
         }
         

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -1173,4 +1173,7 @@
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>شفافية الأسلاك</value>
   </data>
+  <data name="tool_wp_unsafe_level" xml:space="preserve">
+    <value>السماح بالقيم غير الآمنة</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -1173,4 +1173,7 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Drahttransparenz</value>
   </data>
+  <data name="tool_wp_unsafe_level" xml:space="preserve">
+    <value>Unsichere Werte zulassen</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -1173,4 +1173,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Wire Transparency</value>
   </data>
+  <data name="tool_wp_unsafe_level" xml:space="preserve">
+    <value>Allow Unsafe Values</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -1173,4 +1173,7 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Przezroczystość przewodu</value>
   </data>
+  <data name="tool_wp_unsafe_level" xml:space="preserve">
+    <value>Zezwalaj na niebezpieczne wartości</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -1173,4 +1173,7 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Transparência aramada</value>
   </data>
+  <data name="tool_wp_unsafe_level" xml:space="preserve">
+    <value>Permitir valores inseguros</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -1173,4 +1173,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Wire Transparency</value>
   </data>
+  <data name="tool_wp_unsafe_level" xml:space="preserve">
+    <value>Allow Unsafe Values</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -1173,4 +1173,7 @@
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Прозрачность проводов</value>
   </data>
+  <data name="tool_wp_unsafe_level" xml:space="preserve">
+    <value>Разрешить небезопасные значения</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1173,4 +1173,7 @@
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>电线透明度</value>
   </data>
+  <data name="tool_wp_unsafe_level" xml:space="preserve">
+    <value>允许不安全的值</value>
+  </data>
 </root>

--- a/src/TEdit/Terraria/World.FileV2.cs
+++ b/src/TEdit/Terraria/World.FileV2.cs
@@ -2017,7 +2017,7 @@ namespace TEdit.Terraria
 
             w.SavedStylist = r.ReadBoolean();
 
-            if (w.Version >= 129)
+            if (w.Version >= 140)
             {
                 w.SavedTaxCollector = r.ReadBoolean();
             }
@@ -2047,29 +2047,30 @@ namespace TEdit.Terraria
 
             if (w.Version < 128) { return; }
 
-            if (w.Version >= 140) // Sundial - Added v140
+            if (w.Version >= 140)
+            {
                 w.FastForwardTime = r.ReadBoolean();
+            }
 
             if (w.Version < 131) { return; }
 
             w.DownedFishron = r.ReadBoolean();
-            
+
             if (w.Version >= 140)
             {
                 w.DownedMartians = r.ReadBoolean();
                 w.DownedLunaticCultist = r.ReadBoolean();
                 w.DownedMoonlord = r.ReadBoolean();
             }
+
             w.DownedHalloweenKing = r.ReadBoolean();
             w.DownedHalloweenTree = r.ReadBoolean();
             w.DownedChristmasQueen = r.ReadBoolean();
             w.DownedSanta = r.ReadBoolean();
             w.DownedChristmasTree = r.ReadBoolean();
-            w.DownedSanta = r.ReadBoolean();
-            w.DownedChristmasTree = r.ReadBoolean();
-            
+
             if (w.Version < 140) { return; }
-            
+
             w.DownedCelestialSolar = r.ReadBoolean();
             w.DownedCelestialVortex = r.ReadBoolean();
             w.DownedCelestialNebula = r.ReadBoolean();

--- a/src/TEdit/Terraria/World.Properties.cs
+++ b/src/TEdit/Terraria/World.Properties.cs
@@ -146,6 +146,7 @@ namespace TEdit.Terraria
         private int _shadowOrbCount;
         private bool _shadowOrbSmashed;
         private bool _spawnMeteor;
+        private bool _unsafeGroundLayers;
         private int _spawnX;
         private int _spawnY;
         private float _tempMaxRain;
@@ -227,8 +228,8 @@ namespace TEdit.Terraria
         private bool _tenthAnniversaryWorld;
         private bool _dontStarveWorld;
         private bool _notTheBeesWorld;
-        
-
+        private int _maxCavernLevel;
+        private int _maxGroundLevel;
 
         public Bestiary Bestiary
         {
@@ -1004,12 +1005,34 @@ namespace TEdit.Terraria
 
         public int MaxCavernLevel
         {
-            get => Math.Min(_tilesHigh, 1239);
+            get
+            {
+                if (!UnsafeGroundLayers)
+                {
+                    return Math.Min(_tilesHigh, 1239);
+                }
+                else
+                {
+                    return _maxCavernLevel;
+                }
+            }
+            set { Set(nameof(MaxCavernLevel), ref _maxCavernLevel, value); }
         }
 
         public int MaxGroundLevel
         {
-            get => Math.Min(_tilesHigh, 1239);
+            get
+            {
+                if (!UnsafeGroundLayers)
+                {
+                    return Math.Min(_tilesHigh, 1239);
+                }
+                else
+                {
+                    return _maxGroundLevel;
+                }
+            }
+            set { Set(nameof(MaxGroundLevel), ref _maxGroundLevel, value); }
         }
 
         public int TilesHigh
@@ -1095,11 +1118,24 @@ namespace TEdit.Terraria
             get { return _groundLevel; }
             set
             {
-                if (value > MaxGroundLevel) value = MaxGroundLevel;
+                if (!UnsafeGroundLayers)
+                {
+                    if (value > MaxGroundLevel) value = MaxGroundLevel;
 
-                Set(nameof(GroundLevel), ref _groundLevel, value);
-                if (_groundLevel > _rockLevel)
-                    RockLevel = _groundLevel;
+                    Set(nameof(GroundLevel), ref _groundLevel, value);
+                    if (_groundLevel > _rockLevel)
+                        RockLevel = _groundLevel;
+
+                    RaisePropertyChanged(nameof(MaxCavernLevel));
+                }
+                else
+                {
+                    Set(nameof(GroundLevel), ref _groundLevel, value);
+                    if (_groundLevel > _rockLevel)
+                        RockLevel = _groundLevel;
+
+                    RaisePropertyChanged(nameof(MaxCavernLevel));
+                }
             }
         }
 
@@ -1108,14 +1144,26 @@ namespace TEdit.Terraria
             get { return _rockLevel; }
             set
             {
-                if (value > MaxCavernLevel) value = MaxCavernLevel;
+                if (!UnsafeGroundLayers)
+                {
+                    if (value > MaxCavernLevel) value = MaxCavernLevel;
 
-                Set(nameof(RockLevel), ref _rockLevel, value);
+                    Set(nameof(RockLevel), ref _rockLevel, value);
 
-                if (_groundLevel > _rockLevel)
-                    GroundLevel = _rockLevel;
+                    if (_groundLevel > _rockLevel)
+                        GroundLevel = _rockLevel;
 
-                RaisePropertyChanged(nameof(MaxGroundLevel));
+                    RaisePropertyChanged(nameof(MaxGroundLevel));
+                }
+                else
+                {
+                    Set(nameof(RockLevel), ref _rockLevel, value);
+
+                    if (_groundLevel > _rockLevel)
+                        GroundLevel = _rockLevel;
+
+                    RaisePropertyChanged(nameof(MaxGroundLevel));
+                }
             }
         }
 
@@ -1213,6 +1261,39 @@ namespace TEdit.Terraria
         {
             get { return _spawnMeteor; }
             set { Set(nameof(SpawnMeteor), ref _spawnMeteor, value); }
+        }
+
+        public bool UnsafeGroundLayers
+        {
+            get { return _unsafeGroundLayers; }
+            set {
+                if (_unsafeGroundLayers == false)
+                {
+                    System.Windows.Forms.DialogResult result = System.Windows.Forms.MessageBox.Show("Values over 1239 could cause visual issues within the world.\n\nDo you wish to continue?", "Enable Unsafe Layer Values?", System.Windows.Forms.MessageBoxButtons.YesNo);
+                    if (result == System.Windows.Forms.DialogResult.Yes)
+                    {
+                        MaxGroundLevel = _tilesHigh;
+                        MaxCavernLevel = _tilesHigh;
+
+                        // Control Updates
+                        GroundLevel = 350;
+                        RockLevel = 480;
+
+                        Set(nameof(UnsafeGroundLayers), ref _unsafeGroundLayers, value);
+                    }
+                }
+                else
+                {
+                    MaxGroundLevel = Math.Min(_tilesHigh, 1239);
+                    MaxCavernLevel = Math.Min(_tilesHigh, 1239);
+
+                    // Control Updates
+                    GroundLevel = 350;
+                    RockLevel = 480;
+
+                    Set(nameof(UnsafeGroundLayers), ref _unsafeGroundLayers, value);
+                }
+            }
         }
 
         public int ShadowOrbCount

--- a/src/TEdit/Terraria/World.cs
+++ b/src/TEdit/Terraria/World.cs
@@ -187,13 +187,12 @@ namespace TEdit.Terraria
                         w.IsTModLoader = File.Exists(twldPath);
 
                         w.Version = b.ReadUInt32();
-                        var readerPos = b.BaseStream.Position;
 
-                        w.Title = b.ReadString();
-
+                        //var readerPos = b.BaseStream.Position;
+                        //w.Title = b.ReadString();
                         // if seed = 0, use load V0
-                        int seed = b.ReadInt32();
-                        b.BaseStream.Position = readerPos;
+                        //int seed = b.ReadInt32();
+                        //b.BaseStream.Position = readerPos;
 
 
                         if (showWarnings)
@@ -239,7 +238,7 @@ namespace TEdit.Terraria
                         {
                             LoadV2(b, w, debugger);
                         }
-                        else if (w.Version <= 38 && seed == 0)
+                        else if (w.Version <= 38) // && seed == 0)
                         {
                             LoadV0(b, filename, w);
                         }

--- a/src/TEdit/View/WorldPropertiesView.xaml
+++ b/src/TEdit/View/WorldPropertiesView.xaml
@@ -383,6 +383,10 @@
             <Slider Value="{Binding CurrentWorld.RockLevel, Mode=TwoWay}" VerticalAlignment="Center" Minimum="0" Maximum="{Binding Path=CurrentWorld.MaxCavernLevel}" SmallChange="1" Width="120" />
             <TextBox Text="{Binding CurrentWorld.RockLevel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="32" DockPanel.Dock="Right" />
         </DockPanel>
+        <TextBlock  />
+        <DockPanel>
+            <CheckBox IsChecked="{Binding CurrentWorld.UnsafeGroundLayers}" Content="{x:Static p:Language.tool_wp_unsafe_level}" VerticalAlignment="Center" />
+        </DockPanel>
         <Separator Grid.ColumnSpan="2" />
         <TextBlock Text="{x:Static p:Language.tool_wp_meteor}" HorizontalAlignment="Right" />
         <CheckBox IsChecked="{Binding CurrentWorld.SpawnMeteor}" Content="{x:Static p:Language.tool_wp_meteor_spawn}" VerticalAlignment="Center" VerticalContentAlignment="Center" />


### PR DESCRIPTION
As many people request, I have added a checkbox to allow for overwriting the "safe" cave levels.
Bellow is an image of the new checkbox.
![out](https://user-images.githubusercontent.com/33048298/187816819-bfb5a184-74fb-4311-bb0a-2c57ffb6bf9f.PNG)
Bellow is the warning prompt that shows when checking the checkbox:
![warning](https://user-images.githubusercontent.com/33048298/187817030-090f97a6-745a-42f2-8341-eea6fb4ec06e.PNG)

Further in this push, I have fixes a few important LoadHeaderFlags such as the `SavedTaxCollector` flag being incorrect.