### PR TITLE
Update bestiary data to 1.4.4.2.

### DIFF
--- a/src/TEdit/BestiaryData.json
+++ b/src/TEdit/BestiaryData.json
@@ -164,7 +164,9 @@
     "TownSlimeRed",
     "TownSlimeYellow",
     "TownSlimeCopper",
-    "BoundTownSlimeOld"
+    "BoundTownSlimeOld",
+    "BoundTownSlimePurple",
+    "BoundTownSlimeYellow"
   ],
   "BestiaryKilledIDs": [
     "DeerclopsLeg",


### PR DESCRIPTION
The Mystic Frog was missing from the current bestiary list. Now gets 100% when completing the bestiary.
![oof](https://user-images.githubusercontent.com/33048298/193426672-a76a0166-afdf-4da2-b71d-17296cb99adf.PNG)
