### PR TITLE
Update settings, style proposition

### DIFF
--- a/src/TEdit/settings.xml
+++ b/src/TEdit/settings.xml
@@ -331,593 +331,593 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="110,506" Name="Aether Torch" Variety="Off" Anchor="Right" />
 			</Frames>
 		</Tile>
-		<Tile Id="5" Color="#FF976B4B" Name="Tree" Framed="true" TextureGrid="20,20">
+		<Tile Id="5" Color="#FF976B4B" Name="Trees" Framed="true" TextureGrid="20,20">
 			<Frames>
-				<Frame UV="0,0" Name="Tree Trunk" Variety="Plain A" />
-				<Frame UV="22,0" Name="Tree Trunk" Variety="Right Indent A" />
-				<Frame UV="44,0" Name="Tree Trunk" Variety="Right Slight Bulge A" />
-				<Frame UV="66,0" Name="Tree Branch" Variety="Plain A" Anchor="Right" />
-				<Frame UV="88,0" Name="Tree Trunk" Variety="Left Slight Bulge A" />
-				<Frame UV="110,0" Name="Tree Top" Variety="Medium A" />
-				<Frame UV="132,0" Name="Tree Top" Variety="Small A" />
-				<Frame UV="154,0" Name="Tree Top" Variety="Large A" />
-				<Frame UV="0,22" Name="Tree Trunk" Variety="Plain B" />
-				<Frame UV="22,22" Name="Tree Trunk" Variety="Right Indent B" />
-				<Frame UV="44,22" Name="Tree Trunk" Variety="Right Slight Bulge B" />
-				<Frame UV="66,22" Name="Tree Branch" Variety="Plain B" />
-				<Frame UV="88,22" Name="Tree Trunk" Variety="Left Slight Bulge B" />
-				<Frame UV="110,22" Name="Tree Top" Variety="Medium B" />
-				<Frame UV="132,22" Name="Tree Top" Variety="Small B" />
-				<Frame UV="154,22" Name="Tree Top" Variety="Large B" />
-				<Frame UV="0,44" Name="Tree Trunk" Variety="Plain C" />
-				<Frame UV="22,44" Name="Tree Trunk" Variety="Right Indent C" />
-				<Frame UV="44,44" Name="Tree Trunk" Variety="Right Slight Bulge C" />
-				<Frame UV="66,44" Name="Tree Branch" Variety="Plain C" />
-				<Frame UV="88,44" Name="Tree Trunk" Variety="Left Slight Bulge C" />
-				<Frame UV="110,44" Name="Tree Top" Variety="Medium C" />
-				<Frame UV="132,44" Name="Tree Top" Variety="Small C" />
-				<Frame UV="154,44" Name="Tree Top" Variety="Large C" />
-				<Frame UV="0,66" Name="Tree Trunk" Variety="Left Indent A" />
-				<Frame UV="22,66" Name="Tree Trunk" Variety="Right Bulge A" />
-				<Frame UV="44,66" Name="Tree Trunk" Variety="Left Bulge A" />
-				<Frame UV="66,66" Name="Tree Trunk" Variety="Right Slight Bulge D" />
-				<Frame UV="88,66" Name="Tree Branch" Variety="Plain A" Anchor="Left" />
-				<Frame UV="110,66" Name="Tree Trunk" Variety="Double Slight Bulge A" />
-				<Frame UV="132,66" Name="Tree Top" Variety="Small Right Slight Bulge A" />
-				<Frame UV="154,66" Name="Tree Top" Variety="Large D" />
-				<Frame UV="0,88" Name="Tree Trunk" Variety="Left Indent B" />
-				<Frame UV="22,88" Name="Tree Trunk" Variety="Right Bulge B" />
-				<Frame UV="44,88" Name="Tree Trunk" Variety="Left Bulge B" />
-				<Frame UV="66,88" Name="Tree Trunk" Variety="Right Slight Bulge E" />
-				<Frame UV="88,88" Name="Tree Branch" Variety="Plain B" Anchor="Left" />
-				<Frame UV="110,88" Name="Tree Trunk" Variety="Double Slight Bulge B" />
-				<Frame UV="132,88" Name="Tree Top" Variety="Small Right Slight Bulge B" />
-				<Frame UV="154,88" Name="Tree Top" Variety="Large E" />
-				<Frame UV="0,110" Name="Tree Trunk" Variety="Left Indent C" />
-				<Frame UV="22,110" Name="Tree Trunk" Variety="Right Bulge C" />
-				<Frame UV="44,110" Name="Tree Trunk" Variety="Left Bulge C" />
-				<Frame UV="66,110" Name="Tree Trunk" Variety="Right Slight Bulge F" />
-				<Frame UV="88,110" Name="Tree Branch" Variety="Plain C" Anchor="Left" />
-				<Frame UV="110,110" Name="Tree Trunk" Variety="Double Slight Bulge C" />
-				<Frame UV="132,110" Name="Tree Top" Variety="Small Right Slight Bulge C" />
-				<Frame UV="154,110" Name="Tree Top" Variety="Large F" />
-				<Frame UV="0,132" Name="Tree Trunk" Variety="Large A" />
-				<Frame UV="22,132" Name="Tree Base" Variety="Plain A" Anchor="Left" />
-				<Frame UV="44,132" Name="Tree Base" Variety="Plain A" Anchor="Right" />
-				<Frame UV="66,132" Name="Tree Trunk" Variety="Large B" />
-				<Frame UV="88,132" Name="Tree Trunk" Variety="Large C" />
-				<Frame UV="132,132" Name="Tree Top" Variety="Small Double Slight Bulge A" />
-				<Frame UV="154,132" Name="Tree Top" Variety="Huge A" />
-				<Frame UV="0,154" Name="Tree Trunk" Variety="Large D" />
-				<Frame UV="22,154" Name="Tree Base" Variety="Plain B" Anchor="Left" />
-				<Frame UV="44,154" Name="Tree Base" Variety="Plain B" Anchor="Right" />
-				<Frame UV="66,154" Name="Tree Trunk" Variety="Large E" />
-				<Frame UV="88,154" Name="Tree Trunk" Variety="Large F" />
-				<Frame UV="132,154" Name="Tree Top" Variety="Small Double Slight Bulge B" />
-				<Frame UV="154,154" Name="Tree Top" Variety="Huge B" />
-				<Frame UV="0,176" Name="Tree Trunk" Variety="Large G" />
-				<Frame UV="22,176" Name="Tree Base" Variety="Plain C" Anchor="Left" />
-				<Frame UV="44,176" Name="Tree Base" Variety="Plain C" Anchor="Right" />
-				<Frame UV="66,176" Name="Tree Trunk" Variety="Large H" />
-				<Frame UV="88,176" Name="Tree Trunk" Variety="Large I" />
-				<Frame UV="132,176" Name="Tree Top" Variety="Small Double Slight Bulge C" />
-				<Frame UV="154,176" Name="Tree Top" Variety="Huge C" />
-				<Frame UV="0,198" Name="Tree Top" Variety="Jagged A" />
-				<Frame UV="0,220" Name="Tree Top" Variety="Jagged B" />
-				<Frame UV="0,242" Name="Tree Top" Variety="Jagged C" />
-				<Frame UV="22,198" Name="Tree Top" Variety="Leafy A (No Sprite)" />
-				<Frame UV="22,220" Name="Tree Top" Variety="Leafy B (No Sprite)" />
-				<Frame UV="22,242" Name="Tree Top" Variety="Leafy C (No Sprite)" />
-				<Frame UV="44,198" Name="Tree Branch" Variety="Left Leafy A (No Sprite)" />
-				<Frame UV="44,220" Name="Tree Branch" Variety="Left Leafy B (No Sprite)" />
-				<Frame UV="44,242" Name="Tree Branch" Variety="Left Leafy C (No Sprite)" />
-				<Frame UV="66,198" Name="Tree Branch" Variety="Right Leafy A (No Sprite)" />
-				<Frame UV="66,220" Name="Tree Branch" Variety="Right Leafy B (No Sprite)" />
-				<Frame UV="66,242" Name="Tree Branch" Variety="Right Leafy C (No Sprite)" />				
-				<Frame UV="176,0" Name="Corrupt Tree Trunk" Variety="Plain A" />
-				<Frame UV="198,0" Name="Corrupt Tree Trunk" Variety="Right Indent A" />
-				<Frame UV="220,0" Name="Corrupt Tree Trunk" Variety="Right Slight Bulge A" />
-				<Frame UV="242,0" Name="Corrupt Tree Branch" Variety="Plain A" Anchor="Right" />
-				<Frame UV="264,0" Name="Corrupt Tree Trunk" Variety="Left Slight Bulge A" />
-				<Frame UV="286,0" Name="Corrupt Tree Top" Variety="Medium A" />
-				<Frame UV="308,0" Name="Corrupt Tree Top" Variety="Small A" />
-				<Frame UV="330,0" Name="Corrupt Tree Top" Variety="Large A" />
-				<Frame UV="176,22" Name="Corrupt Tree Trunk" Variety="Plain B" />
-				<Frame UV="198,22" Name="Corrupt Tree Trunk" Variety="Right Indent B" />
-				<Frame UV="220,22" Name="Corrupt Tree Trunk" Variety="Right Slight Bulge B" />
-				<Frame UV="242,22" Name="Corrupt Tree Branch" Variety="Plain B" Anchor="Right" />
-				<Frame UV="264,22" Name="Corrupt Tree Trunk" Variety="Left Slight Bulge B" />
-				<Frame UV="286,22" Name="Corrupt Tree Top" Variety="Medium B" />
-				<Frame UV="308,22" Name="Corrupt Tree Top" Variety="Small B" />
-				<Frame UV="330,22" Name="Corrupt Tree Top" Variety="Large B" />
-				<Frame UV="176,44" Name="Corrupt Tree Trunk" Variety="Plain C" />
-				<Frame UV="198,44" Name="Corrupt Tree Trunk" Variety="Right Indent C" />
-				<Frame UV="220,44" Name="Corrupt Tree Trunk" Variety="Right Slight Bulge C" />
-				<Frame UV="242,44" Name="Corrupt Tree Branch" Variety="Plain C" Anchor="Right" />
-				<Frame UV="264,44" Name="Corrupt Tree Trunk" Variety="Left Slight Bulge C" />
-				<Frame UV="286,44" Name="Corrupt Tree Top" Variety="Medium C" />
-				<Frame UV="308,44" Name="Corrupt Tree Top" Variety="Small C" />
-				<Frame UV="330,44" Name="Corrupt Tree Top" Variety="Large C" />
-				<Frame UV="176,66" Name="Corrupt Tree Trunk" Variety="Left Indent A" />
-				<Frame UV="198,66" Name="Corrupt Tree Trunk" Variety="Right Bulge A" />
-				<Frame UV="220,66" Name="Corrupt Tree Trunk" Variety="Left Bulge A" />
-				<Frame UV="242,66" Name="Corrupt Tree Trunk" Variety="Right Slight Bulge D" />
-				<Frame UV="264,66" Name="Corrupt Tree Branch" Variety="Plain A" Anchor="Left" />
-				<Frame UV="286,66" Name="Corrupt Tree Trunk" Variety="Double Slight Bulge A" />
-				<Frame UV="308,66" Name="Corrupt Tree Top" Variety="Small Right Slight Bulge A" />
-				<Frame UV="330,66" Name="Corrupt Tree Top" Variety="Large D" />
-				<Frame UV="176,88" Name="Corrupt Tree Trunk" Variety="Left Indent B" />
-				<Frame UV="198,88" Name="Corrupt Tree Trunk" Variety="Right Bulge B" />
-				<Frame UV="220,88" Name="Corrupt Tree Trunk" Variety="Left Bulge B" />
-				<Frame UV="242,88" Name="Corrupt Tree Trunk" Variety="Right Slight Bulge E" />
-				<Frame UV="264,88" Name="Corrupt Tree Branch" Variety="Plain B" Anchor="Left" />
-				<Frame UV="286,88" Name="Corrupt Tree Trunk" Variety="Double Slight Bulge B" />
-				<Frame UV="308,88" Name="Corrupt Tree Top" Variety="Small Right Slight Bulge B" />
-				<Frame UV="330,88" Name="Corrupt Tree Top" Variety="Large E" />
-				<Frame UV="176,110" Name="Corrupt Tree Trunk" Variety="Left Indent C" />
-				<Frame UV="198,110" Name="Corrupt Tree Trunk" Variety="Right Bulge C" />
-				<Frame UV="220,110" Name="Corrupt Tree Trunk" Variety="Left Bulge C" />
-				<Frame UV="242,110" Name="Corrupt Tree Trunk" Variety="Right Slight Bulge F" />
-				<Frame UV="264,110" Name="Corrupt Tree Branch" Variety="Plain C" Anchor="Left" />
-				<Frame UV="286,110" Name="Corrupt Tree Trunk" Variety="Double Slight Bulge C" />
-				<Frame UV="308,110" Name="Corrupt Tree Top" Variety="Small Right Slight Bulge C" />
-				<Frame UV="330,110" Name="Corrupt Tree Top" Variety="Large F" />
-				<Frame UV="176,132" Name="Corrupt Tree Trunk" Variety="Large A" />
-				<Frame UV="198,132" Name="Corrupt Tree Base" Variety="Plain A" Anchor="Left" />
-				<Frame UV="220,132" Name="Corrupt Tree Base" Variety="Plain A" Anchor="Right" />
-				<Frame UV="242,132" Name="Corrupt Tree Trunk" Variety="Large B" />
-				<Frame UV="264,132" Name="Corrupt Tree Trunk" Variety="Large C" />
-				<Frame UV="308,132" Name="Corrupt Tree Top" Variety="Small Double Slight Bulge A" />
-				<Frame UV="330,132" Name="Corrupt Tree Top" Variety="Huge A" />
-				<Frame UV="176,154" Name="Corrupt Tree Trunk" Variety="Large D" />
-				<Frame UV="198,154" Name="Corrupt Tree Base" Variety="Plain B" Anchor="Left" />
-				<Frame UV="220,154" Name="Corrupt Tree Base" Variety="Plain B" Anchor="Right" />
-				<Frame UV="242,154" Name="Corrupt Tree Trunk" Variety="Large E" />
-				<Frame UV="264,154" Name="Corrupt Tree Trunk" Variety="Large F" />
-				<Frame UV="308,154" Name="Corrupt Tree Top" Variety="Small Double Slight Bulge B" />
-				<Frame UV="330,154" Name="Corrupt Tree Top" Variety="Huge B" />
-				<Frame UV="176,176" Name="Corrupt Tree Trunk" Variety="Large G" />
-				<Frame UV="198,176" Name="Corrupt Tree Base" Variety="Plain C" Anchor="Left" />
-				<Frame UV="220,176" Name="Corrupt Tree Base" Variety="Plain C" Anchor="Right" />
-				<Frame UV="242,176" Name="Corrupt Tree Trunk" Variety="Large H" />
-				<Frame UV="264,176" Name="Corrupt Tree Trunk" Variety="Large I" />
-				<Frame UV="308,176" Name="Corrupt Tree Top" Variety="Small Double Slight Bulge C" />
-				<Frame UV="330,176" Name="Corrupt Tree Top" Variety="Huge C" />
-				<Frame UV="176,198" Name="Corrupt Tree Top" Variety="Jagged A" />
-				<Frame UV="176,220" Name="Corrupt Tree Top" Variety="Jagged B" />
-				<Frame UV="176,242" Name="Corrupt Tree Top" Variety="Jagged C" />				
-				<Frame UV="352,0" Name="Jungle Tree Trunk" Variety="Plain A" />
-				<Frame UV="374,0" Name="Jungle Tree Trunk" Variety="Right Indent A" />
-				<Frame UV="396,0" Name="Jungle Tree Trunk" Variety="Right Slight Bulge A" />
-				<Frame UV="418,0" Name="Jungle Tree Branch" Variety="Plain A" Anchor="Right" />
-				<Frame UV="440,0" Name="Jungle Tree Trunk" Variety="Left Slight Bulge A" />
-				<Frame UV="462,0" Name="Jungle Tree Top" Variety="Medium A" />
-				<Frame UV="484,0" Name="Jungle Tree Top" Variety="Small A" />
-				<Frame UV="506,0" Name="Jungle Tree Top" Variety="Large A" />
-				<Frame UV="352,22" Name="Jungle Tree Trunk" Variety="Plain B" />
-				<Frame UV="374,22" Name="Jungle Tree Trunk" Variety="Right Indent B" />
-				<Frame UV="396,22" Name="Jungle Tree Trunk" Variety="Right Slight Bulge B" />
-				<Frame UV="418,22" Name="Jungle Tree Branch" Variety="Plain B" Anchor="Right" />
-				<Frame UV="440,22" Name="Jungle Tree Trunk" Variety="Left Slight Bulge B" />
-				<Frame UV="462,22" Name="Jungle Tree Top" Variety="Medium B" />
-				<Frame UV="484,22" Name="Jungle Tree Top" Variety="Small B" />
-				<Frame UV="506,22" Name="Jungle Tree Top" Variety="Large B" />
-				<Frame UV="352,44" Name="Jungle Tree Trunk" Variety="Plain C" />
-				<Frame UV="374,44" Name="Jungle Tree Trunk" Variety="Right Indent C" />
-				<Frame UV="396,44" Name="Jungle Tree Trunk" Variety="Right Slight Bulge C" />
-				<Frame UV="418,44" Name="Jungle Tree Branch" Variety="Plain C" Anchor="Right" />
-				<Frame UV="440,44" Name="Jungle Tree Trunk" Variety="Left Slight Bulge C" />
-				<Frame UV="462,44" Name="Jungle Tree Top" Variety="Medium C" />
-				<Frame UV="484,44" Name="Jungle Tree Top" Variety="Small C" />
-				<Frame UV="506,44" Name="Jungle Tree Top" Variety="Large C" />
-				<Frame UV="352,66" Name="Jungle Tree Trunk" Variety="Left Indent A" />
-				<Frame UV="374,66" Name="Jungle Tree Trunk" Variety="Right Bulge A" />
-				<Frame UV="396,66" Name="Jungle Tree Trunk" Variety="Left Bulge A" />
-				<Frame UV="418,66" Name="Jungle Tree Trunk" Variety="Right Slight Bulge D" />
-				<Frame UV="440,66" Name="Jungle Tree Branch" Variety="Plain A" Anchor="Left" />
-				<Frame UV="462,66" Name="Jungle Tree Trunk" Variety="Double Slight Bulge A" />
-				<Frame UV="484,66" Name="Jungle Tree Top" Variety="Small Right Slight Bulge A" />
-				<Frame UV="506,66" Name="Jungle Tree Top" Variety="Large D" />
-				<Frame UV="352,88" Name="Jungle Tree Trunk" Variety="Left Indent B" />
-				<Frame UV="374,88" Name="Jungle Tree Trunk" Variety="Right Bulge B" />
-				<Frame UV="396,88" Name="Jungle Tree Trunk" Variety="Left Bulge B" />
-				<Frame UV="418,88" Name="Jungle Tree Trunk" Variety="Right Slight Bulge E" />
-				<Frame UV="440,88" Name="Jungle Tree Branch" Variety="Plain B" Anchor="Left" />
-				<Frame UV="462,88" Name="Jungle Tree Trunk" Variety="Double Slight Bulge B" />
-				<Frame UV="484,88" Name="Jungle Tree Top" Variety="Small Right Slight Bulge B" />
-				<Frame UV="506,88" Name="Jungle Tree Top" Variety="Large E" />
-				<Frame UV="352,110" Name="Jungle Tree Trunk" Variety="Left Indent C" />
-				<Frame UV="374,110" Name="Jungle Tree Trunk" Variety="Right Bulge C" />
-				<Frame UV="396,110" Name="Jungle Tree Trunk" Variety="Left Bulge C" />
-				<Frame UV="418,110" Name="Jungle Tree Trunk" Variety="Right Slight Bulge F" />
-				<Frame UV="440,110" Name="Jungle Tree Branch" Variety="Plain C" Anchor="Left" />
-				<Frame UV="462,110" Name="Jungle Tree Trunk" Variety="Double Slight Bulge C" />
-				<Frame UV="484,110" Name="Jungle Tree Top" Variety="Small Right Slight Bulge C" />
-				<Frame UV="506,110" Name="Jungle Tree Top" Variety="Large F" />
-				<Frame UV="352,132" Name="Jungle Tree Trunk" Variety="Large A" />
-				<Frame UV="374,132" Name="Jungle Tree Base" Variety="Plain A" Anchor="Left" />
-				<Frame UV="396,132" Name="Jungle Tree Base" Variety="Plain A" Anchor="Right" />
-				<Frame UV="418,132" Name="Jungle Tree Trunk" Variety="Large B" />
-				<Frame UV="440,132" Name="Jungle Tree Trunk" Variety="Large C" />
-				<Frame UV="484,132" Name="Jungle Tree Top" Variety="Small Double Slight Bulge A" />
-				<Frame UV="506,132" Name="Jungle Tree Top" Variety="Huge A" />
-				<Frame UV="352,154" Name="Jungle Tree Trunk" Variety="Large D" />
-				<Frame UV="374,154" Name="Jungle Tree Base" Variety="Plain B" Anchor="Left" />
-				<Frame UV="396,154" Name="Jungle Tree Base" Variety="Plain B" Anchor="Right" />
-				<Frame UV="418,154" Name="Jungle Tree Trunk" Variety="Large E" />
-				<Frame UV="440,154" Name="Jungle Tree Trunk" Variety="Large F" />
-				<Frame UV="484,154" Name="Jungle Tree Top" Variety="Small Double Slight Bulge B" />
-				<Frame UV="506,154" Name="Jungle Tree Top" Variety="Huge B" />
-				<Frame UV="352,176" Name="Jungle Tree Trunk" Variety="Large G" />
-				<Frame UV="374,176" Name="Jungle Tree Base" Variety="Plain C" Anchor="Left" />
-				<Frame UV="396,176" Name="Jungle Tree Base" Variety="Plain C" Anchor="Right" />
-				<Frame UV="418,176" Name="Jungle Tree Trunk" Variety="Large H" />
-				<Frame UV="440,176" Name="Jungle Tree Trunk" Variety="Large I" />
-				<Frame UV="484,176" Name="Jungle Tree Top" Variety="Small Double Slight Bulge C" />
-				<Frame UV="506,176" Name="Jungle Tree Top" Variety="Huge C" />
-				<Frame UV="352,198" Name="Jungle Tree Top" Variety="Jagged A" />
-				<Frame UV="352,220" Name="Jungle Tree Top" Variety="Jagged B" />
-				<Frame UV="352,242" Name="Jungle Tree Top" Variety="Jagged C" />				
-				<Frame UV="528,0" Name="Hallow Tree Trunk" Variety="Plain A" />
-				<Frame UV="550,0" Name="Hallow Tree Trunk" Variety="Right Indent A" />
-				<Frame UV="572,0" Name="Hallow Tree Trunk" Variety="Right Slight Bulge A" />
-				<Frame UV="594,0" Name="Hallow Tree Branch" Variety="Plain A" Anchor="Right" />
-				<Frame UV="616,0" Name="Hallow Tree Trunk" Variety="Left Slight Bulge A" />
-				<Frame UV="638,0" Name="Hallow Tree Top" Variety="Medium A" />
-				<Frame UV="660,0" Name="Hallow Tree Top" Variety="Small A" />
-				<Frame UV="682,0" Name="Hallow Tree Top" Variety="Large A" />
-				<Frame UV="528,22" Name="Hallow Tree Trunk" Variety="Plain B" />
-				<Frame UV="550,22" Name="Hallow Tree Trunk" Variety="Right Indent B" />
-				<Frame UV="572,22" Name="Hallow Tree Trunk" Variety="Right Slight Bulge B" />
-				<Frame UV="594,22" Name="Hallow Tree Branch" Variety="Plain B" Anchor="Right" />
-				<Frame UV="616,22" Name="Hallow Tree Trunk" Variety="Left Slight Bulge B" />
-				<Frame UV="638,22" Name="Hallow Tree Top" Variety="Medium B" />
-				<Frame UV="660,22" Name="Hallow Tree Top" Variety="Small B" />
-				<Frame UV="682,22" Name="Hallow Tree Top" Variety="Large B" />
-				<Frame UV="528,44" Name="Hallow Tree Trunk" Variety="Plain C" />
-				<Frame UV="550,44" Name="Hallow Tree Trunk" Variety="Right Indent C" />
-				<Frame UV="572,44" Name="Hallow Tree Trunk" Variety="Right Slight Bulge C" />
-				<Frame UV="594,44" Name="Hallow Tree Branch" Variety="Plain C" Anchor="Right" />
-				<Frame UV="616,44" Name="Hallow Tree Trunk" Variety="Left Slight Bulge C" />
-				<Frame UV="638,44" Name="Hallow Tree Top" Variety="Medium C" />
-				<Frame UV="660,44" Name="Hallow Tree Top" Variety="Small C" />
-				<Frame UV="682,44" Name="Hallow Tree Top" Variety="Large C" />
-				<Frame UV="528,66" Name="Hallow Tree Trunk" Variety="Left Indent A" />
-				<Frame UV="550,66" Name="Hallow Tree Trunk" Variety="Right Bulge A" />
-				<Frame UV="572,66" Name="Hallow Tree Trunk" Variety="Left Bulge A" />
-				<Frame UV="594,66" Name="Hallow Tree Trunk" Variety="Right Slight Bulge D" />
-				<Frame UV="616,66" Name="Hallow Tree Branch" Variety="Plain A" Anchor="Left" />
-				<Frame UV="638,66" Name="Hallow Tree Trunk" Variety="Double Slight Bulge A" />
-				<Frame UV="660,66" Name="Hallow Tree Top" Variety="Small Right Slight Bulge A" />
-				<Frame UV="682,66" Name="Hallow Tree Top" Variety="Large D" />
-				<Frame UV="528,88" Name="Hallow Tree Trunk" Variety="Left Indent B" />
-				<Frame UV="550,88" Name="Hallow Tree Trunk" Variety="Right Bulge B" />
-				<Frame UV="572,88" Name="Hallow Tree Trunk" Variety="Left Bulge B" />
-				<Frame UV="594,88" Name="Hallow Tree Trunk" Variety="Right Slight Bulge E" />
-				<Frame UV="616,88" Name="Hallow Tree Branch" Variety="Plain B" Anchor="Left" />
-				<Frame UV="638,88" Name="Hallow Tree Trunk" Variety="Double Slight Bulge B" />
-				<Frame UV="660,88" Name="Hallow Tree Top" Variety="Small Right Slight Bulge B" />
-				<Frame UV="682,88" Name="Hallow Tree Top" Variety="Large E" />
-				<Frame UV="528,110" Name="Hallow Tree Trunk" Variety="Left Indent C" />
-				<Frame UV="550,110" Name="Hallow Tree Trunk" Variety="Right Bulge C" />
-				<Frame UV="572,110" Name="Hallow Tree Trunk" Variety="Left Bulge C" />
-				<Frame UV="594,110" Name="Hallow Tree Trunk" Variety="Right Slight Bulge F" />
-				<Frame UV="616,110" Name="Hallow Tree Branch" Variety="Plain C" Anchor="Left" />
-				<Frame UV="638,110" Name="Hallow Tree Trunk" Variety="Double Slight Bulge C" />
-				<Frame UV="660,110" Name="Hallow Tree Top" Variety="Small Right Slight Bulge C" />
-				<Frame UV="682,110" Name="Hallow Tree Top" Variety="Large F" />
-				<Frame UV="528,132" Name="Hallow Tree Trunk" Variety="Large A" />
-				<Frame UV="550,132" Name="Hallow Tree Base" Variety="Plain A" Anchor="Left" />
-				<Frame UV="572,132" Name="Hallow Tree Base" Variety="Plain A" Anchor="Right" />
-				<Frame UV="594,132" Name="Hallow Tree Trunk" Variety="Large B" />
-				<Frame UV="616,132" Name="Hallow Tree Trunk" Variety="Large C" />
-				<Frame UV="660,132" Name="Hallow Tree Top" Variety="Small Double Slight Bulge A" />
-				<Frame UV="682,132" Name="Hallow Tree Top" Variety="Huge A" />
-				<Frame UV="528,154" Name="Hallow Tree Trunk" Variety="Large D" />
-				<Frame UV="550,154" Name="Hallow Tree Base" Variety="Plain B" Anchor="Left" />
-				<Frame UV="572,154" Name="Hallow Tree Base" Variety="Plain B" Anchor="Right" />
-				<Frame UV="594,154" Name="Hallow Tree Trunk" Variety="Large E" />
-				<Frame UV="616,154" Name="Hallow Tree Trunk" Variety="Large F" />
-				<Frame UV="660,154" Name="Hallow Tree Top" Variety="Small Double Slight Bulge B" />
-				<Frame UV="682,154" Name="Hallow Tree Top" Variety="Huge B" />
-				<Frame UV="528,176" Name="Hallow Tree Trunk" Variety="Large G" />
-				<Frame UV="550,176" Name="Hallow Tree Base" Variety="Plain C" Anchor="Left" />
-				<Frame UV="572,176" Name="Hallow Tree Base" Variety="Plain C" Anchor="Right" />
-				<Frame UV="594,176" Name="Hallow Tree Trunk" Variety="Large H" />
-				<Frame UV="616,176" Name="Hallow Tree Trunk" Variety="Large I" />
-				<Frame UV="660,176" Name="Hallow Tree Top" Variety="Small Double Slight Bulge C" />
-				<Frame UV="682,176" Name="Hallow Tree Top" Variety="Huge C" />
-				<Frame UV="528,198" Name="Hallow Tree Top" Variety="Jagged A" />
-				<Frame UV="528,220" Name="Hallow Tree Top" Variety="Jagged B" />
-				<Frame UV="528,242" Name="Hallow Tree Top" Variety="Jagged C" />				
-				<Frame UV="704,0" Name="Boreal Tree Trunk" Variety="Plain A" />
-				<Frame UV="726,0" Name="Boreal Tree Trunk" Variety="Right Indent A" />
-				<Frame UV="748,0" Name="Boreal Tree Trunk" Variety="Right Slight Bulge A" />
-				<Frame UV="770,0" Name="Boreal Tree Branch" Variety="Plain A" Anchor="Right" />
-				<Frame UV="792,0" Name="Boreal Tree Trunk" Variety="Left Slight Bulge A" />
-				<Frame UV="814,0" Name="Boreal Tree Top" Variety="Medium A" />
-				<Frame UV="836,0" Name="Boreal Tree Top" Variety="Small A" />
-				<Frame UV="858,0" Name="Boreal Tree Top" Variety="Large A" />
-				<Frame UV="704,22" Name="Boreal Tree Trunk" Variety="Plain B" />
-				<Frame UV="726,22" Name="Boreal Tree Trunk" Variety="Right Indent B" />
-				<Frame UV="748,22" Name="Boreal Tree Trunk" Variety="Right Slight Bulge B" />
-				<Frame UV="770,22" Name="Boreal Tree Branch" Variety="Plain B" Anchor="Right" />
-				<Frame UV="792,22" Name="Boreal Tree Trunk" Variety="Left Slight Bulge B" />
-				<Frame UV="814,22" Name="Boreal Tree Top" Variety="Medium B" />
-				<Frame UV="836,22" Name="Boreal Tree Top" Variety="Small B" />
-				<Frame UV="858,22" Name="Boreal Tree Top" Variety="Large B" />
-				<Frame UV="704,44" Name="Boreal Tree Trunk" Variety="Plain C" />
-				<Frame UV="726,44" Name="Boreal Tree Trunk" Variety="Right Indent C" />
-				<Frame UV="748,44" Name="Boreal Tree Trunk" Variety="Right Slight Bulge C" />
-				<Frame UV="770,44" Name="Boreal Tree Branch" Variety="Plain C" Anchor="Right" />
-				<Frame UV="792,44" Name="Boreal Tree Trunk" Variety="Left Slight Bulge C" />
-				<Frame UV="814,44" Name="Boreal Tree Top" Variety="Medium C" />
-				<Frame UV="836,44" Name="Boreal Tree Top" Variety="Small C" />
-				<Frame UV="858,44" Name="Boreal Tree Top" Variety="Large C" />
-				<Frame UV="704,66" Name="Boreal Tree Trunk" Variety="Left Indent A" />
-				<Frame UV="726,66" Name="Boreal Tree Trunk" Variety="Right Bulge A" />
-				<Frame UV="748,66" Name="Boreal Tree Trunk" Variety="Left Bulge A" />
-				<Frame UV="770,66" Name="Boreal Tree Trunk" Variety="Right Slight Bulge D" />
-				<Frame UV="792,66" Name="Boreal Tree Branch" Variety="Plain A" Anchor="Left" />
-				<Frame UV="814,66" Name="Boreal Tree Trunk" Variety="Double Slight Bulge A" />
-				<Frame UV="836,66" Name="Boreal Tree Top" Variety="Small Right Slight Bulge A" />
-				<Frame UV="858,66" Name="Boreal Tree Top" Variety="Large D" />
-				<Frame UV="704,88" Name="Boreal Tree Trunk" Variety="Left Indent B" />
-				<Frame UV="726,88" Name="Boreal Tree Trunk" Variety="Right Bulge B" />
-				<Frame UV="748,88" Name="Boreal Tree Trunk" Variety="Left Bulge B" />
-				<Frame UV="770,88" Name="Boreal Tree Trunk" Variety="Right Slight Bulge E" />
-				<Frame UV="792,88" Name="Boreal Tree Branch" Variety="Plain B" Anchor="Left" />
-				<Frame UV="814,88" Name="Boreal Tree Trunk" Variety="Double Slight Bulge B" />
-				<Frame UV="836,88" Name="Boreal Tree Top" Variety="Small Right Slight Bulge B" />
-				<Frame UV="858,88" Name="Boreal Tree Top" Variety="Large E" />
-				<Frame UV="704,110" Name="Boreal Tree Trunk" Variety="Left Indent C" />
-				<Frame UV="726,110" Name="Boreal Tree Trunk" Variety="Right Bulge C" />
-				<Frame UV="748,110" Name="Boreal Tree Trunk" Variety="Left Bulge C" />
-				<Frame UV="770,110" Name="Boreal Tree Trunk" Variety="Right Slight Bulge F" />
-				<Frame UV="792,110" Name="Boreal Tree Branch" Variety="Plain C" Anchor="Left" />
-				<Frame UV="814,110" Name="Boreal Tree Trunk" Variety="Double Slight Bulge C" />
-				<Frame UV="836,110" Name="Boreal Tree Top" Variety="Small Right Slight Bulge C" />
-				<Frame UV="858,110" Name="Boreal Tree Top" Variety="Large F" />
-				<Frame UV="704,132" Name="Boreal Tree Trunk" Variety="Large A" />
-				<Frame UV="726,132" Name="Boreal Tree Base" Variety="Plain A" Anchor="Left" />
-				<Frame UV="748,132" Name="Boreal Tree Base" Variety="Plain A" Anchor="Right" />
-				<Frame UV="770,132" Name="Boreal Tree Trunk" Variety="Large B" />
-				<Frame UV="792,132" Name="Boreal Tree Trunk" Variety="Large C" />
-				<Frame UV="836,132" Name="Boreal Tree Top" Variety="Small Double Slight Bulge A" />
-				<Frame UV="858,132" Name="Boreal Tree Top" Variety="Huge A" />
-				<Frame UV="704,154" Name="Boreal Tree Trunk" Variety="Large D" />
-				<Frame UV="726,154" Name="Boreal Tree Base" Variety="Plain B" Anchor="Left" />
-				<Frame UV="748,154" Name="Boreal Tree Base" Variety="Plain B" Anchor="Right" />
-				<Frame UV="770,154" Name="Boreal Tree Trunk" Variety="Large E" />
-				<Frame UV="792,154" Name="Boreal Tree Trunk" Variety="Large F" />
-				<Frame UV="836,154" Name="Boreal Tree Top" Variety="Small Double Slight Bulge B" />
-				<Frame UV="858,154" Name="Boreal Tree Top" Variety="Huge B" />
-				<Frame UV="704,176" Name="Boreal Tree Trunk" Variety="Large G" />
-				<Frame UV="726,176" Name="Boreal Tree Base" Variety="Plain C" Anchor="Left" />
-				<Frame UV="748,176" Name="Boreal Tree Base" Variety="Plain C" Anchor="Right" />
-				<Frame UV="770,176" Name="Boreal Tree Trunk" Variety="Large H" />
-				<Frame UV="792,176" Name="Boreal Tree Trunk" Variety="Large I" />
-				<Frame UV="836,176" Name="Boreal Tree Top" Variety="Small Double Slight Bulge C" />
-				<Frame UV="858,176" Name="Boreal Tree Top" Variety="Huge C" />
-				<Frame UV="704,198" Name="Boreal Tree Top" Variety="Jagged A" />
-				<Frame UV="704,220" Name="Boreal Tree Top" Variety="Jagged B" />
-				<Frame UV="704,242" Name="Boreal Tree Top" Variety="Jagged C" />				
-				<Frame UV="880,0" Name="Crimson Tree Trunk" Variety="Plain A" />
-				<Frame UV="902,0" Name="Crimson Tree Trunk" Variety="Right Indent A" />
-				<Frame UV="924,0" Name="Crimson Tree Trunk" Variety="Right Slight Bulge A" />
-				<Frame UV="946,0" Name="Crimson Tree Branch" Variety="Plain A" Anchor="Right" />
-				<Frame UV="968,0" Name="Crimson Tree Trunk" Variety="Left Slight Bulge A" />
-				<Frame UV="990,0" Name="Crimson Tree Top" Variety="Medium A" />
-				<Frame UV="1012,0" Name="Crimson Tree Top" Variety="Small A" />
-				<Frame UV="1034,0" Name="Crimson Tree Top" Variety="Large A" />
-				<Frame UV="880,22" Name="Crimson Tree Trunk" Variety="Plain B" />
-				<Frame UV="902,22" Name="Crimson Tree Trunk" Variety="Right Indent B" />
-				<Frame UV="924,22" Name="Crimson Tree Trunk" Variety="Right Slight Bulge B" />
-				<Frame UV="946,22" Name="Crimson Tree Branch" Variety="Plain B" Anchor="Right" />
-				<Frame UV="968,22" Name="Crimson Tree Trunk" Variety="Left Slight Bulge B" />
-				<Frame UV="990,22" Name="Crimson Tree Top" Variety="Medium B" />
-				<Frame UV="1012,22" Name="Crimson Tree Top" Variety="Small B" />
-				<Frame UV="1034,22" Name="Crimson Tree Top" Variety="Large B" />
-				<Frame UV="880,44" Name="Crimson Tree Trunk" Variety="Plain C" />
-				<Frame UV="902,44" Name="Crimson Tree Trunk" Variety="Right Indent C" />
-				<Frame UV="924,44" Name="Crimson Tree Trunk" Variety="Right Slight Bulge C" />
-				<Frame UV="946,44" Name="Crimson Tree Branch" Variety="Plain C" Anchor="Right" />
-				<Frame UV="968,44" Name="Crimson Tree Trunk" Variety="Left Slight Bulge C" />
-				<Frame UV="990,44" Name="Crimson Tree Top" Variety="Medium C" />
-				<Frame UV="1012,44" Name="Crimson Tree Top" Variety="Small C" />
-				<Frame UV="1034,44" Name="Crimson Tree Top" Variety="Large C" />
-				<Frame UV="880,66" Name="Crimson Tree Trunk" Variety="Left Indent A" />
-				<Frame UV="902,66" Name="Crimson Tree Trunk" Variety="Right Bulge A" />
-				<Frame UV="924,66" Name="Crimson Tree Trunk" Variety="Left Bulge A" />
-				<Frame UV="946,66" Name="Crimson Tree Trunk" Variety="Right Slight Bulge D" />
-				<Frame UV="968,66" Name="Crimson Tree Branch" Variety="Plain A" Anchor="Left" />
-				<Frame UV="990,66" Name="Crimson Tree Trunk" Variety="Double Slight Bulge A" />
-				<Frame UV="1012,66" Name="Crimson Tree Top" Variety="Small Right Slight Bulge A" />
-				<Frame UV="1034,66" Name="Crimson Tree Top" Variety="Large D" />
-				<Frame UV="880,88" Name="Crimson Tree Trunk" Variety="Left Indent B" />
-				<Frame UV="902,88" Name="Crimson Tree Trunk" Variety="Right Bulge B" />
-				<Frame UV="924,88" Name="Crimson Tree Trunk" Variety="Left Bulge B" />
-				<Frame UV="946,88" Name="Crimson Tree Trunk" Variety="Right Slight Bulge E" />
-				<Frame UV="968,88" Name="Crimson Tree Branch" Variety="Plain B" Anchor="Left" />
-				<Frame UV="990,88" Name="Crimson Tree Trunk" Variety="Double Slight Bulge B" />
-				<Frame UV="1012,88" Name="Crimson Tree Top" Variety="Small Right Slight Bulge B" />
-				<Frame UV="1034,88" Name="Crimson Tree Top" Variety="Large E" />
-				<Frame UV="880,110" Name="Crimson Tree Trunk" Variety="Left Indent C" />
-				<Frame UV="902,110" Name="Crimson Tree Trunk" Variety="Right Bulge C" />
-				<Frame UV="924,110" Name="Crimson Tree Trunk" Variety="Left Bulge C" />
-				<Frame UV="946,110" Name="Crimson Tree Trunk" Variety="Right Slight Bulge F" />
-				<Frame UV="968,110" Name="Crimson Tree Branch" Variety="Plain C" Anchor="Left" />
-				<Frame UV="990,110" Name="Crimson Tree Trunk" Variety="Double Slight Bulge C" />
-				<Frame UV="1012,110" Name="Crimson Tree Top" Variety="Small Right Slight Bulge C" />
-				<Frame UV="1034,110" Name="Crimson Tree Top" Variety="Large F" />
-				<Frame UV="880,132" Name="Crimson Tree Trunk" Variety="Large A" />
-				<Frame UV="902,132" Name="Crimson Tree Base" Variety="Plain A" Anchor="Left" />
-				<Frame UV="924,132" Name="Crimson Tree Base" Variety="Plain A" Anchor="Right" />
-				<Frame UV="946,132" Name="Crimson Tree Trunk" Variety="Large B" />
-				<Frame UV="968,132" Name="Crimson Tree Trunk" Variety="Large C" />
-				<Frame UV="1012,132" Name="Crimson Tree Top" Variety="Small Double Slight Bulge A" />
-				<Frame UV="1034,132" Name="Crimson Tree Top" Variety="Huge A" />
-				<Frame UV="880,154" Name="Crimson Tree Trunk" Variety="Large D" />
-				<Frame UV="902,154" Name="Crimson Tree Base" Variety="Plain B" Anchor="Left" />
-				<Frame UV="924,154" Name="Crimson Tree Base" Variety="Plain B" Anchor="Right" />
-				<Frame UV="946,154" Name="Crimson Tree Trunk" Variety="Large E" />
-				<Frame UV="968,154" Name="Crimson Tree Trunk" Variety="Large F" />
-				<Frame UV="1012,154" Name="Crimson Tree Top" Variety="Small Double Slight Bulge B" />
-				<Frame UV="1034,154" Name="Crimson Tree Top" Variety="Huge B" />
-				<Frame UV="880,176" Name="Crimson Tree Trunk" Variety="Large G" />
-				<Frame UV="902,176" Name="Crimson Tree Base" Variety="Plain C" Anchor="Left" />
-				<Frame UV="924,176" Name="Crimson Tree Base" Variety="Plain C" Anchor="Right" />
-				<Frame UV="946,176" Name="Crimson Tree Trunk" Variety="Large H" />
-				<Frame UV="968,176" Name="Crimson Tree Trunk" Variety="Large I" />
-				<Frame UV="1012,176" Name="Crimson Tree Top" Variety="Small Double Slight Bulge C" />
-				<Frame UV="1034,176" Name="Crimson Tree Top" Variety="Huge C" />
-				<Frame UV="880,198" Name="Crimson Tree Top" Variety="Jagged A" />
-				<Frame UV="880,220" Name="Crimson Tree Top" Variety="Jagged B" />
-				<Frame UV="880,242" Name="Crimson Tree Top" Variety="Jagged C" />				
-				<Frame UV="1056,0" Name="Underground Jungle Tree Trunk" Variety="Plain A" />
-				<Frame UV="1078,0" Name="Underground Jungle Tree Trunk" Variety="Right Indent A" />
-				<Frame UV="1100,0" Name="Underground Jungle Tree Trunk" Variety="Right Slight Bulge A" />
-				<Frame UV="1122,0" Name="Underground Jungle Tree Branch" Variety="Plain A" Anchor="Right" />
-				<Frame UV="1144,0" Name="Underground Jungle Tree Trunk" Variety="Left Slight Bulge A" />
-				<Frame UV="1166,0" Name="Underground Jungle Tree Top" Variety="Medium A" />
-				<Frame UV="1188,0" Name="Underground Jungle Tree Top" Variety="Small A" />
-				<Frame UV="1210,0" Name="Underground Jungle Tree Top" Variety="Large A" />
-				<Frame UV="1056,22" Name="Underground Jungle Tree Trunk" Variety="Plain B" />
-				<Frame UV="1078,22" Name="Underground Jungle Tree Trunk" Variety="Right Indent B" />
-				<Frame UV="1100,22" Name="Underground Jungle Tree Trunk" Variety="Right Slight Bulge B" />
-				<Frame UV="1122,22" Name="Underground Jungle Tree Branch" Variety="Plain B" Anchor="Right" />
-				<Frame UV="1144,22" Name="Underground Jungle Tree Trunk" Variety="Left Slight Bulge B" />
-				<Frame UV="1166,22" Name="Underground Jungle Tree Top" Variety="Medium B" />
-				<Frame UV="1188,22" Name="Underground Jungle Tree Top" Variety="Small B" />
-				<Frame UV="1210,22" Name="Underground Jungle Tree Top" Variety="Large B" />
-				<Frame UV="1056,44" Name="Underground Jungle Tree Trunk" Variety="Plain C" />
-				<Frame UV="1078,44" Name="Underground Jungle Tree Trunk" Variety="Right Indent C" />
-				<Frame UV="1100,44" Name="Underground Jungle Tree Trunk" Variety="Right Slight Bulge C" />
-				<Frame UV="1122,44" Name="Underground Jungle Tree Branch" Variety="Plain C" Anchor="Right" />
-				<Frame UV="1144,44" Name="Underground Jungle Tree Trunk" Variety="Left Slight Bulge C" />
-				<Frame UV="1166,44" Name="Underground Jungle Tree Top" Variety="Medium C" />
-				<Frame UV="1188,44" Name="Underground Jungle Tree Top" Variety="Small C" />
-				<Frame UV="1210,44" Name="Underground Jungle Tree Top" Variety="Large C" />
-				<Frame UV="1056,66" Name="Underground Jungle Tree Trunk" Variety="Left Indent A" />
-				<Frame UV="1078,66" Name="Underground Jungle Tree Trunk" Variety="Right Bulge A" />
-				<Frame UV="1100,66" Name="Underground Jungle Tree Trunk" Variety="Left Bulge A" />
-				<Frame UV="1122,66" Name="Underground Jungle Tree Trunk" Variety="Right Slight Bulge D" />
-				<Frame UV="1144,66" Name="Underground Jungle Tree Branch" Variety="Plain A" Anchor="Left" />
-				<Frame UV="1166,66" Name="Underground Jungle Tree Trunk" Variety="Double Slight Bulge A" />
-				<Frame UV="1188,66" Name="Underground Jungle Tree Top" Variety="Small Right Slight Bulge A" />
-				<Frame UV="1210,66" Name="Underground Jungle Tree Top" Variety="Large D" />
-				<Frame UV="1056,88" Name="Underground Jungle Tree Trunk" Variety="Left Indent B" />
-				<Frame UV="1078,88" Name="Underground Jungle Tree Trunk" Variety="Right Bulge B" />
-				<Frame UV="1100,88" Name="Underground Jungle Tree Trunk" Variety="Left Bulge B" />
-				<Frame UV="1122,88" Name="Underground Jungle Tree Trunk" Variety="Right Slight Bulge E" />
-				<Frame UV="1144,88" Name="Underground Jungle Tree Branch" Variety="Plain B" Anchor="Left" />
-				<Frame UV="1166,88" Name="Underground Jungle Tree Trunk" Variety="Double Slight Bulge B" />
-				<Frame UV="1188,88" Name="Underground Jungle Tree Top" Variety="Small Right Slight Bulge B" />
-				<Frame UV="1210,88" Name="Underground Jungle Tree Top" Variety="Large E" />
-				<Frame UV="1056,110" Name="Underground Jungle Tree Trunk" Variety="Left Indent C" />
-				<Frame UV="1078,110" Name="Underground Jungle Tree Trunk" Variety="Right Bulge C" />
-				<Frame UV="1100,110" Name="Underground Jungle Tree Trunk" Variety="Left Bulge C" />
-				<Frame UV="1122,110" Name="Underground Jungle Tree Trunk" Variety="Right Slight Bulge F" />
-				<Frame UV="1144,110" Name="Underground Jungle Tree Branch" Variety="Plain C" Anchor="Left" />
-				<Frame UV="1166,110" Name="Underground Jungle Tree Trunk" Variety="Double Slight Bulge C" />
-				<Frame UV="1188,110" Name="Underground Jungle Tree Top" Variety="Small Right Slight Bulge C" />
-				<Frame UV="1210,110" Name="Underground Jungle Tree Top" Variety="Large F" />
-				<Frame UV="1056,132" Name="Underground Jungle Tree Trunk" Variety="Large A" />
-				<Frame UV="1078,132" Name="Underground Jungle Tree Base" Variety="Plain A" Anchor="Left" />
-				<Frame UV="1100,132" Name="Underground Jungle Tree Base" Variety="Plain A" Anchor="Right" />
-				<Frame UV="1122,132" Name="Underground Jungle Tree Trunk" Variety="Large B" />
-				<Frame UV="1144,132" Name="Underground Jungle Tree Trunk" Variety="Large C" />
-				<Frame UV="1188,132" Name="Underground Jungle Tree Top" Variety="Small Double Slight Bulge A" />
-				<Frame UV="1210,132" Name="Underground Jungle Tree Top" Variety="Huge A" />
-				<Frame UV="1056,154" Name="Underground Jungle Tree Trunk" Variety="Large D" />
-				<Frame UV="1078,154" Name="Underground Jungle Tree Base" Variety="Plain B" Anchor="Left" />
-				<Frame UV="1100,154" Name="Underground Jungle Tree Base" Variety="Plain B" Anchor="Right" />
-				<Frame UV="1122,154" Name="Underground Jungle Tree Trunk" Variety="Large E" />
-				<Frame UV="1144,154" Name="Underground Jungle Tree Trunk" Variety="Large F" />
-				<Frame UV="1188,154" Name="Underground Jungle Tree Top" Variety="Small Double Slight Bulge B" />
-				<Frame UV="1210,154" Name="Underground Jungle Tree Top" Variety="Huge B" />
-				<Frame UV="1056,176" Name="Underground Jungle Tree Trunk" Variety="Large G" />
-				<Frame UV="1078,176" Name="Underground Jungle Tree Base" Variety="Plain C" Anchor="Left" />
-				<Frame UV="1100,176" Name="Underground Jungle Tree Base" Variety="Plain C" Anchor="Right" />
-				<Frame UV="1122,176" Name="Underground Jungle Tree Trunk" Variety="Large H" />
-				<Frame UV="1144,176" Name="Underground Jungle Tree Trunk" Variety="Large I" />
-				<Frame UV="1188,176" Name="Underground Jungle Tree Top" Variety="Small Double Slight Bulge C" />
-				<Frame UV="1210,176" Name="Underground Jungle Tree Top" Variety="Huge C" />
-				<Frame UV="1056,198" Name="Underground Jungle Tree Top" Variety="Jagged A" />
-				<Frame UV="1056,220" Name="Underground Jungle Tree Top" Variety="Jagged B" />
-				<Frame UV="1056,242" Name="Underground Jungle Tree Top" Variety="Jagged C" />				
-				<Frame UV="1232,0" Name="Giant Glowing Tree Trunk" Variety="Plain A" />
-				<Frame UV="1254,0" Name="Giant Glowing Tree Trunk" Variety="Right Indent A" />
-				<Frame UV="1276,0" Name="Giant Glowing Tree Trunk" Variety="Right Slight Bulge A" />
-				<Frame UV="1298,0" Name="Giant Glowing Tree Branch" Variety="Plain A" Anchor="Right" />
-				<Frame UV="1320,0" Name="Giant Glowing Tree Trunk" Variety="Left Slight Bulge A" />
-				<Frame UV="1342,0" Name="Giant Glowing Tree Top" Variety="Medium A" />
-				<Frame UV="1364,0" Name="Giant Glowing Tree Top" Variety="Small A" />
-				<Frame UV="1386,0" Name="Giant Glowing Tree Top" Variety="Large A" />
-				<Frame UV="1232,22" Name="Giant Glowing Tree Trunk" Variety="Plain B" />
-				<Frame UV="1254,22" Name="Giant Glowing Tree Trunk" Variety="Right Indent B" />
-				<Frame UV="1276,22" Name="Giant Glowing Tree Trunk" Variety="Right Slight Bulge B" />
-				<Frame UV="1298,22" Name="Giant Glowing Tree Branch" Variety="Plain B" Anchor="Right" />
-				<Frame UV="1320,22" Name="Giant Glowing Tree Trunk" Variety="Left Slight Bulge B" />
-				<Frame UV="1342,22" Name="Giant Glowing Tree Top" Variety="Medium B" />
-				<Frame UV="1364,22" Name="Giant Glowing Tree Top" Variety="Small B" />
-				<Frame UV="1386,22" Name="Giant Glowing Tree Top" Variety="Large B" />
-				<Frame UV="1232,44" Name="Giant Glowing Tree Trunk" Variety="Plain C" />
-				<Frame UV="1254,44" Name="Giant Glowing Tree Trunk" Variety="Right Indent C" />
-				<Frame UV="1276,44" Name="Giant Glowing Tree Trunk" Variety="Right Slight Bulge C" />
-				<Frame UV="1298,44" Name="Giant Glowing Tree Branch" Variety="Plain C" Anchor="Right" />
-				<Frame UV="1320,44" Name="Giant Glowing Tree Trunk" Variety="Left Slight Bulge C" />
-				<Frame UV="1342,44" Name="Giant Glowing Tree Top" Variety="Medium C" />
-				<Frame UV="1364,44" Name="Giant Glowing Tree Top" Variety="Small C" />
-				<Frame UV="1386,44" Name="Giant Glowing Tree Top" Variety="Large C" />
-				<Frame UV="1232,66" Name="Giant Glowing Tree Trunk" Variety="Left Indent A" />
-				<Frame UV="1254,66" Name="Giant Glowing Tree Trunk" Variety="Right Bulge A" />
-				<Frame UV="1276,66" Name="Giant Glowing Tree Trunk" Variety="Left Bulge A" />
-				<Frame UV="1298,66" Name="Giant Glowing Tree Trunk" Variety="Right Slight Bulge D" />
-				<Frame UV="1320,66" Name="Giant Glowing Tree Branch" Variety="Plain A" Anchor="Left" />
-				<Frame UV="1342,66" Name="Giant Glowing Tree Trunk" Variety="Double Slight Bulge A" />
-				<Frame UV="1364,66" Name="Giant Glowing Tree Top" Variety="Small Right Slight Bulge A" />
-				<Frame UV="1386,66" Name="Giant Glowing Tree Top" Variety="Large D" />
-				<Frame UV="1232,88" Name="Giant Glowing Tree Trunk" Variety="Left Indent B" />
-				<Frame UV="1254,88" Name="Giant Glowing Tree Trunk" Variety="Right Bulge B" />
-				<Frame UV="1276,88" Name="Giant Glowing Tree Trunk" Variety="Left Bulge B" />
-				<Frame UV="1298,88" Name="Giant Glowing Tree Trunk" Variety="Right Slight Bulge E" />
-				<Frame UV="1320,88" Name="Giant Glowing Tree Branch" Variety="Plain B" Anchor="Left" />
-				<Frame UV="1342,88" Name="Giant Glowing Tree Trunk" Variety="Double Slight Bulge B" />
-				<Frame UV="1364,88" Name="Giant Glowing Tree Top" Variety="Small Right Slight Bulge B" />
-				<Frame UV="1386,88" Name="Giant Glowing Tree Top" Variety="Large E" />
-				<Frame UV="1232,110" Name="Giant Glowing Tree Trunk" Variety="Left Indent C" />
-				<Frame UV="1254,110" Name="Giant Glowing Tree Trunk" Variety="Right Bulge C" />
-				<Frame UV="1276,110" Name="Giant Glowing Tree Trunk" Variety="Left Bulge C" />
-				<Frame UV="1298,110" Name="Giant Glowing Tree Trunk" Variety="Right Slight Bulge F" />
-				<Frame UV="1320,110" Name="Giant Glowing Tree Branch" Variety="Plain C" Anchor="Left" />
-				<Frame UV="1342,110" Name="Giant Glowing Tree Trunk" Variety="Double Slight Bulge C" />
-				<Frame UV="1364,110" Name="Giant Glowing Tree Top" Variety="Small Right Slight Bulge C" />
-				<Frame UV="1386,110" Name="Giant Glowing Tree Top" Variety="Large F" />
-				<Frame UV="1232,132" Name="Giant Glowing Tree Trunk" Variety="Large A" />
-				<Frame UV="1254,132" Name="Giant Glowing Tree Base" Variety="Plain A" Anchor="Left" />
-				<Frame UV="1276,132" Name="Giant Glowing Tree Base" Variety="Plain A" Anchor="Right" />
-				<Frame UV="1298,132" Name="Giant Glowing Tree Trunk" Variety="Large B" />
-				<Frame UV="1320,132" Name="Giant Glowing Tree Trunk" Variety="Large C" />
-				<Frame UV="1364,132" Name="Giant Glowing Tree Top" Variety="Small Double Slight Bulge A" />
-				<Frame UV="1386,132" Name="Giant Glowing Tree Top" Variety="Huge A" />
-				<Frame UV="1232,154" Name="Giant Glowing Tree Trunk" Variety="Large D" />
-				<Frame UV="1254,154" Name="Giant Glowing Tree Base" Variety="Plain B" Anchor="Left" />
-				<Frame UV="1276,154" Name="Giant Glowing Tree Base" Variety="Plain B" Anchor="Right" />
-				<Frame UV="1298,154" Name="Giant Glowing Tree Trunk" Variety="Large E" />
-				<Frame UV="1320,154" Name="Giant Glowing Tree Trunk" Variety="Large F" />
-				<Frame UV="1364,154" Name="Giant Glowing Tree Top" Variety="Small Double Slight Bulge B" />
-				<Frame UV="1386,154" Name="Giant Glowing Tree Top" Variety="Huge B" />
-				<Frame UV="1232,176" Name="Giant Glowing Tree Trunk" Variety="Large G" />
-				<Frame UV="1254,176" Name="Giant Glowing Tree Base" Variety="Plain C" Anchor="Left" />
-				<Frame UV="1276,176" Name="Giant Glowing Tree Base" Variety="Plain C" Anchor="Right" />
-				<Frame UV="1298,176" Name="Giant Glowing Tree Trunk" Variety="Large H" />
-				<Frame UV="1320,176" Name="Giant Glowing Tree Trunk" Variety="Large I" />
-				<Frame UV="1364,176" Name="Giant Glowing Tree Top" Variety="Small Double Slight Bulge C" />
-				<Frame UV="1386,176" Name="Giant Glowing Tree Top" Variety="Huge C" />
-				<Frame UV="1232,198" Name="Giant Glowing Jungle Tree Top" Variety="Jagged A" />
-				<Frame UV="1232,220" Name="Giant Glowing Jungle Tree Top" Variety="Jagged B" />
-				<Frame UV="1232,242" Name="Giant Glowing Jungle Tree Top" Variety="Jagged C" />
+				<Frame UV="0,0" Name="Forest Tree" Variety="Trunk Plain A" />
+				<Frame UV="22,0" Name="Forest Tree" Variety="Trunk Right Indent A" />
+				<Frame UV="44,0" Name="Forest Tree" Variety="Trunk Right Slight Bulge A" />
+				<Frame UV="66,0" Name="Forest Tree" Variety="Branch Plain A" />
+				<Frame UV="88,0" Name="Forest Tree" Variety="Trunk Left Slight Bulge A" />
+				<Frame UV="110,0" Name="Forest Tree" Variety="Top Medium A" />
+				<Frame UV="132,0" Name="Forest Tree" Variety="Top Small A" />
+				<Frame UV="154,0" Name="Forest Tree" Variety="Top Large A" />
+				<Frame UV="0,22" Name="Forest Tree" Variety="Trunk Plain B" />
+				<Frame UV="22,22" Name="Forest Tree" Variety="Trunk Right Indent B" />
+				<Frame UV="44,22" Name="Forest Tree" Variety="Trunk Right Slight Bulge B" />
+				<Frame UV="66,22" Name="Forest Tree" Variety="Branch Plain B" />
+				<Frame UV="88,22" Name="Forest Tree" Variety="Trunk Left Slight Bulge B" />
+				<Frame UV="110,22" Name="Forest Tree" Variety="Top Medium B" />
+				<Frame UV="132,22" Name="Forest Tree" Variety="Top Small B" />
+				<Frame UV="154,22" Name="Forest Tree" Variety="Top Large B" />
+				<Frame UV="0,44" Name="Forest Tree" Variety="Trunk Plain C" />
+				<Frame UV="22,44" Name="Forest Tree" Variety="Trunk Right Indent C" />
+				<Frame UV="44,44" Name="Forest Tree" Variety="Trunk Right Slight Bulge C" />
+				<Frame UV="66,44" Name="Forest Tree" Variety="Branch Plain C" />
+				<Frame UV="88,44" Name="Forest Tree" Variety="Trunk Left Slight Bulge C" />
+				<Frame UV="110,44" Name="Forest Tree" Variety="Top Medium C" />
+				<Frame UV="132,44" Name="Forest Tree" Variety="Top Small C" />
+				<Frame UV="154,44" Name="Forest Tree" Variety="Top Large C" />
+				<Frame UV="0,66" Name="Forest Tree" Variety="Trunk Left Indent A" />
+				<Frame UV="22,66" Name="Forest Tree" Variety="Trunk Right Bulge A" />
+				<Frame UV="44,66" Name="Forest Tree" Variety="Trunk Left Bulge A" />
+				<Frame UV="66,66" Name="Forest Tree" Variety="Trunk Right Slight Bulge D" />
+				<Frame UV="88,66" Name="Forest Tree" Variety="Branch Plain A" />
+				<Frame UV="110,66" Name="Forest Tree" Variety="Trunk Double Slight Bulge A" />
+				<Frame UV="132,66" Name="Forest Tree" Variety="Top Small Right Slight Bulge A" />
+				<Frame UV="154,66" Name="Forest Tree" Variety="Top Large D" />
+				<Frame UV="0,88" Name="Forest Tree" Variety="Trunk Left Indent B" />
+				<Frame UV="22,88" Name="Forest Tree" Variety="Trunk Right Bulge B" />
+				<Frame UV="44,88" Name="Forest Tree" Variety="Trunk Left Bulge B" />
+				<Frame UV="66,88" Name="Forest Tree" Variety="Trunk Right Slight Bulge E" />
+				<Frame UV="88,88" Name="Forest Tree" Variety="Branch Plain B" />
+				<Frame UV="110,88" Name="Forest Tree" Variety="Trunk Double Slight Bulge B" />
+				<Frame UV="132,88" Name="Forest Tree" Variety="Top Small Right Slight Bulge B" />
+				<Frame UV="154,88" Name="Forest Tree" Variety="Top Large E" />
+				<Frame UV="0,110" Name="Forest Tree" Variety="Trunk Left Indent C" />
+				<Frame UV="22,110" Name="Forest Tree" Variety="Trunk Right Bulge C" />
+				<Frame UV="44,110" Name="Forest Tree" Variety="Trunk Left Bulge C" />
+				<Frame UV="66,110" Name="Forest Tree" Variety="Trunk Right Slight Bulge F" />
+				<Frame UV="88,110" Name="Forest Tree" Variety="Branch Plain C" />
+				<Frame UV="110,110" Name="Forest Tree" Variety="Trunk Double Slight Bulge C" />
+				<Frame UV="132,110" Name="Forest Tree" Variety="Top Small Right Slight Bulge C" />
+				<Frame UV="154,110" Name="Forest Tree" Variety="Top Large F" />
+				<Frame UV="0,132" Name="Forest Tree" Variety="Trunk Large A" />
+				<Frame UV="22,132" Name="Forest Tree" Variety="Base Plain A" />
+				<Frame UV="44,132" Name="Forest Tree" Variety="Base Plain A" />
+				<Frame UV="66,132" Name="Forest Tree" Variety="Trunk Large B" />
+				<Frame UV="88,132" Name="Forest Tree" Variety="Trunk Large C" />
+				<Frame UV="132,132" Name="Forest Tree" Variety="Top Small Double Slight Bulge A" />
+				<Frame UV="154,132" Name="Forest Tree" Variety="Top Huge A" />
+				<Frame UV="0,154" Name="Forest Tree" Variety="Trunk Large D" />
+				<Frame UV="22,154" Name="Forest Tree" Variety="Base Plain B" />
+				<Frame UV="44,154" Name="Forest Tree" Variety="Base Plain B" />
+				<Frame UV="66,154" Name="Forest Tree" Variety="Trunk Large E" />
+				<Frame UV="88,154" Name="Forest Tree" Variety="Trunk Large F" />
+				<Frame UV="132,154" Name="Forest Tree" Variety="Top Small Double Slight Bulge B" />
+				<Frame UV="154,154" Name="Forest Tree" Variety="Top Huge B" />
+				<Frame UV="0,176" Name="Forest Tree" Variety="Trunk Large G" />
+				<Frame UV="22,176" Name="Forest Tree" Variety="Base Plain C" />
+				<Frame UV="44,176" Name="Forest Tree" Variety="Base Plain C" />
+				<Frame UV="66,176" Name="Forest Tree" Variety="Trunk Large H" />
+				<Frame UV="88,176" Name="Forest Tree" Variety="Trunk Large I" />
+				<Frame UV="132,176" Name="Forest Tree" Variety="Top Small Double Slight Bulge C" />
+				<Frame UV="154,176" Name="Forest Tree" Variety="Top Huge C" />
+				<Frame UV="0,198" Name="Forest Tree" Variety="Top Jagged A" />
+				<Frame UV="0,220" Name="Forest Tree" Variety="Top Jagged B" />
+				<Frame UV="0,242" Name="Forest Tree" Variety="Top Jagged C" />
+				<Frame UV="22,198" Name="Forest Tree" Variety="Top Leafy A (No Sprite)" />
+				<Frame UV="22,220" Name="Forest Tree" Variety="Top Leafy B (No Sprite)" />
+				<Frame UV="22,242" Name="Forest Tree" Variety="Top Leafy C (No Sprite)" />
+				<Frame UV="44,198" Name="Forest Tree" Variety="Branch Left Leafy A (No Sprite)" />
+				<Frame UV="44,220" Name="Forest Tree" Variety="Branch Left Leafy B (No Sprite)" />
+				<Frame UV="44,242" Name="Forest Tree" Variety="Branch Left Leafy C (No Sprite)" />
+				<Frame UV="66,198" Name="Forest Tree" Variety="Branch Right Leafy A (No Sprite)" />
+				<Frame UV="66,220" Name="Forest Tree" Variety="Branch Right Leafy B (No Sprite)" />
+				<Frame UV="66,242" Name="Forest Tree" Variety="Branch Right Leafy C (No Sprite)" />				
+				<Frame UV="176,0" Name="Corrupt Tree" Variety="Trunk Plain A" />
+				<Frame UV="198,0" Name="Corrupt Tree" Variety="Trunk Right Indent A" />
+				<Frame UV="220,0" Name="Corrupt Tree" Variety="Trunk Right Slight Bulge A" />
+				<Frame UV="242,0" Name="Corrupt Tree" Variety="Branch Plain A" />
+				<Frame UV="264,0" Name="Corrupt Tree" Variety="Trunk Left Slight Bulge A" />
+				<Frame UV="286,0" Name="Corrupt Tree" Variety="Top Medium A" />
+				<Frame UV="308,0" Name="Corrupt Tree" Variety="Top Small A" />
+				<Frame UV="330,0" Name="Corrupt Tree" Variety="Top Large A" />
+				<Frame UV="176,22" Name="Corrupt Tree" Variety="Trunk Plain B" />
+				<Frame UV="198,22" Name="Corrupt Tree" Variety="Trunk Right Indent B" />
+				<Frame UV="220,22" Name="Corrupt Tree" Variety="Trunk Right Slight Bulge B" />
+				<Frame UV="242,22" Name="Corrupt Tree" Variety="Branch Plain B" />
+				<Frame UV="264,22" Name="Corrupt Tree" Variety="Trunk Left Slight Bulge B" />
+				<Frame UV="286,22" Name="Corrupt Tree" Variety="Top Medium B" />
+				<Frame UV="308,22" Name="Corrupt Tree" Variety="Top Small B" />
+				<Frame UV="330,22" Name="Corrupt Tree" Variety="Top Large B" />
+				<Frame UV="176,44" Name="Corrupt Tree" Variety="Trunk Plain C" />
+				<Frame UV="198,44" Name="Corrupt Tree" Variety="Trunk Right Indent C" />
+				<Frame UV="220,44" Name="Corrupt Tree" Variety="Trunk Right Slight Bulge C" />
+				<Frame UV="242,44" Name="Corrupt Tree" Variety="Branch Plain C" />
+				<Frame UV="264,44" Name="Corrupt Tree" Variety="Trunk Left Slight Bulge C" />
+				<Frame UV="286,44" Name="Corrupt Tree" Variety="Top Medium C" />
+				<Frame UV="308,44" Name="Corrupt Tree" Variety="Top Small C" />
+				<Frame UV="330,44" Name="Corrupt Tree" Variety="Top Large C" />
+				<Frame UV="176,66" Name="Corrupt Tree" Variety="Trunk Left Indent A" />
+				<Frame UV="198,66" Name="Corrupt Tree" Variety="Trunk Right Bulge A" />
+				<Frame UV="220,66" Name="Corrupt Tree" Variety="Trunk Left Bulge A" />
+				<Frame UV="242,66" Name="Corrupt Tree" Variety="Trunk Right Slight Bulge D" />
+				<Frame UV="264,66" Name="Corrupt Tree" Variety="Branch Plain A" />
+				<Frame UV="286,66" Name="Corrupt Tree" Variety="Trunk Double Slight Bulge A" />
+				<Frame UV="308,66" Name="Corrupt Tree" Variety="Top Small Right Slight Bulge A" />
+				<Frame UV="330,66" Name="Corrupt Tree" Variety="Top Large D" />
+				<Frame UV="176,88" Name="Corrupt Tree" Variety="Trunk Left Indent B" />
+				<Frame UV="198,88" Name="Corrupt Tree" Variety="Trunk Right Bulge B" />
+				<Frame UV="220,88" Name="Corrupt Tree" Variety="Trunk Left Bulge B" />
+				<Frame UV="242,88" Name="Corrupt Tree" Variety="Trunk Right Slight Bulge E" />
+				<Frame UV="264,88" Name="Corrupt Tree" Variety="Branch Plain B" />
+				<Frame UV="286,88" Name="Corrupt Tree" Variety="Trunk Double Slight Bulge B" />
+				<Frame UV="308,88" Name="Corrupt Tree" Variety="Top Small Right Slight Bulge B" />
+				<Frame UV="330,88" Name="Corrupt Tree" Variety="Top Large E" />
+				<Frame UV="176,110" Name="Corrupt Tree" Variety="Trunk Left Indent C" />
+				<Frame UV="198,110" Name="Corrupt Tree" Variety="Trunk Right Bulge C" />
+				<Frame UV="220,110" Name="Corrupt Tree" Variety="Trunk Left Bulge C" />
+				<Frame UV="242,110" Name="Corrupt Tree" Variety="Trunk Right Slight Bulge F" />
+				<Frame UV="264,110" Name="Corrupt Tree" Variety="Branch Plain C" />
+				<Frame UV="286,110" Name="Corrupt Tree" Variety="Trunk Double Slight Bulge C" />
+				<Frame UV="308,110" Name="Corrupt Tree" Variety="Top Small Right Slight Bulge C" />
+				<Frame UV="330,110" Name="Corrupt Tree" Variety="Top Large F" />
+				<Frame UV="176,132" Name="Corrupt Tree" Variety="Trunk Large A" />
+				<Frame UV="198,132" Name="Corrupt Tree" Variety="Base Plain A" />
+				<Frame UV="220,132" Name="Corrupt Tree" Variety="Base Plain A" />
+				<Frame UV="242,132" Name="Corrupt Tree" Variety="Trunk Large B" />
+				<Frame UV="264,132" Name="Corrupt Tree" Variety="Trunk Large C" />
+				<Frame UV="308,132" Name="Corrupt Tree" Variety="Top Small Double Slight Bulge A" />
+				<Frame UV="330,132" Name="Corrupt Tree" Variety="Top Huge A" />
+				<Frame UV="176,154" Name="Corrupt Tree" Variety="Trunk Large D" />
+				<Frame UV="198,154" Name="Corrupt Tree" Variety="Base Plain B" />
+				<Frame UV="220,154" Name="Corrupt Tree" Variety="Base Plain B" />
+				<Frame UV="242,154" Name="Corrupt Tree" Variety="Trunk Large E" />
+				<Frame UV="264,154" Name="Corrupt Tree" Variety="Trunk Large F" />
+				<Frame UV="308,154" Name="Corrupt Tree" Variety="Top Small Double Slight Bulge B" />
+				<Frame UV="330,154" Name="Corrupt Tree" Variety="Top Huge B" />
+				<Frame UV="176,176" Name="Corrupt Tree" Variety="Trunk Large G" />
+				<Frame UV="198,176" Name="Corrupt Tree" Variety="Base Plain C" />
+				<Frame UV="220,176" Name="Corrupt Tree" Variety="Base Plain C" />
+				<Frame UV="242,176" Name="Corrupt Tree" Variety="Trunk Large H" />
+				<Frame UV="264,176" Name="Corrupt Tree" Variety="Trunk Large I" />
+				<Frame UV="308,176" Name="Corrupt Tree" Variety="Top Small Double Slight Bulge C" />
+				<Frame UV="330,176" Name="Corrupt Tree" Variety="Top Huge C" />
+				<Frame UV="176,198" Name="Corrupt Tree" Variety="Top Jagged A" />
+				<Frame UV="176,220" Name="Corrupt Tree" Variety="Top Jagged B" />
+				<Frame UV="176,242" Name="Corrupt Tree" Variety="Top Jagged C" />				
+				<Frame UV="352,0" Name="Jungle Tree" Variety="Trunk Plain A" />
+				<Frame UV="374,0" Name="Jungle Tree" Variety="Trunk Right Indent A" />
+				<Frame UV="396,0" Name="Jungle Tree" Variety="Trunk Right Slight Bulge A" />
+				<Frame UV="418,0" Name="Jungle Tree" Variety="Branch Plain A" />
+				<Frame UV="440,0" Name="Jungle Tree" Variety="Trunk Left Slight Bulge A" />
+				<Frame UV="462,0" Name="Jungle Tree" Variety="Top Medium A" />
+				<Frame UV="484,0" Name="Jungle Tree" Variety="Top Small A" />
+				<Frame UV="506,0" Name="Jungle Tree" Variety="Top Large A" />
+				<Frame UV="352,22" Name="Jungle Tree" Variety="Trunk Plain B" />
+				<Frame UV="374,22" Name="Jungle Tree" Variety="Trunk Right Indent B" />
+				<Frame UV="396,22" Name="Jungle Tree" Variety="Trunk Right Slight Bulge B" />
+				<Frame UV="418,22" Name="Jungle Tree" Variety="Branch Plain B" />
+				<Frame UV="440,22" Name="Jungle Tree" Variety="Trunk Left Slight Bulge B" />
+				<Frame UV="462,22" Name="Jungle Tree" Variety="Top Medium B" />
+				<Frame UV="484,22" Name="Jungle Tree" Variety="Top Small B" />
+				<Frame UV="506,22" Name="Jungle Tree" Variety="Top Large B" />
+				<Frame UV="352,44" Name="Jungle Tree" Variety="Trunk Plain C" />
+				<Frame UV="374,44" Name="Jungle Tree" Variety="Trunk Right Indent C" />
+				<Frame UV="396,44" Name="Jungle Tree" Variety="Trunk Right Slight Bulge C" />
+				<Frame UV="418,44" Name="Jungle Tree" Variety="Branch Plain C" />
+				<Frame UV="440,44" Name="Jungle Tree" Variety="Trunk Left Slight Bulge C" />
+				<Frame UV="462,44" Name="Jungle Tree" Variety="Top Medium C" />
+				<Frame UV="484,44" Name="Jungle Tree" Variety="Top Small C" />
+				<Frame UV="506,44" Name="Jungle Tree" Variety="Top Large C" />
+				<Frame UV="352,66" Name="Jungle Tree" Variety="Trunk Left Indent A" />
+				<Frame UV="374,66" Name="Jungle Tree" Variety="Trunk Right Bulge A" />
+				<Frame UV="396,66" Name="Jungle Tree" Variety="Trunk Left Bulge A" />
+				<Frame UV="418,66" Name="Jungle Tree" Variety="Trunk Right Slight Bulge D" />
+				<Frame UV="440,66" Name="Jungle Tree" Variety="Branch Plain A" />
+				<Frame UV="462,66" Name="Jungle Tree" Variety="Trunk Double Slight Bulge A" />
+				<Frame UV="484,66" Name="Jungle Tree" Variety="Top Small Right Slight Bulge A" />
+				<Frame UV="506,66" Name="Jungle Tree" Variety="Top Large D" />
+				<Frame UV="352,88" Name="Jungle Tree" Variety="Trunk Left Indent B" />
+				<Frame UV="374,88" Name="Jungle Tree" Variety="Trunk Right Bulge B" />
+				<Frame UV="396,88" Name="Jungle Tree" Variety="Trunk Left Bulge B" />
+				<Frame UV="418,88" Name="Jungle Tree" Variety="Trunk Right Slight Bulge E" />
+				<Frame UV="440,88" Name="Jungle Tree" Variety="Branch Plain B" />
+				<Frame UV="462,88" Name="Jungle Tree" Variety="Trunk Double Slight Bulge B" />
+				<Frame UV="484,88" Name="Jungle Tree" Variety="Top Small Right Slight Bulge B" />
+				<Frame UV="506,88" Name="Jungle Tree" Variety="Top Large E" />
+				<Frame UV="352,110" Name="Jungle Tree" Variety="Trunk Left Indent C" />
+				<Frame UV="374,110" Name="Jungle Tree" Variety="Trunk Right Bulge C" />
+				<Frame UV="396,110" Name="Jungle Tree" Variety="Trunk Left Bulge C" />
+				<Frame UV="418,110" Name="Jungle Tree" Variety="Trunk Right Slight Bulge F" />
+				<Frame UV="440,110" Name="Jungle Tree" Variety="Branch Plain C" />
+				<Frame UV="462,110" Name="Jungle Tree" Variety="Trunk Double Slight Bulge C" />
+				<Frame UV="484,110" Name="Jungle Tree" Variety="Top Small Right Slight Bulge C" />
+				<Frame UV="506,110" Name="Jungle Tree" Variety="Top Large F" />
+				<Frame UV="352,132" Name="Jungle Tree" Variety="Trunk Large A" />
+				<Frame UV="374,132" Name="Jungle Tree" Variety="Base Plain A" />
+				<Frame UV="396,132" Name="Jungle Tree" Variety="Base Plain A" />
+				<Frame UV="418,132" Name="Jungle Tree" Variety="Trunk Large B" />
+				<Frame UV="440,132" Name="Jungle Tree" Variety="Trunk Large C" />
+				<Frame UV="484,132" Name="Jungle Tree" Variety="Top Small Double Slight Bulge A" />
+				<Frame UV="506,132" Name="Jungle Tree" Variety="Top Huge A" />
+				<Frame UV="352,154" Name="Jungle Tree" Variety="Trunk Large D" />
+				<Frame UV="374,154" Name="Jungle Tree" Variety="Base Plain B" />
+				<Frame UV="396,154" Name="Jungle Tree" Variety="Base Plain B" />
+				<Frame UV="418,154" Name="Jungle Tree" Variety="Trunk Large E" />
+				<Frame UV="440,154" Name="Jungle Tree" Variety="Trunk Large F" />
+				<Frame UV="484,154" Name="Jungle Tree" Variety="Top Small Double Slight Bulge B" />
+				<Frame UV="506,154" Name="Jungle Tree" Variety="Top Huge B" />
+				<Frame UV="352,176" Name="Jungle Tree" Variety="Trunk Large G" />
+				<Frame UV="374,176" Name="Jungle Tree" Variety="Base Plain C" />
+				<Frame UV="396,176" Name="Jungle Tree" Variety="Base Plain C" />
+				<Frame UV="418,176" Name="Jungle Tree" Variety="Trunk Large H" />
+				<Frame UV="440,176" Name="Jungle Tree" Variety="Trunk Large I" />
+				<Frame UV="484,176" Name="Jungle Tree" Variety="Top Small Double Slight Bulge C" />
+				<Frame UV="506,176" Name="Jungle Tree" Variety="Top Huge C" />
+				<Frame UV="352,198" Name="Jungle Tree" Variety="Top Jagged A" />
+				<Frame UV="352,220" Name="Jungle Tree" Variety="Top Jagged B" />
+				<Frame UV="352,242" Name="Jungle Tree" Variety="Top Jagged C" />				
+				<Frame UV="528,0" Name="Hallow Tree" Variety="Trunk Plain A" />
+				<Frame UV="550,0" Name="Hallow Tree" Variety="Trunk Right Indent A" />
+				<Frame UV="572,0" Name="Hallow Tree" Variety="Trunk Right Slight Bulge A" />
+				<Frame UV="594,0" Name="Hallow Tree" Variety="Branch Plain A" />
+				<Frame UV="616,0" Name="Hallow Tree" Variety="Trunk Left Slight Bulge A" />
+				<Frame UV="638,0" Name="Hallow Tree" Variety="Top Medium A" />
+				<Frame UV="660,0" Name="Hallow Tree" Variety="Top Small A" />
+				<Frame UV="682,0" Name="Hallow Tree" Variety="Top Large A" />
+				<Frame UV="528,22" Name="Hallow Tree" Variety="Trunk Plain B" />
+				<Frame UV="550,22" Name="Hallow Tree" Variety="Trunk Right Indent B" />
+				<Frame UV="572,22" Name="Hallow Tree" Variety="Trunk Right Slight Bulge B" />
+				<Frame UV="594,22" Name="Hallow Tree" Variety="Branch Plain B" />
+				<Frame UV="616,22" Name="Hallow Tree" Variety="Trunk Left Slight Bulge B" />
+				<Frame UV="638,22" Name="Hallow Tree" Variety="Top Medium B" />
+				<Frame UV="660,22" Name="Hallow Tree" Variety="Top Small B" />
+				<Frame UV="682,22" Name="Hallow Tree" Variety="Top Large B" />
+				<Frame UV="528,44" Name="Hallow Tree" Variety="Trunk Plain C" />
+				<Frame UV="550,44" Name="Hallow Tree" Variety="Trunk Right Indent C" />
+				<Frame UV="572,44" Name="Hallow Tree" Variety="Trunk Right Slight Bulge C" />
+				<Frame UV="594,44" Name="Hallow Tree" Variety="Branch Plain C" />
+				<Frame UV="616,44" Name="Hallow Tree" Variety="Trunk Left Slight Bulge C" />
+				<Frame UV="638,44" Name="Hallow Tree" Variety="Top Medium C" />
+				<Frame UV="660,44" Name="Hallow Tree" Variety="Top Small C" />
+				<Frame UV="682,44" Name="Hallow Tree" Variety="Top Large C" />
+				<Frame UV="528,66" Name="Hallow Tree" Variety="Trunk Left Indent A" />
+				<Frame UV="550,66" Name="Hallow Tree" Variety="Trunk Right Bulge A" />
+				<Frame UV="572,66" Name="Hallow Tree" Variety="Trunk Left Bulge A" />
+				<Frame UV="594,66" Name="Hallow Tree" Variety="Trunk Right Slight Bulge D" />
+				<Frame UV="616,66" Name="Hallow Tree" Variety="Branch Plain A" />
+				<Frame UV="638,66" Name="Hallow Tree" Variety="Trunk Double Slight Bulge A" />
+				<Frame UV="660,66" Name="Hallow Tree" Variety="Top Small Right Slight Bulge A" />
+				<Frame UV="682,66" Name="Hallow Tree" Variety="Top Large D" />
+				<Frame UV="528,88" Name="Hallow Tree" Variety="Trunk Left Indent B" />
+				<Frame UV="550,88" Name="Hallow Tree" Variety="Trunk Right Bulge B" />
+				<Frame UV="572,88" Name="Hallow Tree" Variety="Trunk Left Bulge B" />
+				<Frame UV="594,88" Name="Hallow Tree" Variety="Trunk Right Slight Bulge E" />
+				<Frame UV="616,88" Name="Hallow Tree" Variety="Branch Plain B" />
+				<Frame UV="638,88" Name="Hallow Tree" Variety="Trunk Double Slight Bulge B" />
+				<Frame UV="660,88" Name="Hallow Tree" Variety="Top Small Right Slight Bulge B" />
+				<Frame UV="682,88" Name="Hallow Tree" Variety="Top Large E" />
+				<Frame UV="528,110" Name="Hallow Tree" Variety="Trunk Left Indent C" />
+				<Frame UV="550,110" Name="Hallow Tree" Variety="Trunk Right Bulge C" />
+				<Frame UV="572,110" Name="Hallow Tree" Variety="Trunk Left Bulge C" />
+				<Frame UV="594,110" Name="Hallow Tree" Variety="Trunk Right Slight Bulge F" />
+				<Frame UV="616,110" Name="Hallow Tree" Variety="Branch Plain C" />
+				<Frame UV="638,110" Name="Hallow Tree" Variety="Trunk Double Slight Bulge C" />
+				<Frame UV="660,110" Name="Hallow Tree" Variety="Top Small Right Slight Bulge C" />
+				<Frame UV="682,110" Name="Hallow Tree" Variety="Top Large F" />
+				<Frame UV="528,132" Name="Hallow Tree" Variety="Trunk Large A" />
+				<Frame UV="550,132" Name="Hallow Tree" Variety="Base Plain A" />
+				<Frame UV="572,132" Name="Hallow Tree" Variety="Base Plain A" />
+				<Frame UV="594,132" Name="Hallow Tree" Variety="Trunk Large B" />
+				<Frame UV="616,132" Name="Hallow Tree" Variety="Trunk Large C" />
+				<Frame UV="660,132" Name="Hallow Tree" Variety="Top Small Double Slight Bulge A" />
+				<Frame UV="682,132" Name="Hallow Tree" Variety="Top Huge A" />
+				<Frame UV="528,154" Name="Hallow Tree" Variety="Trunk Large D" />
+				<Frame UV="550,154" Name="Hallow Tree" Variety="Base Plain B" />
+				<Frame UV="572,154" Name="Hallow Tree" Variety="Base Plain B" />
+				<Frame UV="594,154" Name="Hallow Tree" Variety="Trunk Large E" />
+				<Frame UV="616,154" Name="Hallow Tree" Variety="Trunk Large F" />
+				<Frame UV="660,154" Name="Hallow Tree" Variety="Top Small Double Slight Bulge B" />
+				<Frame UV="682,154" Name="Hallow Tree" Variety="Top Huge B" />
+				<Frame UV="528,176" Name="Hallow Tree" Variety="Trunk Large G" />
+				<Frame UV="550,176" Name="Hallow Tree" Variety="Base Plain C" />
+				<Frame UV="572,176" Name="Hallow Tree" Variety="Base Plain C" />
+				<Frame UV="594,176" Name="Hallow Tree" Variety="Trunk Large H" />
+				<Frame UV="616,176" Name="Hallow Tree" Variety="Trunk Large I" />
+				<Frame UV="660,176" Name="Hallow Tree" Variety="Top Small Double Slight Bulge C" />
+				<Frame UV="682,176" Name="Hallow Tree" Variety="Top Huge C" />
+				<Frame UV="528,198" Name="Hallow Tree" Variety="Top Jagged A" />
+				<Frame UV="528,220" Name="Hallow Tree" Variety="Top Jagged B" />
+				<Frame UV="528,242" Name="Hallow Tree" Variety="Top Jagged C" />				
+				<Frame UV="704,0" Name="Boreal Tree" Variety="Trunk Plain A" />
+				<Frame UV="726,0" Name="Boreal Tree" Variety="Trunk Right Indent A" />
+				<Frame UV="748,0" Name="Boreal Tree" Variety="Trunk Right Slight Bulge A" />
+				<Frame UV="770,0" Name="Boreal Tree" Variety="Branch Plain A" />
+				<Frame UV="792,0" Name="Boreal Tree" Variety="Trunk Left Slight Bulge A" />
+				<Frame UV="814,0" Name="Boreal Tree" Variety="Top Medium A" />
+				<Frame UV="836,0" Name="Boreal Tree" Variety="Top Small A" />
+				<Frame UV="858,0" Name="Boreal Tree" Variety="Top Large A" />
+				<Frame UV="704,22" Name="Boreal Tree" Variety="Trunk Plain B" />
+				<Frame UV="726,22" Name="Boreal Tree" Variety="Trunk Right Indent B" />
+				<Frame UV="748,22" Name="Boreal Tree" Variety="Trunk Right Slight Bulge B" />
+				<Frame UV="770,22" Name="Boreal Tree" Variety="Branch Plain B" />
+				<Frame UV="792,22" Name="Boreal Tree" Variety="Trunk Left Slight Bulge B" />
+				<Frame UV="814,22" Name="Boreal Tree" Variety="Top Medium B" />
+				<Frame UV="836,22" Name="Boreal Tree" Variety="Top Small B" />
+				<Frame UV="858,22" Name="Boreal Tree" Variety="Top Large B" />
+				<Frame UV="704,44" Name="Boreal Tree" Variety="Trunk Plain C" />
+				<Frame UV="726,44" Name="Boreal Tree" Variety="Trunk Right Indent C" />
+				<Frame UV="748,44" Name="Boreal Tree" Variety="Trunk Right Slight Bulge C" />
+				<Frame UV="770,44" Name="Boreal Tree" Variety="Branch Plain C" />
+				<Frame UV="792,44" Name="Boreal Tree" Variety="Trunk Left Slight Bulge C" />
+				<Frame UV="814,44" Name="Boreal Tree" Variety="Top Medium C" />
+				<Frame UV="836,44" Name="Boreal Tree" Variety="Top Small C" />
+				<Frame UV="858,44" Name="Boreal Tree" Variety="Top Large C" />
+				<Frame UV="704,66" Name="Boreal Tree" Variety="Trunk Left Indent A" />
+				<Frame UV="726,66" Name="Boreal Tree" Variety="Trunk Right Bulge A" />
+				<Frame UV="748,66" Name="Boreal Tree" Variety="Trunk Left Bulge A" />
+				<Frame UV="770,66" Name="Boreal Tree" Variety="Trunk Right Slight Bulge D" />
+				<Frame UV="792,66" Name="Boreal Tree" Variety="Branch Plain A" />
+				<Frame UV="814,66" Name="Boreal Tree" Variety="Trunk Double Slight Bulge A" />
+				<Frame UV="836,66" Name="Boreal Tree" Variety="Top Small Right Slight Bulge A" />
+				<Frame UV="858,66" Name="Boreal Tree" Variety="Top Large D" />
+				<Frame UV="704,88" Name="Boreal Tree" Variety="Trunk Left Indent B" />
+				<Frame UV="726,88" Name="Boreal Tree" Variety="Trunk Right Bulge B" />
+				<Frame UV="748,88" Name="Boreal Tree" Variety="Trunk Left Bulge B" />
+				<Frame UV="770,88" Name="Boreal Tree" Variety="Trunk Right Slight Bulge E" />
+				<Frame UV="792,88" Name="Boreal Tree" Variety="Branch Plain B" />
+				<Frame UV="814,88" Name="Boreal Tree" Variety="Trunk Double Slight Bulge B" />
+				<Frame UV="836,88" Name="Boreal Tree" Variety="Top Small Right Slight Bulge B" />
+				<Frame UV="858,88" Name="Boreal Tree" Variety="Top Large E" />
+				<Frame UV="704,110" Name="Boreal Tree" Variety="Trunk Left Indent C" />
+				<Frame UV="726,110" Name="Boreal Tree" Variety="Trunk Right Bulge C" />
+				<Frame UV="748,110" Name="Boreal Tree" Variety="Trunk Left Bulge C" />
+				<Frame UV="770,110" Name="Boreal Tree" Variety="Trunk Right Slight Bulge F" />
+				<Frame UV="792,110" Name="Boreal Tree" Variety="Branch Plain C" />
+				<Frame UV="814,110" Name="Boreal Tree" Variety="Trunk Double Slight Bulge C" />
+				<Frame UV="836,110" Name="Boreal Tree" Variety="Top Small Right Slight Bulge C" />
+				<Frame UV="858,110" Name="Boreal Tree" Variety="Top Large F" />
+				<Frame UV="704,132" Name="Boreal Tree" Variety="Trunk Large A" />
+				<Frame UV="726,132" Name="Boreal Tree" Variety="Base Plain A" />
+				<Frame UV="748,132" Name="Boreal Tree" Variety="Base Plain A" />
+				<Frame UV="770,132" Name="Boreal Tree" Variety="Trunk Large B" />
+				<Frame UV="792,132" Name="Boreal Tree" Variety="Trunk Large C" />
+				<Frame UV="836,132" Name="Boreal Tree" Variety="Top Small Double Slight Bulge A" />
+				<Frame UV="858,132" Name="Boreal Tree" Variety="Top Huge A" />
+				<Frame UV="704,154" Name="Boreal Tree" Variety="Trunk Large D" />
+				<Frame UV="726,154" Name="Boreal Tree" Variety="Base Plain B" />
+				<Frame UV="748,154" Name="Boreal Tree" Variety="Base Plain B" />
+				<Frame UV="770,154" Name="Boreal Tree" Variety="Trunk Large E" />
+				<Frame UV="792,154" Name="Boreal Tree" Variety="Trunk Large F" />
+				<Frame UV="836,154" Name="Boreal Tree" Variety="Top Small Double Slight Bulge B" />
+				<Frame UV="858,154" Name="Boreal Tree" Variety="Top Huge B" />
+				<Frame UV="704,176" Name="Boreal Tree" Variety="Trunk Large G" />
+				<Frame UV="726,176" Name="Boreal Tree" Variety="Base Plain C" />
+				<Frame UV="748,176" Name="Boreal Tree" Variety="Base Plain C" />
+				<Frame UV="770,176" Name="Boreal Tree" Variety="Trunk Large H" />
+				<Frame UV="792,176" Name="Boreal Tree" Variety="Trunk Large I" />
+				<Frame UV="836,176" Name="Boreal Tree" Variety="Top Small Double Slight Bulge C" />
+				<Frame UV="858,176" Name="Boreal Tree" Variety="Top Huge C" />
+				<Frame UV="704,198" Name="Boreal Tree" Variety="Top Jagged A" />
+				<Frame UV="704,220" Name="Boreal Tree" Variety="Top Jagged B" />
+				<Frame UV="704,242" Name="Boreal Tree" Variety="Top Jagged C" />				
+				<Frame UV="880,0" Name="Crimson Tree" Variety="Trunk Plain A" />
+				<Frame UV="902,0" Name="Crimson Tree" Variety="Trunk Right Indent A" />
+				<Frame UV="924,0" Name="Crimson Tree" Variety="Trunk Right Slight Bulge A" />
+				<Frame UV="946,0" Name="Crimson Tree" Variety="Branch Plain A" />
+				<Frame UV="968,0" Name="Crimson Tree" Variety="Trunk Left Slight Bulge A" />
+				<Frame UV="990,0" Name="Crimson Tree" Variety="Top Medium A" />
+				<Frame UV="1012,0" Name="Crimson Tree" Variety="Top Small A" />
+				<Frame UV="1034,0" Name="Crimson Tree" Variety="Top Large A" />
+				<Frame UV="880,22" Name="Crimson Tree" Variety="Trunk Plain B" />
+				<Frame UV="902,22" Name="Crimson Tree" Variety="Trunk Right Indent B" />
+				<Frame UV="924,22" Name="Crimson Tree" Variety="Trunk Right Slight Bulge B" />
+				<Frame UV="946,22" Name="Crimson Tree" Variety="Branch Plain B" />
+				<Frame UV="968,22" Name="Crimson Tree" Variety="Trunk Left Slight Bulge B" />
+				<Frame UV="990,22" Name="Crimson Tree" Variety="Top Medium B" />
+				<Frame UV="1012,22" Name="Crimson Tree" Variety="Top Small B" />
+				<Frame UV="1034,22" Name="Crimson Tree" Variety="Top Large B" />
+				<Frame UV="880,44" Name="Crimson Tree" Variety="Trunk Plain C" />
+				<Frame UV="902,44" Name="Crimson Tree" Variety="Trunk Right Indent C" />
+				<Frame UV="924,44" Name="Crimson Tree" Variety="Trunk Right Slight Bulge C" />
+				<Frame UV="946,44" Name="Crimson Tree" Variety="Branch Plain C" />
+				<Frame UV="968,44" Name="Crimson Tree" Variety="Trunk Left Slight Bulge C" />
+				<Frame UV="990,44" Name="Crimson Tree" Variety="Top Medium C" />
+				<Frame UV="1012,44" Name="Crimson Tree" Variety="Top Small C" />
+				<Frame UV="1034,44" Name="Crimson Tree" Variety="Top Large C" />
+				<Frame UV="880,66" Name="Crimson Tree" Variety="Trunk Left Indent A" />
+				<Frame UV="902,66" Name="Crimson Tree" Variety="Trunk Right Bulge A" />
+				<Frame UV="924,66" Name="Crimson Tree" Variety="Trunk Left Bulge A" />
+				<Frame UV="946,66" Name="Crimson Tree" Variety="Trunk Right Slight Bulge D" />
+				<Frame UV="968,66" Name="Crimson Tree" Variety="Branch Plain A" />
+				<Frame UV="990,66" Name="Crimson Tree" Variety="Trunk Double Slight Bulge A" />
+				<Frame UV="1012,66" Name="Crimson Tree" Variety="Top Small Right Slight Bulge A" />
+				<Frame UV="1034,66" Name="Crimson Tree" Variety="Top Large D" />
+				<Frame UV="880,88" Name="Crimson Tree" Variety="Trunk Left Indent B" />
+				<Frame UV="902,88" Name="Crimson Tree" Variety="Trunk Right Bulge B" />
+				<Frame UV="924,88" Name="Crimson Tree" Variety="Trunk Left Bulge B" />
+				<Frame UV="946,88" Name="Crimson Tree" Variety="Trunk Right Slight Bulge E" />
+				<Frame UV="968,88" Name="Crimson Tree" Variety="Branch Plain B" />
+				<Frame UV="990,88" Name="Crimson Tree" Variety="Trunk Double Slight Bulge B" />
+				<Frame UV="1012,88" Name="Crimson Tree" Variety="Top Small Right Slight Bulge B" />
+				<Frame UV="1034,88" Name="Crimson Tree" Variety="Top Large E" />
+				<Frame UV="880,110" Name="Crimson Tree" Variety="Trunk Left Indent C" />
+				<Frame UV="902,110" Name="Crimson Tree" Variety="Trunk Right Bulge C" />
+				<Frame UV="924,110" Name="Crimson Tree" Variety="Trunk Left Bulge C" />
+				<Frame UV="946,110" Name="Crimson Tree" Variety="Trunk Right Slight Bulge F" />
+				<Frame UV="968,110" Name="Crimson Tree" Variety="Branch Plain C" />
+				<Frame UV="990,110" Name="Crimson Tree" Variety="Trunk Double Slight Bulge C" />
+				<Frame UV="1012,110" Name="Crimson Tree" Variety="Top Small Right Slight Bulge C" />
+				<Frame UV="1034,110" Name="Crimson Tree" Variety="Top Large F" />
+				<Frame UV="880,132" Name="Crimson Tree" Variety="Trunk Large A" />
+				<Frame UV="902,132" Name="Crimson Tree" Variety="Base Plain A" />
+				<Frame UV="924,132" Name="Crimson Tree" Variety="Base Plain A" />
+				<Frame UV="946,132" Name="Crimson Tree" Variety="Trunk Large B" />
+				<Frame UV="968,132" Name="Crimson Tree" Variety="Trunk Large C" />
+				<Frame UV="1012,132" Name="Crimson Tree" Variety="Top Small Double Slight Bulge A" />
+				<Frame UV="1034,132" Name="Crimson Tree" Variety="Top Huge A" />
+				<Frame UV="880,154" Name="Crimson Tree" Variety="Trunk Large D" />
+				<Frame UV="902,154" Name="Crimson Tree" Variety="Base Plain B" />
+				<Frame UV="924,154" Name="Crimson Tree" Variety="Base Plain B" />
+				<Frame UV="946,154" Name="Crimson Tree" Variety="Trunk Large E" />
+				<Frame UV="968,154" Name="Crimson Tree" Variety="Trunk Large F" />
+				<Frame UV="1012,154" Name="Crimson Tree" Variety="Top Small Double Slight Bulge B" />
+				<Frame UV="1034,154" Name="Crimson Tree" Variety="Top Huge B" />
+				<Frame UV="880,176" Name="Crimson Tree" Variety="Trunk Large G" />
+				<Frame UV="902,176" Name="Crimson Tree" Variety="Base Plain C" />
+				<Frame UV="924,176" Name="Crimson Tree" Variety="Base Plain C" />
+				<Frame UV="946,176" Name="Crimson Tree" Variety="Trunk Large H" />
+				<Frame UV="968,176" Name="Crimson Tree" Variety="Trunk Large I" />
+				<Frame UV="1012,176" Name="Crimson Tree" Variety="Top Small Double Slight Bulge C" />
+				<Frame UV="1034,176" Name="Crimson Tree" Variety="Top Huge C" />
+				<Frame UV="880,198" Name="Crimson Tree" Variety="Top Jagged A" />
+				<Frame UV="880,220" Name="Crimson Tree" Variety="Top Jagged B" />
+				<Frame UV="880,242" Name="Crimson Tree" Variety="Top Jagged C" />				
+				<Frame UV="1056,0" Name="Underground Jungle Tree" Variety="Trunk Plain A" />
+				<Frame UV="1078,0" Name="Underground Jungle Tree" Variety="Trunk Right Indent A" />
+				<Frame UV="1100,0" Name="Underground Jungle Tree" Variety="Trunk Right Slight Bulge A" />
+				<Frame UV="1122,0" Name="Underground Jungle Tree" Variety="Branch Plain A" />
+				<Frame UV="1144,0" Name="Underground Jungle Tree" Variety="Trunk Left Slight Bulge A" />
+				<Frame UV="1166,0" Name="Underground Jungle Tree" Variety="Top Medium A" />
+				<Frame UV="1188,0" Name="Underground Jungle Tree" Variety="Top Small A" />
+				<Frame UV="1210,0" Name="Underground Jungle Tree" Variety="Top Large A" />
+				<Frame UV="1056,22" Name="Underground Jungle Tree" Variety="Trunk Plain B" />
+				<Frame UV="1078,22" Name="Underground Jungle Tree" Variety="Trunk Right Indent B" />
+				<Frame UV="1100,22" Name="Underground Jungle Tree" Variety="Trunk Right Slight Bulge B" />
+				<Frame UV="1122,22" Name="Underground Jungle Tree" Variety="Branch Plain B" />
+				<Frame UV="1144,22" Name="Underground Jungle Tree" Variety="Trunk Left Slight Bulge B" />
+				<Frame UV="1166,22" Name="Underground Jungle Tree" Variety="Top Medium B" />
+				<Frame UV="1188,22" Name="Underground Jungle Tree" Variety="Top Small B" />
+				<Frame UV="1210,22" Name="Underground Jungle Tree" Variety="Top Large B" />
+				<Frame UV="1056,44" Name="Underground Jungle Tree" Variety="Trunk Plain C" />
+				<Frame UV="1078,44" Name="Underground Jungle Tree" Variety="Trunk Right Indent C" />
+				<Frame UV="1100,44" Name="Underground Jungle Tree" Variety="Trunk Right Slight Bulge C" />
+				<Frame UV="1122,44" Name="Underground Jungle Tree" Variety="Branch Plain C" />
+				<Frame UV="1144,44" Name="Underground Jungle Tree" Variety="Trunk Left Slight Bulge C" />
+				<Frame UV="1166,44" Name="Underground Jungle Tree" Variety="Top Medium C" />
+				<Frame UV="1188,44" Name="Underground Jungle Tree" Variety="Top Small C" />
+				<Frame UV="1210,44" Name="Underground Jungle Tree" Variety="Top Large C" />
+				<Frame UV="1056,66" Name="Underground Jungle Tree" Variety="Trunk Left Indent A" />
+				<Frame UV="1078,66" Name="Underground Jungle Tree" Variety="Trunk Right Bulge A" />
+				<Frame UV="1100,66" Name="Underground Jungle Tree" Variety="Trunk Left Bulge A" />
+				<Frame UV="1122,66" Name="Underground Jungle Tree" Variety="Trunk Right Slight Bulge D" />
+				<Frame UV="1144,66" Name="Underground Jungle Tree" Variety="Branch Plain A" />
+				<Frame UV="1166,66" Name="Underground Jungle Tree" Variety="Trunk Double Slight Bulge A" />
+				<Frame UV="1188,66" Name="Underground Jungle Tree" Variety="Top Small Right Slight Bulge A" />
+				<Frame UV="1210,66" Name="Underground Jungle Tree" Variety="Top Large D" />
+				<Frame UV="1056,88" Name="Underground Jungle Tree" Variety="Trunk Left Indent B" />
+				<Frame UV="1078,88" Name="Underground Jungle Tree" Variety="Trunk Right Bulge B" />
+				<Frame UV="1100,88" Name="Underground Jungle Tree" Variety="Trunk Left Bulge B" />
+				<Frame UV="1122,88" Name="Underground Jungle Tree" Variety="Trunk Right Slight Bulge E" />
+				<Frame UV="1144,88" Name="Underground Jungle Tree" Variety="Branch Plain B" />
+				<Frame UV="1166,88" Name="Underground Jungle Tree" Variety="Trunk Double Slight Bulge B" />
+				<Frame UV="1188,88" Name="Underground Jungle Tree" Variety="Top Small Right Slight Bulge B" />
+				<Frame UV="1210,88" Name="Underground Jungle Tree" Variety="Top Large E" />
+				<Frame UV="1056,110" Name="Underground Jungle Tree" Variety="Trunk Left Indent C" />
+				<Frame UV="1078,110" Name="Underground Jungle Tree" Variety="Trunk Right Bulge C" />
+				<Frame UV="1100,110" Name="Underground Jungle Tree" Variety="Trunk Left Bulge C" />
+				<Frame UV="1122,110" Name="Underground Jungle Tree" Variety="Trunk Right Slight Bulge F" />
+				<Frame UV="1144,110" Name="Underground Jungle Tree" Variety="Branch Plain C" />
+				<Frame UV="1166,110" Name="Underground Jungle Tree" Variety="Trunk Double Slight Bulge C" />
+				<Frame UV="1188,110" Name="Underground Jungle Tree" Variety="Top Small Right Slight Bulge C" />
+				<Frame UV="1210,110" Name="Underground Jungle Tree" Variety="Top Large F" />
+				<Frame UV="1056,132" Name="Underground Jungle Tree" Variety="Trunk Large A" />
+				<Frame UV="1078,132" Name="Underground Jungle Tree" Variety="Base Plain A" />
+				<Frame UV="1100,132" Name="Underground Jungle Tree" Variety="Base Plain A" />
+				<Frame UV="1122,132" Name="Underground Jungle Tree" Variety="Trunk Large B" />
+				<Frame UV="1144,132" Name="Underground Jungle Tree" Variety="Trunk Large C" />
+				<Frame UV="1188,132" Name="Underground Jungle Tree" Variety="Top Small Double Slight Bulge A" />
+				<Frame UV="1210,132" Name="Underground Jungle Tree" Variety="Top Huge A" />
+				<Frame UV="1056,154" Name="Underground Jungle Tree" Variety="Trunk Large D" />
+				<Frame UV="1078,154" Name="Underground Jungle Tree" Variety="Base Plain B" />
+				<Frame UV="1100,154" Name="Underground Jungle Tree" Variety="Base Plain B" />
+				<Frame UV="1122,154" Name="Underground Jungle Tree" Variety="Trunk Large E" />
+				<Frame UV="1144,154" Name="Underground Jungle Tree" Variety="Trunk Large F" />
+				<Frame UV="1188,154" Name="Underground Jungle Tree" Variety="Top Small Double Slight Bulge B" />
+				<Frame UV="1210,154" Name="Underground Jungle Tree" Variety="Top Huge B" />
+				<Frame UV="1056,176" Name="Underground Jungle Tree" Variety="Trunk Large G" />
+				<Frame UV="1078,176" Name="Underground Jungle Tree" Variety="Base Plain C" />
+				<Frame UV="1100,176" Name="Underground Jungle Tree" Variety="Base Plain C" />
+				<Frame UV="1122,176" Name="Underground Jungle Tree" Variety="Trunk Large H" />
+				<Frame UV="1144,176" Name="Underground Jungle Tree" Variety="Trunk Large I" />
+				<Frame UV="1188,176" Name="Underground Jungle Tree" Variety="Top Small Double Slight Bulge C" />
+				<Frame UV="1210,176" Name="Underground Jungle Tree" Variety="Top Huge C" />
+				<Frame UV="1056,198" Name="Underground Jungle Tree" Variety="Top Jagged A" />
+				<Frame UV="1056,220" Name="Underground Jungle Tree" Variety="Top Jagged B" />
+				<Frame UV="1056,242" Name="Underground Jungle Tree" Variety="Top Jagged C" />				
+				<Frame UV="1232,0" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Plain A" />
+				<Frame UV="1254,0" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Indent A" />
+				<Frame UV="1276,0" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Slight Bulge A" />
+				<Frame UV="1298,0" Name="Giant Glowing Mushroom (Surface)" Variety="Branch Plain A" />
+				<Frame UV="1320,0" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Left Slight Bulge A" />
+				<Frame UV="1342,0" Name="Giant Glowing Mushroom (Surface)" Variety="Top Medium A" />
+				<Frame UV="1364,0" Name="Giant Glowing Mushroom (Surface)" Variety="Top Small A" />
+				<Frame UV="1386,0" Name="Giant Glowing Mushroom (Surface)" Variety="Top Large A" />
+				<Frame UV="1232,22" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Plain B" />
+				<Frame UV="1254,22" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Indent B" />
+				<Frame UV="1276,22" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Slight Bulge B" />
+				<Frame UV="1298,22" Name="Giant Glowing Mushroom (Surface)" Variety="Branch Plain B" />
+				<Frame UV="1320,22" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Left Slight Bulge B" />
+				<Frame UV="1342,22" Name="Giant Glowing Mushroom (Surface)" Variety="Top Medium B" />
+				<Frame UV="1364,22" Name="Giant Glowing Mushroom (Surface)" Variety="Top Small B" />
+				<Frame UV="1386,22" Name="Giant Glowing Mushroom (Surface)" Variety="Top Large B" />
+				<Frame UV="1232,44" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Plain C" />
+				<Frame UV="1254,44" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Indent C" />
+				<Frame UV="1276,44" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Slight Bulge C" />
+				<Frame UV="1298,44" Name="Giant Glowing Mushroom (Surface)" Variety="Branch Plain C" />
+				<Frame UV="1320,44" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Left Slight Bulge C" />
+				<Frame UV="1342,44" Name="Giant Glowing Mushroom (Surface)" Variety="Top Medium C" />
+				<Frame UV="1364,44" Name="Giant Glowing Mushroom (Surface)" Variety="Top Small C" />
+				<Frame UV="1386,44" Name="Giant Glowing Mushroom (Surface)" Variety="Top Large C" />
+				<Frame UV="1232,66" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Left Indent A" />
+				<Frame UV="1254,66" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Bulge A" />
+				<Frame UV="1276,66" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Left Bulge A" />
+				<Frame UV="1298,66" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Slight Bulge D" />
+				<Frame UV="1320,66" Name="Giant Glowing Mushroom (Surface)" Variety="Branch Plain A" />
+				<Frame UV="1342,66" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Double Slight Bulge A" />
+				<Frame UV="1364,66" Name="Giant Glowing Mushroom (Surface)" Variety="Top Small Right Slight Bulge A" />
+				<Frame UV="1386,66" Name="Giant Glowing Mushroom (Surface)" Variety="Top Large D" />
+				<Frame UV="1232,88" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Left Indent B" />
+				<Frame UV="1254,88" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Bulge B" />
+				<Frame UV="1276,88" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Left Bulge B" />
+				<Frame UV="1298,88" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Slight Bulge E" />
+				<Frame UV="1320,88" Name="Giant Glowing Mushroom (Surface)" Variety="Branch Plain B" />
+				<Frame UV="1342,88" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Double Slight Bulge B" />
+				<Frame UV="1364,88" Name="Giant Glowing Mushroom (Surface)" Variety="Top Small Right Slight Bulge B" />
+				<Frame UV="1386,88" Name="Giant Glowing Mushroom (Surface)" Variety="Top Large E" />
+				<Frame UV="1232,110" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Left Indent C" />
+				<Frame UV="1254,110" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Bulge C" />
+				<Frame UV="1276,110" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Left Bulge C" />
+				<Frame UV="1298,110" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Right Slight Bulge F" />
+				<Frame UV="1320,110" Name="Giant Glowing Mushroom (Surface)" Variety="Branch Plain C" />
+				<Frame UV="1342,110" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Double Slight Bulge C" />
+				<Frame UV="1364,110" Name="Giant Glowing Mushroom (Surface)" Variety="Top Small Right Slight Bulge C" />
+				<Frame UV="1386,110" Name="Giant Glowing Mushroom (Surface)" Variety="Top Large F" />
+				<Frame UV="1232,132" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Large A" />
+				<Frame UV="1254,132" Name="Giant Glowing Mushroom (Surface)" Variety="Base Plain A" />
+				<Frame UV="1276,132" Name="Giant Glowing Mushroom (Surface)" Variety="Base Plain A" />
+				<Frame UV="1298,132" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Large B" />
+				<Frame UV="1320,132" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Large C" />
+				<Frame UV="1364,132" Name="Giant Glowing Mushroom (Surface)" Variety="Top Small Double Slight Bulge A" />
+				<Frame UV="1386,132" Name="Giant Glowing Mushroom (Surface)" Variety="Top Huge A" />
+				<Frame UV="1232,154" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Large D" />
+				<Frame UV="1254,154" Name="Giant Glowing Mushroom (Surface)" Variety="Base Plain B" />
+				<Frame UV="1276,154" Name="Giant Glowing Mushroom (Surface)" Variety="Base Plain B" />
+				<Frame UV="1298,154" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Large E" />
+				<Frame UV="1320,154" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Large F" />
+				<Frame UV="1364,154" Name="Giant Glowing Mushroom (Surface)" Variety="Top Small Double Slight Bulge B" />
+				<Frame UV="1386,154" Name="Giant Glowing Mushroom (Surface)" Variety="Top Huge B" />
+				<Frame UV="1232,176" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Large G" />
+				<Frame UV="1254,176" Name="Giant Glowing Mushroom (Surface)" Variety="Base Plain C" />
+				<Frame UV="1276,176" Name="Giant Glowing Mushroom (Surface)" Variety="Base Plain C" />
+				<Frame UV="1298,176" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Large H" />
+				<Frame UV="1320,176" Name="Giant Glowing Mushroom (Surface)" Variety="Trunk Large I" />
+				<Frame UV="1364,176" Name="Giant Glowing Mushroom (Surface)" Variety="Top Small Double Slight Bulge C" />
+				<Frame UV="1386,176" Name="Giant Glowing Mushroom (Surface)" Variety="Top Huge C" />
+				<Frame UV="1232,198" Name="Giant Glowing Mushroom (Surface)" Variety="Top Jagged A" />
+				<Frame UV="1232,220" Name="Giant Glowing Mushroom (Surface)" Variety="Top Jagged B" />
+				<Frame UV="1232,242" Name="Giant Glowing Mushroom (Surface)" Variety="Top Jagged C" />
 			</Frames>
 		</Tile>
 		<Tile Id="6" Color="#FF8C6550" Name="Iron Ore" Solid="true" Blends="true" MergeWith="0" />
@@ -3398,7 +3398,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="72,0" Variety="Standard" />
 			</Frames>
 		</Tile>
-		<Tile Id="72" Color="#FFB6AF82" Name="Mushroom Tree" Framed="true" Light="true">
+		<Tile Id="72" Color="#FFB6AF82" Name="Giant Glowing Mushroom (Underground)" Framed="true" Light="true">
 			<Frames>
 				<Frame UV="0,0" Variety="Trunk A" />
 				<Frame UV="18,0" Variety="Top Plain" />
@@ -6387,17 +6387,94 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="322" Color="#FFC6AA68" Name="Palm Wood" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="323" Color="#FFB68D56" Name="Palm Tree" Framed="true" Blends="true" TextureGrid="20,20">
 			<Frames>
-				<Frame UV="0,0" Variety="Trunk 1" />
-				<Frame UV="22,0" Variety="Trunk 2" />
-				<Frame UV="44,0" Variety="Trunk 3" />
-				<Frame UV="66,0" Variety="Trunk Bottom" />
-				<Frame UV="88,0" Variety="Trunk Topper 1" />
-				<Frame UV="110,0" Variety="Trunk Topper 2" />
-				<Frame UV="132,0" Variety="Trunk Topper 3" />
-				<Frame UV="154,0" Variety="Trunk Topper 1 No Leaves" />
-				<Frame UV="176,0" Variety="Trunk Topper 2 No Leaves" />
-				<Frame UV="198,0" Variety="Trunk Topper 3 No Leaves" />
-				<Frame UV="220,0" Variety="Trunk Bottom Only" />
+				<Frame UV="0,22" Name="Palm Tree" Variety="Trunk A" />
+				<Frame UV="22,22" Name="Palm Tree" Variety="Trunk B" />
+				<Frame UV="44,22" Name="Palm Tree" Variety="Trunk C" />
+				<Frame UV="66,22" Name="Palm Tree" Variety="Base A" />
+				<Frame UV="88,22" Name="Palm Tree" Variety="Top A" />
+				<Frame UV="110,22" Name="Palm Tree" Variety="Top B" />
+				<Frame UV="132,22" Name="Palm Tree" Variety="Top C" />
+				<Frame UV="154,22" Name="Palm Tree" Variety="Top A No Leaves" />
+				<Frame UV="176,22" Name="Palm Tree" Variety="Top B No Leaves" />
+				<Frame UV="198,22" Name="Palm Tree" Variety="Top C No Leaves" />
+				<Frame UV="220,22" Name="Palm Tree" Variety="Base Only A" />
+				<Frame UV="0,22" Name="Hallowed Palm Tree" Variety="Trunk A" />
+				<Frame UV="22,22" Name="Hallowed Palm Tree" Variety="Trunk B" />
+				<Frame UV="44,22" Name="Hallowed Palm Tree" Variety="Trunk C" />
+				<Frame UV="66,22" Name="Hallowed Palm Tree" Variety="Base A" />
+				<Frame UV="88,22" Name="Hallowed Palm Tree" Variety="Top A" />
+				<Frame UV="110,22" Name="Hallowed Palm Tree" Variety="Top B" />
+				<Frame UV="132,22" Name="Hallowed Palm Tree" Variety="Top C" />
+				<Frame UV="154,22" Name="Hallowed Palm Tree" Variety="Top A No Leaves" />
+				<Frame UV="176,22" Name="Hallowed Palm Tree" Variety="Top B No Leaves" />
+				<Frame UV="198,22" Name="Hallowed Palm Tree" Variety="Top C No Leaves" />
+				<Frame UV="220,22" Name="Hallowed Palm Tree" Variety="Base Only A" />
+				<Frame UV="0,44" Name="Crimson Palm Tree" Variety="Trunk A" />
+				<Frame UV="22,44" Name="Crimson Palm Tree" Variety="Trunk B" />
+				<Frame UV="44,44" Name="Crimson Palm Tree" Variety="Trunk C" />
+				<Frame UV="66,44" Name="Crimson Palm Tree" Variety="Base A" />
+				<Frame UV="88,44" Name="Crimson Palm Tree" Variety="Top A" />
+				<Frame UV="110,44" Name="Crimson Palm Tree" Variety="Top B" />
+				<Frame UV="132,44" Name="Crimson Palm Tree" Variety="Top C" />
+				<Frame UV="154,44" Name="Crimson Palm Tree" Variety="Top A No Leaves" />
+				<Frame UV="176,44" Name="Crimson Palm Tree" Variety="Top B No Leaves" />
+				<Frame UV="198,44" Name="Crimson Palm Tree" Variety="Top C No Leaves" />
+				<Frame UV="220,44" Name="Crimson Palm Tree" Variety="Base Only A" />
+				<Frame UV="0,66" Name="Corrupt Palm Tree" Variety="Trunk A" />
+				<Frame UV="22,66" Name="Corrupt Palm Tree" Variety="Trunk B" />
+				<Frame UV="44,66" Name="Corrupt Palm Tree" Variety="Trunk C" />
+				<Frame UV="66,66" Name="Corrupt Palm Tree" Variety="Base A" />
+				<Frame UV="88,66" Name="Corrupt Palm Tree" Variety="Top A" />
+				<Frame UV="110,66" Name="Corrupt Palm Tree" Variety="Top B" />
+				<Frame UV="132,66" Name="Corrupt Palm Tree" Variety="Top C" />
+				<Frame UV="154,66" Name="Corrupt Palm Tree" Variety="Top A No Leaves" />
+				<Frame UV="176,66" Name="Corrupt Palm Tree" Variety="Top B No Leaves" />
+				<Frame UV="198,66" Name="Corrupt Palm Tree" Variety="Top C No Leaves" />
+				<Frame UV="220,66" Name="Corrupt Palm Tree" Variety="Base Only A" />
+				<Frame UV="0,88" Name="Palm Tree" Variety="Trunk D" />
+				<Frame UV="22,88" Name="Palm Tree" Variety="Trunk E" />
+				<Frame UV="44,88" Name="Palm Tree" Variety="Trunk F" />
+				<Frame UV="66,88" Name="Palm Tree" Variety="Base B" />
+				<Frame UV="88,88" Name="Palm Tree" Variety="Top D" />
+				<Frame UV="110,88" Name="Palm Tree" Variety="Top E" />
+				<Frame UV="132,88" Name="Palm Tree" Variety="Top F" />
+				<Frame UV="154,88" Name="Palm Tree" Variety="Top D No Leaves" />
+				<Frame UV="176,88" Name="Palm Tree" Variety="Top E No Leaves" />
+				<Frame UV="198,88" Name="Palm Tree" Variety="Top F No Leaves" />
+				<Frame UV="220,88" Name="Palm Tree" Variety="Base Only B" />
+				<Frame UV="0,110" Name="Hallowed Palm Tree" Variety="Trunk D" />
+				<Frame UV="22,110" Name="Hallowed Palm Tree" Variety="Trunk E" />
+				<Frame UV="44,110" Name="Hallowed Palm Tree" Variety="Trunk F" />
+				<Frame UV="66,110" Name="Hallowed Palm Tree" Variety="Base B" />
+				<Frame UV="88,110" Name="Hallowed Palm Tree" Variety="Top D" />
+				<Frame UV="110,110" Name="Hallowed Palm Tree" Variety="Top E" />
+				<Frame UV="132,110" Name="Hallowed Palm Tree" Variety="Top F" />
+				<Frame UV="154,110" Name="Hallowed Palm Tree" Variety="Top D No Leaves" />
+				<Frame UV="176,110" Name="Hallowed Palm Tree" Variety="Top E No Leaves" />
+				<Frame UV="198,110" Name="Hallowed Palm Tree" Variety="Top F No Leaves" />
+				<Frame UV="220,110" Name="Hallowed Palm Tree" Variety="Base Only B" />
+				<Frame UV="0,132" Name="Crimson Palm Tree" Variety="Trunk D" />
+				<Frame UV="22,132" Name="Crimson Palm Tree" Variety="Trunk E" />
+				<Frame UV="44,132" Name="Crimson Palm Tree" Variety="Trunk F" />
+				<Frame UV="66,132" Name="Crimson Palm Tree" Variety="Base B" />
+				<Frame UV="88,132" Name="Crimson Palm Tree" Variety="Top D" />
+				<Frame UV="110,132" Name="Crimson Palm Tree" Variety="Top E" />
+				<Frame UV="132,132" Name="Crimson Palm Tree" Variety="Top F" />
+				<Frame UV="154,132" Name="Crimson Palm Tree" Variety="Top D No Leaves" />
+				<Frame UV="176,132" Name="Crimson Palm Tree" Variety="Top E No Leaves" />
+				<Frame UV="198,132" Name="Crimson Palm Tree" Variety="Top F No Leaves" />
+				<Frame UV="220,132" Name="Crimson Palm Tree" Variety="Base Only B" />
+				<Frame UV="0,154" Name="Corrupt Palm Tree" Variety="Trunk D" />
+				<Frame UV="22,154" Name="Corrupt Palm Tree" Variety="Trunk E" />
+				<Frame UV="44,154" Name="Corrupt Palm Tree" Variety="Trunk F" />
+				<Frame UV="66,154" Name="Corrupt Palm Tree" Variety="Base B" />
+				<Frame UV="88,154" Name="Corrupt Palm Tree" Variety="Top D" />
+				<Frame UV="110,154" Name="Corrupt Palm Tree" Variety="Top E" />
+				<Frame UV="132,154" Name="Corrupt Palm Tree" Variety="Top F" />
+				<Frame UV="154,154" Name="Corrupt Palm Tree" Variety="Top D No Leaves" />
+				<Frame UV="176,154" Name="Corrupt Palm Tree" Variety="Top E No Leaves" />
+				<Frame UV="198,154" Name="Corrupt Palm Tree" Variety="Top F No Leaves" />
+				<Frame UV="220,154" Name="Corrupt Palm Tree" Variety="Base Only B" />
 			</Frames>
 		</Tile>
 		<Tile Id="324" Color="#FFE4D5AD" Name="Seashell" Framed="true" TextureGrid="20,20">
@@ -8087,7 +8164,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Ore Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8112,7 +8189,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8120,7 +8197,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8128,27 +8205,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />
@@ -8163,7 +8240,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Ore Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8188,7 +8265,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8196,7 +8273,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8204,27 +8281,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />
@@ -8239,7 +8316,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Ore Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8264,7 +8341,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8272,7 +8349,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8280,27 +8357,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />
@@ -8315,7 +8392,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Ore Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8340,7 +8417,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8348,7 +8425,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8356,27 +8433,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />
@@ -8391,7 +8468,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Ore Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8416,7 +8493,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8424,7 +8501,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8432,27 +8509,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />
@@ -8467,7 +8544,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Ore Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8492,7 +8569,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8500,7 +8577,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8508,27 +8585,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />
@@ -8543,7 +8620,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Ore Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8568,7 +8645,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8576,7 +8653,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8584,27 +8661,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />
@@ -8665,12 +8742,12 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="36,0" Variety="C" />
 			</Frames>
 		</Tile>
-		<Tile Id="596" Name="Vanity Tree Sakura" Framed="true" TextureGrid="20,20" Color="#FF6E5B4D">
+		<Tile Id="596" Color="#FF6E5B4D" Name="Vanity Tree Sakura" Framed="true" TextureGrid="20,20">
 			<Frames>
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8695,7 +8772,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8703,7 +8780,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8711,27 +8788,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />
@@ -8783,12 +8860,12 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="36,0" Variety="C" />
 			</Frames>
 		</Tile>
-		<Tile Id="616" Name="Vanity Tree Yellow Willow" Framed="true" TextureGrid="20,20" Color="#FF854F4D">
+		<Tile Id="616" Color="#FF854F4D" Name="Vanity Tree Yellow Willow" Framed="true" TextureGrid="20,20">
 			<Frames>
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8813,7 +8890,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8821,7 +8898,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8829,27 +8906,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />
@@ -8909,7 +8986,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,0" Variety="Trunk Plain A" />
 				<Frame UV="22,0" Variety="Trunk Ore Right Indent A" />
 				<Frame UV="44,0" Variety="Trunk Right Slight Bulge A" />
-				<Frame UV="66,0" Variety="Branch Plain A" Anchor="Right" />
+				<Frame UV="66,0" Variety="Branch Plain A" />
 				<Frame UV="88,0" Variety="Trunk Left Slight Bulge A" />
 				<Frame UV="110,0" Variety="Top Medium A" />
 				<Frame UV="132,0" Variety="Top Small A" />
@@ -8934,7 +9011,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,66" Variety="Trunk Right Bulge A" />
 				<Frame UV="44,66" Variety="Trunk Left Bulge A" />
 				<Frame UV="66,66" Variety="Trunk Right Slight Bulge D" />
-				<Frame UV="88,66" Variety="Branch Plain A" Anchor="Left" />
+				<Frame UV="88,66" Variety="Branch Plain A" />
 				<Frame UV="110,66" Variety="Trunk Double Slight Bulge A" />
 				<Frame UV="132,66" Variety="Top Small Right Slight Bulge A" />
 				<Frame UV="154,66" Variety="Top Large D" />
@@ -8942,7 +9019,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,88" Variety="Trunk Right Bulge B" />
 				<Frame UV="44,88" Variety="Trunk Left Bulge B" />
 				<Frame UV="66,88" Variety="Trunk Right Slight Bulge E" />
-				<Frame UV="88,88" Variety="Branch Plain B" Anchor="Left" />
+				<Frame UV="88,88" Variety="Branch Plain B" />
 				<Frame UV="110,88" Variety="Trunk Double Slight Bulge B" />
 				<Frame UV="132,88" Variety="Top Small Right Slight Bulge B" />
 				<Frame UV="154,88" Variety="Top Large E" />
@@ -8950,27 +9027,27 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="22,110" Variety="Trunk Right Bulge C" />
 				<Frame UV="44,110" Variety="Trunk Left Bulge C" />
 				<Frame UV="66,110" Variety="Trunk Right Slight Bulge F" />
-				<Frame UV="88,110" Variety="Branch Plain C" Anchor="Left" />
+				<Frame UV="88,110" Variety="Branch Plain C" />
 				<Frame UV="110,110" Variety="Trunk Double Slight Bulge C" />
 				<Frame UV="132,110" Variety="Top Small Right Slight Bulge C" />
 				<Frame UV="154,110" Variety="Top Large F" />
 				<Frame UV="0,132" Variety="Trunk Large A" />
-				<Frame UV="22,132" Variety="Base Plain A" Anchor="Left" />
-				<Frame UV="44,132" Variety="Base Plain A" Anchor="Right" />
+				<Frame UV="22,132" Variety="Base Plain A" />
+				<Frame UV="44,132" Variety="Base Plain A" />
 				<Frame UV="66,132" Variety="Trunk Large B" />
 				<Frame UV="88,132" Variety="Trunk Large C" />
 				<Frame UV="132,132" Variety="Top Small Double Slight Bulge A" />
 				<Frame UV="154,132" Variety="Top Huge A" />
 				<Frame UV="0,154" Variety="Trunk Large D" />
-				<Frame UV="22,154" Variety="Base Plain B" Anchor="Left" />
-				<Frame UV="44,154" Variety="Base Plain B" Anchor="Right" />
+				<Frame UV="22,154" Variety="Base Plain B" />
+				<Frame UV="44,154" Variety="Base Plain B" />
 				<Frame UV="66,154" Variety="Trunk Large E" />
 				<Frame UV="88,154" Variety="Trunk Large F" />
 				<Frame UV="132,154" Variety="Top Small Double Slight Bulge B" />
 				<Frame UV="154,154" Variety="Top Huge B" />
 				<Frame UV="0,176" Variety="Trunk Large G" />
-				<Frame UV="22,176" Variety="Base Plain C" Anchor="Left" />
-				<Frame UV="44,176" Variety="Base Plain C" Anchor="Right" />
+				<Frame UV="22,176" Variety="Base Plain C" />
+				<Frame UV="44,176" Variety="Base Plain C" />
 				<Frame UV="66,176" Variety="Trunk Large H" />
 				<Frame UV="88,176" Variety="Trunk Large I" />
 				<Frame UV="132,176" Variety="Top Small Double Slight Bulge C" />

--- a/src/TEdit/settings.xml
+++ b/src/TEdit/settings.xml
@@ -134,53 +134,53 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="0" Color="#FF976B4B" Name="Dirt Block" Solid="true" Blends="true" />
 		<Tile Id="1" Color="#FF808080" Name="Stone Block" Solid="true" Blends="true" MergeWith="0" Stone="true" />
 		<Tile Id="2" Color="#FF1CD85E" Name="Grass Block" Solid="true" Blends="true" MergeWith="0" Special="Grass" />
-		<Tile Id="3" Color="#FF1BC56D" Name="Grass Flowers" Framed="true" TextureGrid="16,20">
+		<Tile Id="3" Color="#FF1BC56D" Name="Forest Short Plants" Framed="true" TextureGrid="16,20">
 			<Frames>
-				<Frame UV="0,0" Name="Tall Grass" Variety="Single Blade" />
-				<Frame UV="18,0" Name="Tall Grass" Variety="Double Blade" />
-				<Frame UV="36,0" Name="Tall Grass" Variety="Small Y" />
-				<Frame UV="54,0" Name="Tall Grass" Variety="Three Small" />
-				<Frame UV="72,0" Name="Tall Grass" Variety="Single Blade" />
-				<Frame UV="90,0" Name="Tall Grass" Variety="Three Large" />
+				<Frame UV="0,0" Variety="Grass Single Blade" />
+				<Frame UV="18,0" Variety="Grass Double Blade" />
+				<Frame UV="36,0" Variety="Grass Small Y" />
+				<Frame UV="54,0" Variety="Grass Three Small" />
+				<Frame UV="72,0" Variety="Grass Single Blade" />
+				<Frame UV="90,0" Variety="Grass Three Large" />
 				<Frame UV="144,0" Name="Mushroom" />
-				<Frame UV="108,0" Name="Magenta Flower" Variety="A" />
-				<Frame UV="540,0" Name="Magenta Flower" Variety="B" />
-				<Frame UV="558,0" Name="Magenta Flower" Variety="C" />
-				<Frame UV="576,0" Name="Magenta Flower" Variety="D" />
-				<Frame UV="126,0" Name="Pink Flower" Variety="A" />
-				<Frame UV="306,0" Name="Pink Flower" Variety="B" />
-				<Frame UV="594,0" Name="Pink Flower" Variety="C" />
-				<Frame UV="612,0" Name="Pink Flower" Variety="D" />
-				<Frame UV="630,0" Name="Pink Flower" Variety="E" />
-				<Frame UV="162,0" Name="Blue Flower" Variety="A" />
-				<Frame UV="288,0" Name="Blue Flower" Variety="B" />
-				<Frame UV="360,0" Name="Blue Flower" Variety="C" />
-				<Frame UV="180,0" Name="Yellow Flower" Variety="A" />
-				<Frame UV="198,0" Name="Yellow Flower" Variety="B" />
-				<Frame UV="234,0" Name="Yellow Flower" Variety="C" />
-				<Frame UV="324,0" Name="Yellow Flower" Variety="D" />
-				<Frame UV="432,0" Name="Yellow Flower" Variety="E" />
-				<Frame UV="450,0" Name="Yellow Flower" Variety="F" />
-				<Frame UV="468,0" Name="Yellow Flower" Variety="G" />
-				<Frame UV="216,0" Name="Violet Flower" Variety="A" />
-				<Frame UV="756,0" Name="Violet Flower" Variety="B" />
-				<Frame UV="774,0" Name="Violet Flower" Variety="C" />
-				<Frame UV="792,0" Name="Violet Flower" Variety="D" />
-				<Frame UV="252,0" Name="White Flower" Variety="A" />
-				<Frame UV="270,0" Name="White Flower" Variety="B" />
-				<Frame UV="486,0" Name="White Flower" Variety="C" />
-				<Frame UV="504,0" Name="White Flower" Variety="D" />
-				<Frame UV="522,0" Name="White Flower" Variety="E" />
-				<Frame UV="648,0" Name="White Flower" Variety="F" />
-				<Frame UV="666,0" Name="White Flower" Variety="G" />
-				<Frame UV="684,0" Name="White Flower" Variety="H" />
-				<Frame UV="342,0" Name="Red Flower" Variety="A" />
-				<Frame UV="378,0" Name="Red Flower" Variety="B" />
-				<Frame UV="396,0" Name="Red Flower" Variety="C" />
-				<Frame UV="414,0" Name="Red Flower" Variety="D" />
-				<Frame UV="702,0" Name="Red Flower" Variety="E" />
-				<Frame UV="720,0" Name="Red Flower" Variety="F" />
-				<Frame UV="738,0" Name="Red Flower" Variety="G" />
+				<Frame UV="108,0" Variety="Magenta Flower A" />
+				<Frame UV="540,0" Variety="Magenta Flower B" />
+				<Frame UV="558,0" Variety="Magenta Flower C" />
+				<Frame UV="576,0" Variety="Magenta Flower D" />
+				<Frame UV="126,0" Variety="Pink Flower A" />
+				<Frame UV="306,0" Variety="Pink Flower B" />
+				<Frame UV="594,0" Variety="Pink Flower C" />
+				<Frame UV="612,0" Variety="Pink Flower D" />
+				<Frame UV="630,0" Variety="Pink Flower E" />
+				<Frame UV="162,0" Variety="Blue Flower A" />
+				<Frame UV="288,0" Variety="Blue Flower B" />
+				<Frame UV="360,0" Variety="Blue Flower C" />
+				<Frame UV="180,0" Variety="Yellow Flower A" />
+				<Frame UV="198,0" Variety="Yellow Flower B" />
+				<Frame UV="234,0" Variety="Yellow Flower C" />
+				<Frame UV="324,0" Variety="Yellow Flower D" />
+				<Frame UV="432,0" Variety="Yellow Flower E" />
+				<Frame UV="450,0" Variety="Yellow Flower F" />
+				<Frame UV="468,0" Variety="Yellow Flower G" />
+				<Frame UV="216,0" Variety="Violet Flower A" />
+				<Frame UV="756,0" Variety="Violet Flower B" />
+				<Frame UV="774,0" Variety="Violet Flower C" />
+				<Frame UV="792,0" Variety="Violet Flower D" />
+				<Frame UV="252,0" Variety="White Flower A" />
+				<Frame UV="270,0" Variety="White Flower B" />
+				<Frame UV="486,0" Variety="White Flower C" />
+				<Frame UV="504,0" Variety="White Flower D" />
+				<Frame UV="522,0" Variety="White Flower E" />
+				<Frame UV="648,0" Variety="White Flower F" />
+				<Frame UV="666,0" Variety="White Flower G" />
+				<Frame UV="684,0" Variety="White Flower H" />
+				<Frame UV="342,0" Variety="Red Flower A" />
+				<Frame UV="378,0" Variety="Red Flower B" />
+				<Frame UV="396,0" Variety="Red Flower C" />
+				<Frame UV="414,0" Variety="Red Flower D" />
+				<Frame UV="702,0" Variety="Red Flower E" />
+				<Frame UV="720,0" Variety="Red Flower F" />
+				<Frame UV="738,0" Variety="Red Flower G" />
 			</Frames>
 		</Tile>
 		<Tile Id="4" Color="#FFFDDD03" Name="Torch" Framed="true" Size="1,1" TextureGrid="20,20" Placement="wallFloor" Light="true">
@@ -2812,31 +2812,31 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		</Tile>
 		<Tile Id="22" Color="#FF625FA7" Name="Demonite Ore" Solid="true" Blends="true" MergeWith="0" Light="true" />
 		<Tile Id="23" Color="#FF8D89DF" Name="Corrupt Grass Block" Solid="true" Blends="true" MergeWith="0" Special="Grass" />
-		<Tile Id="24" Color="#FF7A74DA" Name="Corruption Plants" Framed="true" TextureGrid="16,20">
+		<Tile Id="24" Color="#FF7A74DA" Name="Corruption Short Plants" Framed="true" TextureGrid="16,20">
 			<Frames>
-				<Frame UV="0,0" Name="Vile Grass" Variety="Single Blade" />
-				<Frame UV="18,0" Name="Vile Grass" Variety="Double Blade" />
-				<Frame UV="36,0" Name="Vile Grass" Variety="Small Y" />
-				<Frame UV="54,0" Name="Vile Grass" Variety="Three Small" />
-				<Frame UV="72,0" Name="Vile Grass" Variety="Single Blade" />
-				<Frame UV="90,0" Name="Vile Grass" Variety="Three Large" />
+				<Frame UV="0,0" Variety="Grass Single Blade" />
+				<Frame UV="18,0" Variety="Grass Double Blade" />
+				<Frame UV="36,0" Variety="Grass Small Y" />
+				<Frame UV="54,0" Variety="Grass Three Small" />
+				<Frame UV="72,0" Variety="Grass Single Blade" />
+				<Frame UV="90,0" Variety="Grass Three Large" />
 				<Frame UV="144,0" Name="Vile Mushroom" />
-				<Frame UV="108,0" Name="Vile Flowers" Variety="A" />
-				<Frame UV="126,0" Name="Vile Flowers" Variety="B" />
-				<Frame UV="162,0" Name="Vile Flowers" Variety="C" />
-				<Frame UV="180,0" Name="Vile Flowers" Variety="D" />
-				<Frame UV="198,0" Name="Vile Flowers" Variety="E" />
-				<Frame UV="216,0" Name="Vile Flowers" Variety="F" />
-				<Frame UV="234,0" Name="Vile Flowers" Variety="G" />
-				<Frame UV="252,0" Name="Vile Flowers" Variety="H" />
-				<Frame UV="270,0" Name="Vile Flowers" Variety="I" />
-				<Frame UV="288,0" Name="Vile Flowers" Variety="J" />
-				<Frame UV="306,0" Name="Vile Flowers" Variety="K" />
-				<Frame UV="324,0" Name="Vile Flowers" Variety="L" />
-				<Frame UV="342,0" Name="Vile Flowers" Variety="M" />
-				<Frame UV="360,0" Name="Vile Flowers" Variety="N" />
-				<Frame UV="378,0" Name="Vile Flowers" Variety="O" />
-				<Frame UV="396,0" Name="Vile Flowers" Variety="P" />
+				<Frame UV="108,0" Variety="Flower A" />
+				<Frame UV="126,0" Variety="Flower B" />
+				<Frame UV="162,0" Variety="Flower C" />
+				<Frame UV="180,0" Variety="Flower D" />
+				<Frame UV="198,0" Variety="Flower E" />
+				<Frame UV="216,0" Variety="Flower F" />
+				<Frame UV="234,0" Variety="Flower G" />
+				<Frame UV="252,0" Variety="Flower H" />
+				<Frame UV="270,0" Variety="Flower I" />
+				<Frame UV="288,0" Variety="Flower J" />
+				<Frame UV="306,0" Variety="Flower K" />
+				<Frame UV="324,0" Variety="Flower L" />
+				<Frame UV="342,0" Variety="Flower M" />
+				<Frame UV="360,0" Variety="Flower N" />
+				<Frame UV="378,0" Variety="Flower O" />
+				<Frame UV="396,0" Variety="Flower P" />
 			</Frames>
 		</Tile>
 		<Tile Id="25" Color="#FF6D5A80" Name="Ebonstone Block" Solid="true" Blends="true" MergeWith="0" />
@@ -3353,31 +3353,31 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="58" Color="#FF8E4242" Name="Hellstone Ore" Solid="true" Blends="true" MergeWith="57" Light="true" />
 		<Tile Id="59" Color="#FF5C4449" Name="Mud Block" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="60" Color="#FF8FD71D" Name="Jungle Grass Block" Solid="true" Blends="true" MergeWith="59" Special="Grass" />
-		<Tile Id="61" Color="#FF87C41A" Name="Jungle Plants" Framed="true" TextureGrid="16,20" Light="true">
+		<Tile Id="61" Color="#FF87C41A" Name="Jungle Short Plants" Framed="true" TextureGrid="16,20" Light="true">
 			<Frames>
-				<Frame UV="0,0" Name="Jungle Grass" Variety="Single Blade" />
-				<Frame UV="18,0" Name="Jungle Grass" Variety="Double Blade" />
-				<Frame UV="36,0" Name="Jungle Grass" Variety="Small Y" />
-				<Frame UV="54,0" Name="Jungle Grass" Variety="Three Small" />
-				<Frame UV="72,0" Name="Jungle Grass" Variety="Single Blade" />
-				<Frame UV="90,0" Name="Jungle Grass" Variety="Three Large" />
-				<Frame UV="108,0" Name="Jungle Flowers" Variety="A" />
-				<Frame UV="126,0" Name="Jungle Flowers" Variety="B" />
-				<Frame UV="144,0" Name="Jungle Spores" />
+				<Frame UV="0,0" Variety="Grass Single Blade" />
+				<Frame UV="18,0" Variety="Grass Double Blade" />
+				<Frame UV="36,0" Variety="Grass Small Y" />
+				<Frame UV="54,0" Variety="Grass Three Small" />
+				<Frame UV="72,0" Variety="Grass Single Blade" />
+				<Frame UV="90,0" Variety="Grass Three Large" />
+				<Frame UV="108,0" Variety="Flower A" />
+				<Frame UV="126,0" Variety="Flower B" />
+				<Frame UV="144,0" Name="Jungle Spore" />
 				<Frame UV="162,0" Name="Nature's Gift" />
-				<Frame UV="180,0" Name="Jungle Flowers" Variety="C" />
-				<Frame UV="198,0" Name="Jungle Flowers" Variety="D" />
-				<Frame UV="216,0" Name="Jungle Flowers" Variety="E" />
-				<Frame UV="234,0" Name="Jungle Flowers" Variety="F" />
-				<Frame UV="252,0" Name="Jungle Flowers" Variety="G" />
-				<Frame UV="270,0" Name="Jungle Flowers" Variety="H" />
-				<Frame UV="288,0" Name="Jungle Flowers" Variety="I" />
-				<Frame UV="306,0" Name="Jungle Flowers" Variety="J" />
-				<Frame UV="324,0" Name="Jungle Flowers" Variety="K" />
-				<Frame UV="342,0" Name="Jungle Flowers" Variety="L" />
-				<Frame UV="360,0" Name="Jungle Flowers" Variety="M" />
-				<Frame UV="378,0" Name="Jungle Flowers" Variety="N" />
-				<Frame UV="396,0" Name="Jungle Flowers" Variety="O" />
+				<Frame UV="180,0" Variety="Flower C" />
+				<Frame UV="198,0" Variety="Flower D" />
+				<Frame UV="216,0" Variety="Flower E" />
+				<Frame UV="234,0" Variety="Flower F" />
+				<Frame UV="252,0" Variety="Flower G" />
+				<Frame UV="270,0" Variety="Flower H" />
+				<Frame UV="288,0" Variety="Flower I" />
+				<Frame UV="306,0" Variety="Flower J" />
+				<Frame UV="324,0" Variety="Flower K" />
+				<Frame UV="342,0" Variety="Flower L" />
+				<Frame UV="360,0" Variety="Flower M" />
+				<Frame UV="378,0" Variety="Flower N" />
+				<Frame UV="396,0" Variety="Flower O" />
 			</Frames>
 		</Tile>
 		<Tile Id="62" Color="#FF79B018" Name="Jungle Vines" Solid="true" Blends="true" />
@@ -3408,72 +3408,72 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="18,36" Variety="Top Right Indent" />
 			</Frames>
 		</Tile>
-		<Tile Id="73" Color="#FF1BC56D" Name="Tall Grass" Framed="true" Size="1,1" TextureGrid="16,32">
+		<Tile Id="73" Color="#FF1BC56D" Name="Forest Tall Plants" Framed="true" Size="1,1" TextureGrid="16,32">
 			<Frames>
-				<Frame UV="0,0" Variety="A" />
-				<Frame UV="18,0" Variety="B" />
-				<Frame UV="36,0" Variety="C" />
-				<Frame UV="54,0" Variety="D" />
-				<Frame UV="72,0" Variety="E" />
-				<Frame UV="90,0" Variety="F" />
-				<Frame UV="108,0" Variety="Magenta Flower A" />
-				<Frame UV="540,0" Variety="Magenta Flower B" />
-				<Frame UV="558,0" Variety="Magenta Flower C" />
-				<Frame UV="576,0" Variety="Magenta Flower D" />
-				<Frame UV="126,0" Variety="Pink Flower A" />
-				<Frame UV="306,0" Variety="Pink Flower B" />
-				<Frame UV="594,0" Variety="Pink Flower C" />
-				<Frame UV="612,0" Variety="Pink Flower D" />
-				<Frame UV="630,0" Variety="Pink Flower E" />
-				<Frame UV="162,0" Variety="Blue Flower A" />
-				<Frame UV="288,0" Variety="Blue Flower B" />
-				<Frame UV="360,0" Variety="Blue Flower C" />
-				<Frame UV="180,0" Variety="Yellow Flower A" />
-				<Frame UV="198,0" Variety="Yellow Flower B" />
-				<Frame UV="234,0" Variety="Yellow Flower C" />
-				<Frame UV="324,0" Variety="Yellow Flower D" />
-				<Frame UV="432,0" Variety="Yellow Flower E" />
-				<Frame UV="450,0" Variety="Yellow Flower F" />
-				<Frame UV="468,0" Variety="Yellow Flower G" />
-				<Frame UV="216,0" Variety="Violet Flower A" />
-				<Frame UV="756,0" Variety="Violet Flower B" />
-				<Frame UV="774,0" Variety="Violet Flower C" />
-				<Frame UV="792,0" Variety="Violet Flower D" />
-				<Frame UV="252,0" Variety="White Flower A" />
-				<Frame UV="270,0" Variety="White Flower B" />
-				<Frame UV="486,0" Variety="White Flower C" />
-				<Frame UV="504,0" Variety="White Flower D" />
-				<Frame UV="522,0" Variety="White Flower E" />
-				<Frame UV="648,0" Variety="White Flower F" />
-				<Frame UV="666,0" Variety="White Flower G" />
-				<Frame UV="684,0" Variety="White Flower H" />
-				<Frame UV="342,0" Variety="Red Flower A" />
-				<Frame UV="378,0" Variety="Red Flower B" />
-				<Frame UV="396,0" Variety="Red Flower C" />
-				<Frame UV="414,0" Variety="Red Flower D" />
-				<Frame UV="702,0" Variety="Red Flower E" />
-				<Frame UV="720,0" Variety="Red Flower F" />
-				<Frame UV="738,0" Variety="Red Flower G" />
+				<Frame UV="0,0" Variety="Grass A" Anchor="Bottom" />
+				<Frame UV="18,0" Variety="Grass B" Anchor="Bottom" />
+				<Frame UV="36,0" Variety="Grass C" Anchor="Bottom" />
+				<Frame UV="54,0" Variety="Grass D" Anchor="Bottom" />
+				<Frame UV="72,0" Variety="Grass E" Anchor="Bottom" />
+				<Frame UV="90,0" Variety="Grass F" Anchor="Bottom" />
+				<Frame UV="108,0" Variety="Magenta Flower A" Anchor="Bottom" />
+				<Frame UV="540,0" Variety="Magenta Flower B" Anchor="Bottom" />
+				<Frame UV="558,0" Variety="Magenta Flower C" Anchor="Bottom" />
+				<Frame UV="576,0" Variety="Magenta Flower D" Anchor="Bottom" />
+				<Frame UV="126,0" Variety="Pink Flower A" Anchor="Bottom" />
+				<Frame UV="306,0" Variety="Pink Flower B" Anchor="Bottom" />
+				<Frame UV="594,0" Variety="Pink Flower C" Anchor="Bottom" />
+				<Frame UV="612,0" Variety="Pink Flower D" Anchor="Bottom" />
+				<Frame UV="630,0" Variety="Pink Flower E" Anchor="Bottom" />
+				<Frame UV="162,0" Variety="Blue Flower A" Anchor="Bottom" />
+				<Frame UV="288,0" Variety="Blue Flower B" Anchor="Bottom" />
+				<Frame UV="360,0" Variety="Blue Flower C" Anchor="Bottom" />
+				<Frame UV="180,0" Variety="Yellow Flower A" Anchor="Bottom" />
+				<Frame UV="198,0" Variety="Yellow Flower B" Anchor="Bottom" />
+				<Frame UV="234,0" Variety="Yellow Flower C" Anchor="Bottom" />
+				<Frame UV="324,0" Variety="Yellow Flower D" Anchor="Bottom" />
+				<Frame UV="432,0" Variety="Yellow Flower E" Anchor="Bottom" />
+				<Frame UV="450,0" Variety="Yellow Flower F" Anchor="Bottom" />
+				<Frame UV="468,0" Variety="Yellow Flower G" Anchor="Bottom" />
+				<Frame UV="216,0" Variety="Violet Flower A" Anchor="Bottom" />
+				<Frame UV="756,0" Variety="Violet Flower B" Anchor="Bottom" />
+				<Frame UV="774,0" Variety="Violet Flower C" Anchor="Bottom" />
+				<Frame UV="792,0" Variety="Violet Flower D" Anchor="Bottom" />
+				<Frame UV="252,0" Variety="White Flower A" Anchor="Bottom" />
+				<Frame UV="270,0" Variety="White Flower B" Anchor="Bottom" />
+				<Frame UV="486,0" Variety="White Flower C" Anchor="Bottom" />
+				<Frame UV="504,0" Variety="White Flower D" Anchor="Bottom" />
+				<Frame UV="522,0" Variety="White Flower E" Anchor="Bottom" />
+				<Frame UV="648,0" Variety="White Flower F" Anchor="Bottom" />
+				<Frame UV="666,0" Variety="White Flower G" Anchor="Bottom" />
+				<Frame UV="684,0" Variety="White Flower H" Anchor="Bottom" />
+				<Frame UV="342,0" Variety="Red Flower A" Anchor="Bottom" />
+				<Frame UV="378,0" Variety="Red Flower B" Anchor="Bottom" />
+				<Frame UV="396,0" Variety="Red Flower C" Anchor="Bottom" />
+				<Frame UV="414,0" Variety="Red Flower D" Anchor="Bottom" />
+				<Frame UV="702,0" Variety="Red Flower E" Anchor="Bottom" />
+				<Frame UV="720,0" Variety="Red Flower F" Anchor="Bottom" />
+				<Frame UV="738,0" Variety="Red Flower G" Anchor="Bottom" />
 			</Frames>
 		</Tile>
-		<Tile Id="74" Color="#FF60C51B" Name="Tall Jungle Grass" Framed="true" Size="1,1" TextureGrid="16,32">
+		<Tile Id="74" Color="#FF60C51B" Name="Jungle Tall Plants" Framed="true" Size="1,1" TextureGrid="16,32">
 			<Frames>
-				<Frame UV="0,0" Variety="A" />
-				<Frame UV="18,0" Variety="B" />
-				<Frame UV="36,0" Variety="C" />
-				<Frame UV="54,0" Variety="D" />
-				<Frame UV="72,0" Variety="E" />
-				<Frame UV="90,0" Variety="F" />
-				<Frame UV="108,0" Variety="Flower A" />
-				<Frame UV="126,0" Variety="Flower B" />
-				<Frame UV="162,0" Variety="Flower C" />
-				<Frame UV="180,0" Variety="Flower D" />
-				<Frame UV="198,0" Variety="Flower E" />
-				<Frame UV="216,0" Variety="Flower F" />
-				<Frame UV="234,0" Variety="Flower G" />
-				<Frame UV="252,0" Variety="Flower H" />
-				<Frame UV="270,0" Variety="Flower I" />
-				<Frame UV="288,0" Variety="Flower J" />
+				<Frame UV="0,0" Variety="A" Anchor="Bottom" />
+				<Frame UV="18,0" Variety="B" Anchor="Bottom" />
+				<Frame UV="36,0" Variety="C" Anchor="Bottom" />
+				<Frame UV="54,0" Variety="D" Anchor="Bottom" />
+				<Frame UV="72,0" Variety="E" Anchor="Bottom" />
+				<Frame UV="90,0" Variety="F" Anchor="Bottom" />
+				<Frame UV="108,0" Variety="Flower A" Anchor="Bottom" />
+				<Frame UV="126,0" Variety="Flower B" Anchor="Bottom" />
+				<Frame UV="162,0" Variety="Flower C" Anchor="Bottom" />
+				<Frame UV="180,0" Variety="Flower D" Anchor="Bottom" />
+				<Frame UV="198,0" Variety="Flower E" Anchor="Bottom" />
+				<Frame UV="216,0" Variety="Flower F" Anchor="Bottom" />
+				<Frame UV="234,0" Variety="Flower G" Anchor="Bottom" />
+				<Frame UV="252,0" Variety="Flower H" Anchor="Bottom" />
+				<Frame UV="270,0" Variety="Flower I" Anchor="Bottom" />
+				<Frame UV="288,0" Variety="Flower J" Anchor="Bottom" />
 			</Frames>
 		</Tile>
 		<Tile Id="75" Color="#FF242424" Name="Obsidian Brick" Solid="true" Blends="true" />
@@ -3581,7 +3581,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="130,0" Variety="Sponge" />
 			</Frames>
 		</Tile>
-		<Tile Id="82" Color="#FFFF7800" Name="Herb Seeds" Framed="true" UseFrameName="true" FrameNamePostfix="seed">
+		<Tile Id="82" Color="#FFFF7800" Name="Herbs (Sprout)" Framed="true" UseFrameName="true" FrameNamePostfix="seed">
 			<Frames>
 				<Frame UV="0,0" Name="Daybloom" growsOn="2,78" />
 				<Frame UV="18,0" Name="Moonglow" growsOn="60,78" />
@@ -3592,7 +3592,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="108,0" Name="Shiverthorn" growsOn="147,161" />
 			</Frames>
 		</Tile>
-		<Tile Id="83" Color="#FFFF7800" Name="Herb Mature" Framed="true" Light="true" UseFrameName="true">
+		<Tile Id="83" Color="#FFFF7800" Name="Herbs (Mature)" Framed="true" Light="true" UseFrameName="true">
 			<Frames>
 				<Frame UV="0,0" Name="Daybloom" growsOn="2,78" />
 				<Frame UV="18,0" Name="Moonglow" growsOn="60,78" />
@@ -3603,7 +3603,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="108,0" Name="Shiverthorn" growsOn="147,161" />
 			</Frames>
 		</Tile>
-		<Tile Id="84" Color="#FFFF7800" Name="Herb Bloom" Framed="true" Light="true" UseFrameName="true" FrameNamePostfix="bloom">
+		<Tile Id="84" Color="#FFFF7800" Name="Herbs (Bloom)" Framed="true" Light="true" UseFrameName="true" FrameNamePostfix="bloom">
 			<Frames>
 				<Frame UV="0,0" Name="Daybloom" growsOn="2,78" />
 				<Frame UV="18,0" Name="Moonglow" growsOn="60,78" />
@@ -4666,45 +4666,45 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="107" Color="#FF0B508F" Name="Cobalt Ore" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="108" Color="#FF5BA9A9" Name="Mythril Ore" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="109" Color="#FF4EC1E3" Name="Hallowed Grass Block" Solid="true" Blends="true" MergeWith="0" Special="Grass" Light="true" />
-		<Tile Id="110" Color="#FF30BA87" Name="Hallowed Plants" Framed="true" TextureGrid="16,20">
+		<Tile Id="110" Color="#FF30BA87" Name="Hallow Short Plants" Framed="true" TextureGrid="16,20">
 			<Frames>
-				<Frame UV="0,0" Name="Hallowed Grass" Variety="Single Blade A" />
-				<Frame UV="18,0" Name="Hallowed Grass" Variety="Double Blade" />
-				<Frame UV="36,0" Name="Hallowed Grass" Variety="Single Blade B" />
-				<Frame UV="54,0" Name="Hallowed Grass" Variety="Three Small" />
-				<Frame UV="72,0" Name="Hallowed Flowers" Variety="A" />
-				<Frame UV="90,0" Name="Hallowed Grass" Variety="Three Large" />
+				<Frame UV="0,0" Variety="Grass Single Blade A" />
+				<Frame UV="18,0" Variety="Grass Double Blade" />
+				<Frame UV="36,0" Variety="Grass Single Blade B" />
+				<Frame UV="54,0" Variety="Grass Three Small" />
+				<Frame UV="90,0" Variety="Grass Three Large" />
+				<Frame UV="162,0" Variety="Grass Small Y" />
 				<Frame UV="144,0" Name="Mushroom (growing)" />
-				<Frame UV="108,0" Name="Hallowed Flowers" Variety="B" />
-				<Frame UV="126,0" Name="Hallowed Flowers" Variety="C" />
-				<Frame UV="162,0" Name="Hallowed Grass" Variety="Small Y" />
-				<Frame UV="180,0" Name="Hallowed Flowers" Variety="D" />
-				<Frame UV="198,0" Name="Hallowed Flowers" Variety="E" />
-				<Frame UV="216,0" Name="Hallowed Flowers" Variety="F" />
-				<Frame UV="234,0" Name="Hallowed Flowers" Variety="G" />
-				<Frame UV="252,0" Name="Hallowed Flowers" Variety="H" />
-				<Frame UV="270,0" Name="Hallowed Flowers" Variety="I" />
-				<Frame UV="288,0" Name="Hallowed Flowers" Variety="J" />
-				<Frame UV="306,0" Name="Hallowed Flowers" Variety="K" />
-				<Frame UV="324,0" Name="Hallowed Flowers" Variety="L" />
-				<Frame UV="342,0" Name="Hallowed Flowers" Variety="M" />
-				<Frame UV="360,0" Name="Hallowed Flowers" Variety="N" />
-				<Frame UV="378,0" Name="Hallowed Flowers" Variety="O" />
-				<Frame UV="396,0" Name="Hallowed Flowers" Variety="P" />
+				<Frame UV="72,0" Variety="Flower A" />
+				<Frame UV="108,0" Variety="Flower B" />
+				<Frame UV="126,0" Variety="Flower C" />
+				<Frame UV="180,0" Variety="Flower D" />
+				<Frame UV="198,0" Variety="Flower E" />
+				<Frame UV="216,0" Variety="Flower F" />
+				<Frame UV="234,0" Variety="Flower G" />
+				<Frame UV="252,0" Variety="Flower H" />
+				<Frame UV="270,0" Variety="Flower I" />
+				<Frame UV="288,0" Variety="Flower J" />
+				<Frame UV="306,0" Variety="Flower K" />
+				<Frame UV="324,0" Variety="Flower L" />
+				<Frame UV="342,0" Variety="Flower M" />
+				<Frame UV="360,0" Variety="Flower N" />
+				<Frame UV="378,0" Variety="Flower O" />
+				<Frame UV="396,0" Variety="Flower P" />
 			</Frames>
 		</Tile>
 		<Tile Id="111" Color="#FF801A34" Name="Adamantite Ore" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="112" Color="#FF67627A" Name="Ebonsand Block" Solid="true" Blends="true" MergeWith="0" />
-		<Tile Id="113" Color="#FF30D0EA" Name="Tall Hallowed Plants" Framed="true" TextureGrid="16,32">
+		<Tile Id="113" Color="#FF30D0EA" Name="Hallow Tall Plants" Framed="true" TextureGrid="16,32">
 			<Frames>
-				<Frame UV="0,0" Name="Hallowed Grass" Variety="A" />
-				<Frame UV="18,0" Name="Hallowed Grass" Variety="B" />
-				<Frame UV="36,0" Name="Hallowed Grass" Variety="C" />
-				<Frame UV="54,0" Name="Hallowed Grass" Variety="D" />
-				<Frame UV="72,0" Name="Hallowed Grass" Variety="E" />
-				<Frame UV="90,0" Name="Hallowed Grass" Variety="F" />
-				<Frame UV="108,0" Name="Hallowed Flowers" Variety="A" />
-				<Frame UV="126,0" Name="Hallowed Flowers" Variety="B" />
+				<Frame UV="0,0" Variety="Grass A" Anchor="Bottom" />
+				<Frame UV="18,0" Variety="Grass B" Anchor="Bottom" />
+				<Frame UV="90,0" Variety="Grass C" Anchor="Bottom" />
+				<Frame UV="36,0" Variety="Flower A" Anchor="Bottom" />
+				<Frame UV="54,0" Variety="Flower B" Anchor="Bottom" />
+				<Frame UV="72,0" Variety="Flower C" Anchor="Bottom" />
+				<Frame UV="108,0" Variety="Flower D" Anchor="Bottom" />
+				<Frame UV="126,0" Variety="Flower E" Anchor="Bottom" />
 			</Frames>
 		</Tile>
 		<Tile Id="114" Color="#FFBF8E6F" Name="Tinkerer's Workshop" Framed="true" Size="3,2" TextureGrid="16,16" SolidTop="true" />
@@ -5768,23 +5768,23 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="198" Color="#FF3E3D34" Name="Asphalt Block" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="199" Color="#FFD05050" Name="Crimson Grass Block" Solid="true" Blends="true" MergeWith="0" Special="Grass" />
 		<Tile Id="200" Color="#FFD89890" Name="Red Ice Block" Solid="true" Blends="true" />
-		<Tile Id="201" Color="#FFCB3D40" Name="Crimson Plants" Framed="true">
+		<Tile Id="201" Color="#FFCB3D40" Name="Crimson Short Plants" Framed="true">
 			<Frames>
-				<Frame UV="0,0" Variety="Three Blades" />
-				<Frame UV="18,0" Variety="Two Blades" />
-				<Frame UV="36,0" Variety="Hooked" />
-				<Frame UV="54,0" Variety="Short" />
-				<Frame UV="72,0" Variety="Thick A" />
-				<Frame UV="90,0" Variety="Fleshy A" />
-				<Frame UV="108,0" Variety="Sparse" />
-				<Frame UV="126,0" Variety="Fleshy B" />
-				<Frame UV="144,0" Variety="Thick B" />
-				<Frame UV="162,0" Variety="Thick C" />
-				<Frame UV="180,0" Variety="Fleshy C" />
-				<Frame UV="198,0" Variety="Thick D" />
-				<Frame UV="216,0" Variety="Thick E" />
-				<Frame UV="234,0" Variety="Thick F" />
-				<Frame UV="252,0" Variety="Thick G" />
+				<Frame UV="0,0" Variety="Grass Three Blades" />
+				<Frame UV="18,0" Variety="Grass Two Blades" />
+				<Frame UV="36,0" Variety="Grass Hooked" />
+				<Frame UV="54,0" Variety="Grass Short" />
+				<Frame UV="72,0" Variety="Grass Thick A" />
+				<Frame UV="90,0" Variety="Grass Fleshy A" />
+				<Frame UV="108,0" Variety="Grass Sparse" />
+				<Frame UV="126,0" Variety="Grass Fleshy B" />
+				<Frame UV="144,0" Variety="Grass Thick B" />
+				<Frame UV="162,0" Variety="Grass Thick C" />
+				<Frame UV="180,0" Variety="Grass Fleshy C" />
+				<Frame UV="198,0" Variety="Grass Thick D" />
+				<Frame UV="216,0" Variety="Grass Thick E" />
+				<Frame UV="234,0" Variety="Grass Thick F" />
+				<Frame UV="252,0" Variety="Grass Thick G" />
 				<Frame UV="270,0" Name="Vile Mushroom" />
 				<Frame UV="288,0" Variety="Flower A" />
 				<Frame UV="306,0" Variety="Flower B" />
@@ -5928,23 +5928,23 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="224" Color="#FF6B848B" Name="Slush Block" Solid="true" Blends="true" />
 		<Tile Id="225" Color="#FFE37D16" Name="Hive Block" Solid="true" Blends="true" />
 		<Tile Id="226" Color="#FF8D3800" Name="Lihzahrd Brick" Solid="true" Blends="true" />
-		<Tile Id="227" Color="#FFFFFFFF" Name="Dye Plant" Framed="true" TextureGrid="32,36">
+		<Tile Id="227" Color="#FFFFFFFF" Name="Dye Plants" Framed="true" TextureGrid="32,38">
 			<Frames>
-				<Frame UV="0,0" Name="Teal Mushroom" />
-				<Frame UV="34,0" Name="Green Mushroom" />
-				<Frame UV="68,0" Name="Sky Blue Flower" />
-				<Frame UV="102,0" Name="Yellow Marigold" />
-				<Frame UV="136,0" Name="Blue Berries" />
-				<Frame UV="170,0" Name="Lime Kelp" />
-				<Frame UV="204,0" Name="Pink Prickly Pear" />
-				<Frame UV="238,0" Name="Orange Bloodroot" />
-				<Frame UV="272,0" Name="Strange Plant" Variety="A" />
-				<Frame UV="306,0" Name="Strange Plant" Variety="B" />
-				<Frame UV="340,0" Name="Strange Plant" Variety="C" />
-				<Frame UV="374,0" Name="Strange Plant" Variety="D" />
-				<Frame UV="408,0" Variety="A (unused)" />
-				<Frame UV="442,0" Variety="B (unused)" />
-				<Frame UV="476,0" Variety="C (unused)" />
+				<Frame UV="0,0" Name="Teal Mushroom" Anchor="Bottom" />
+				<Frame UV="34,0" Name="Green Mushroom" Anchor="Bottom" />
+				<Frame UV="68,0" Name="Sky Blue Flower" Anchor="Bottom" />
+				<Frame UV="102,0" Name="Yellow Marigold" Anchor="Bottom" />
+				<Frame UV="136,0" Name="Blue Berries" Anchor="Bottom" />
+				<Frame UV="170,0" Name="Lime Kelp" Anchor="Bottom" />
+				<Frame UV="204,0" Name="Pink Prickly Pear" Anchor="Bottom" />
+				<Frame UV="238,0" Name="Orange Bloodroot" Anchor="Top" />
+				<Frame UV="272,0" Name="Strange Plant" Variety="A" Anchor="Bottom" />
+				<Frame UV="306,0" Name="Strange Plant" Variety="B" Anchor="Bottom" />
+				<Frame UV="340,0" Name="Strange Plant" Variety="C" Anchor="Bottom" />
+				<Frame UV="374,0" Name="Strange Plant" Variety="D" Anchor="Bottom" />
+				<Frame UV="408,0" Name="Corrupt Pink Prickly Pear (USE PURE PEAR - DO NOT USE)" Anchor="Bottom" />
+				<Frame UV="442,0" Name="Crimson Pink Prickly Pear (USE PURE PEAR - DO NOT USE)" Anchor="Bottom" />
+				<Frame UV="476,0" Name="Hallow Pink Prickly Pear (USE PURE PEAR - DO NOT USE)" Anchor="Bottom" />
 			</Frames>
 		</Tile>
 		<Tile Id="228" Color="#FF909490" Name="Dye Vat" Framed="true" Size="3,3" IsAnimated="true" />
@@ -5952,29 +5952,29 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="230" Color="#FF834F0D" Name="Crispy Honey Block" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="231" Color="#FFE0C265" Name="Larva" Framed="true" Size="3,3" IsAnimated="true" />
 		<Tile Id="232" Color="#FF915155" Name="Wooden Spike" Solid="true" Blends="true" />
-		<Tile Id="233" Color="#FFFF00FF" Name="Jungle Vegetation" Framed="true" Size="[3,2 2,2]">
+		<Tile Id="233" Color="#FFFF00FF" Name="Jungle Large Plants" Framed="true" Size="[3,2 2,2]">
 			<Frames>
-				<Frame UV="0,0" Variety="Plant A" />
-				<Frame UV="54,0" Variety="Plant B" />
-				<Frame UV="108,0" Variety="Plant C" />
-				<Frame UV="162,0" Variety="Plant D" />
-				<Frame UV="216,0" Variety="Plant E" />
-				<Frame UV="270,0" Variety="Plant F" />
-				<Frame UV="324,0" Variety="Plant G" />
-				<Frame UV="378,0" Variety="Plant H" />
-				<Frame UV="432,0" Variety="Plant I" />
-				<Frame UV="0,36" Variety="Plant A" FrameSize="2,2" />
-				<Frame UV="36,36" Variety="Plant B" FrameSize="2,2" />
-				<Frame UV="72,36" Variety="Plant C" FrameSize="2,2" />
-				<Frame UV="108,36" Variety="Plant D" FrameSize="2,2" />
-				<Frame UV="144,36" Variety="Plant E" FrameSize="2,2" />
-				<Frame UV="180,36" Variety="Plant F" FrameSize="2,2" />
-				<Frame UV="216,36" Variety="Plant G" FrameSize="2,2" />
-				<Frame UV="252,36" Variety="Plant H" FrameSize="2,2" />
-				<Frame UV="288,36" Variety="Plant I" FrameSize="2,2" />
-				<Frame UV="324,36" Variety="Plant J" FrameSize="2,2" />
-				<Frame UV="360,36" Variety="Plant K" FrameSize="2,2" />
-				<Frame UV="396,36" Variety="Plant L" FrameSize="2,2" />
+				<Frame UV="0,0" Variety="3x2 A" />
+				<Frame UV="54,0" Variety="3x2 B" />
+				<Frame UV="108,0" Variety="3x2 C" />
+				<Frame UV="162,0" Variety="3x2 D" />
+				<Frame UV="216,0" Variety="3x2 E" />
+				<Frame UV="270,0" Variety="3x2 F" />
+				<Frame UV="324,0" Variety="3x2 G" />
+				<Frame UV="378,0" Variety="3x2 H" />
+				<Frame UV="432,0" Variety="3x2 I" />
+				<Frame UV="0,36" Variety="2x2 A" FrameSize="2,2" />
+				<Frame UV="36,36" Variety="2x2 B" FrameSize="2,2" />
+				<Frame UV="72,36" Variety="2x2 C" FrameSize="2,2" />
+				<Frame UV="108,36" Variety="2x2 D" FrameSize="2,2" />
+				<Frame UV="144,36" Variety="2x2 E" FrameSize="2,2" />
+				<Frame UV="180,36" Variety="2x2 F" FrameSize="2,2" />
+				<Frame UV="216,36" Variety="2x2 G" FrameSize="2,2" />
+				<Frame UV="252,36" Variety="2x2 H" FrameSize="2,2" />
+				<Frame UV="288,36" Variety="2x2 I" FrameSize="2,2" />
+				<Frame UV="324,36" Variety="2x2 J" FrameSize="2,2" />
+				<Frame UV="360,36" Variety="2x2 K" FrameSize="2,2" />
+				<Frame UV="396,36" Variety="2x2 L" FrameSize="2,2" />
 			</Frames>
 		</Tile>
 		<Tile Id="234" Color="#FF352C29" Name="Crimsand Block" Solid="true" Blends="true" MergeWith="0" />
@@ -7881,42 +7881,42 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		</Tile>
 		<Tile Id="530" Name="Oasis Plants" Framed="true" Size="[3,2]" Color="#FF5B546C">
 			<Frames>
-				<Frame UV="0,0" Name="Oasis Plants" Variety="A" />
-				<Frame UV="54,0" Name="Oasis Plants" Variety="B" />
-				<Frame UV="108,0" Name="Oasis Plants" Variety="C" />
-				<Frame UV="162,0" Name="Oasis Plants" Variety="D" />
-				<Frame UV="216,0" Name="Oasis Plants" Variety="E" />
-				<Frame UV="270,0" Name="Oasis Plants" Variety="F" />
-				<Frame UV="324,0" Name="Oasis Plants" Variety="G" />
-				<Frame UV="378,0" Name="Oasis Plants" Variety="H" />
-				<Frame UV="432,0" Name="Oasis Plants" Variety="I" />
-				<Frame UV="0,36" Name="Hallowed Oasis Plants" Variety="A" />
-				<Frame UV="54,36" Name="Hallowed Oasis Plants" Variety="B" />
-				<Frame UV="108,36" Name="Hallowed Oasis Plants" Variety="C" />
-				<Frame UV="162,36" Name="Hallowed Oasis Plants" Variety="D" />
-				<Frame UV="216,36" Name="Hallowed Oasis Plants" Variety="E" />
-				<Frame UV="270,36" Name="Hallowed Oasis Plants" Variety="F" />
-				<Frame UV="324,36" Name="Hallowed Oasis Plants" Variety="G" />
-				<Frame UV="378,36" Name="Hallowed Oasis Plants" Variety="H" />
-				<Frame UV="432,36" Name="Hallowed Oasis Plants" Variety="I" />
-				<Frame UV="0,72" Name="Crimson Oasis Plants" Variety="A" />
-				<Frame UV="54,72" Name="Crimson Oasis Plants" Variety="B" />
-				<Frame UV="108,72" Name="Crimson Oasis Plants" Variety="C" />
-				<Frame UV="162,72" Name="Crimson Oasis Plants" Variety="D" />
-				<Frame UV="216,72" Name="Crimson Oasis Plants" Variety="E" />
-				<Frame UV="270,72" Name="Crimson Oasis Plants" Variety="F" />
-				<Frame UV="324,72" Name="Crimson Oasis Plants" Variety="G" />
-				<Frame UV="378,72" Name="Crimson Oasis Plants" Variety="H" />
-				<Frame UV="432,72" Name="Crimson Oasis Plants" Variety="I" />
-				<Frame UV="0,108" Name="Corruption Oasis Plants" Variety="A" />
-				<Frame UV="54,108" Name="Corruption Oasis Plants" Variety="B" />
-				<Frame UV="108,108" Name="Corruption Oasis Plants" Variety="C" />
-				<Frame UV="162,108" Name="Corruption Oasis Plants" Variety="D" />
-				<Frame UV="216,108" Name="Corruption Oasis Plants" Variety="E" />
-				<Frame UV="270,108" Name="Corruption Oasis Plants" Variety="F" />
-				<Frame UV="324,108" Name="Corruption Oasis Plants" Variety="G" />
-				<Frame UV="378,108" Name="Corruption Oasis Plants" Variety="H" />
-				<Frame UV="432,108" Name="Corruption Oasis Plants" Variety="I" />
+				<Frame UV="0,0" Variety="A" />
+				<Frame UV="54,0" Variety="B" />
+				<Frame UV="108,0" Variety="C" />
+				<Frame UV="162,0" Variety="D" />
+				<Frame UV="216,0" Variety="E" />
+				<Frame UV="270,0" Variety="F" />
+				<Frame UV="324,0" Variety="G" />
+				<Frame UV="378,0" Variety="H" />
+				<Frame UV="432,0" Variety="I" />
+				<Frame UV="0,36" Variety="Hallow A" />
+				<Frame UV="54,36" Variety="Hallow B" />
+				<Frame UV="108,36" Variety="Hallow C" />
+				<Frame UV="162,36" Variety="Hallow D" />
+				<Frame UV="216,36" Variety="Hallow E" />
+				<Frame UV="270,36" Variety="Hallow F" />
+				<Frame UV="324,36" Variety="Hallow G" />
+				<Frame UV="378,36" Variety="Hallow H" />
+				<Frame UV="432,36" Variety="Hallow I" />
+				<Frame UV="0,72" Variety="Crimson A" />
+				<Frame UV="54,72" Variety="Crimson B" />
+				<Frame UV="108,72" Variety="Crimson C" />
+				<Frame UV="162,72" Variety="Crimson D" />
+				<Frame UV="216,72" Variety="Crimson E" />
+				<Frame UV="270,72" Variety="Crimson F" />
+				<Frame UV="324,72" Variety="Crimson G" />
+				<Frame UV="378,72" Variety="Crimson H" />
+				<Frame UV="432,72" Variety="Crimson I" />
+				<Frame UV="0,108" Variety="Corruption A" />
+				<Frame UV="54,108" Variety="Corruption B" />
+				<Frame UV="108,108" Variety="Corruption C" />
+				<Frame UV="162,108" Variety="Corruption D" />
+				<Frame UV="216,108" Variety="Corruption E" />
+				<Frame UV="270,108" Variety="Corruption F" />
+				<Frame UV="324,108" Variety="Corruption G" />
+				<Frame UV="378,108" Variety="Corruption H" />
+				<Frame UV="432,108" Variety="Corruption I" />
 			</Frames>
 		</Tile>
 		<Tile Id="531" Name="Boulder Statue" Framed="true" Size="2,3" Color="#FF6B6B6B" />
@@ -8982,19 +8982,19 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		</Tile>
 		<Tile Id="635" Name="Ash Wood" Solid="true" Color="#FF5F525C" />
 		<Tile Id="636" Name="Corrupt Vines" Color="#FF746CA3" />
-		<Tile Id="637" Name="Ash Plants" Light="true" Framed="true" Color="#FF884338">
+		<Tile Id="637" Name="Ash Short Plants" Light="true" Framed="true" Color="#FF884338">
 			<Frames>
-				<Frame UV="0,0" Variety="A" />
-				<Frame UV="18,0" Variety="B" />
-				<Frame UV="36,0" Variety="C" />
-				<Frame UV="54,0" Variety="D" />
-				<Frame UV="72,0" Variety="E" />
-				<Frame UV="90,0" Variety="F" />
-				<Frame UV="108,0" Variety="G" />
-				<Frame UV="126,0" Variety="H" />
-				<Frame UV="144,0" Variety="I" />
-				<Frame UV="162,0" Variety="J" />
-				<Frame UV="180,0" Variety="K" />
+				<Frame UV="0,0" Variety="Grass A" />
+				<Frame UV="18,0" Variety="Grass B" />
+				<Frame UV="36,0" Variety="Grass C" />
+				<Frame UV="54,0" Variety="Grass D" />
+				<Frame UV="72,0" Variety="Grass E" />
+				<Frame UV="90,0" Variety="Grass F" />
+				<Frame UV="108,0" Variety="Flower A" />
+				<Frame UV="126,0" Variety="Flower B" />
+				<Frame UV="144,0" Variety="Flower C" />
+				<Frame UV="162,0" Variety="Flower D" />
+				<Frame UV="180,0" Variety="Flower E" />
 			</Frames>
 		</Tile>
 		<Tile Id="638" Name="Ash Vines" Light="true" Color="#FF844A3C" />

--- a/src/TEdit/settings.xml
+++ b/src/TEdit/settings.xml
@@ -2752,7 +2752,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="576,0" Name="Ash Tree Sapling" Variety="C" />
 			</Frames>
 		</Tile>
-		<Tile Id="21" Color="#FFE9CF5E" Name="Chest" TextureGrid="16,16" Framed="true" Size="2,2" Placement="floor" UseFrameName="true" FrameGap="2,2" IsAnimated="true">
+		<Tile Id="21" Color="#FFE9CF5E" Name="Chests" TextureGrid="16,16" Framed="true" Size="2,2" Placement="floor" UseFrameName="true" FrameGap="2,2" IsAnimated="true">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Chest" />
 				<Frame UV="36,0" Name="Gold Chest" />
@@ -2806,8 +2806,8 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="1764,0" Name="Meteorite Chest" />
 				<Frame UV="1800,0" Name="Granite Chest" />
 				<Frame UV="1836,0" Name="Marble Chest" />
-				<Frame UV="1872,0" Name="Crystal Chest" />
-				<Frame UV="1908,0" Name="Golden Chest" />
+				<Frame UV="1872,0" Name="Crystal Chest (unused - DO NOT USE)" />
+				<Frame UV="1908,0" Name="Golden Chest (unused - DO NOT USE)" />
 			</Frames>
 		</Tile>
 		<Tile Id="22" Color="#FF625FA7" Name="Demonite Ore" Solid="true" Blends="true" MergeWith="0" Light="true" />
@@ -7241,11 +7241,11 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			<Frames>
 				<Frame UV="0,0" Name="Trapped Chest" />
 				<Frame UV="36,0" Name="Trapped Gold Chest" />
-				<Frame UV="72,0" Name="Trapped Gold Chest" Variety="Locked" />
+				<Frame UV="72,0" Name="Trapped Gold Chest (unused - DO NOT USE)" Variety="Locked" />
 				<Frame UV="108,0" Name="Trapped Shadow Chest" />
-				<Frame UV="144,0" Name="Trapped Shadow Chest" Variety="Locked" />
-				<Frame UV="180,0" Name="Trapped Barrel" />
-				<Frame UV="216,0" Name="Trapped Trash Can" />
+				<Frame UV="144,0" Name="Trapped Shadow Chest (unused - DO NOT USE)" Variety="Locked" />
+				<Frame UV="180,0" Name="Trapped Barrel (unused - DO NOT USE)" />
+				<Frame UV="216,0" Name="Trapped Trash Can (unused - DO NOT USE)" />
 				<Frame UV="252,0" Name="Trapped Ebonwood Chest" />
 				<Frame UV="288,0" Name="Trapped Rich Mahogany Chest" />
 				<Frame UV="324,0" Name="Trapped Pearlwood Chest" />
@@ -7262,11 +7262,11 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="720,0" Name="Trapped Crimson Chest" />
 				<Frame UV="756,0" Name="Trapped Hallowed Chest" />
 				<Frame UV="792,0" Name="Trapped Frozen Chest" />
-				<Frame UV="828,0" Name="Trapped Jungle Chest" Variety="Locked" />
-				<Frame UV="864,0" Name="Trapped Corruption Chest" Variety="Locked" />
-				<Frame UV="900,0" Name="Trapped Crimson Chest" Variety="Locked" />
-				<Frame UV="936,0" Name="Trapped Hallowed Chest" Variety="Locked" />
-				<Frame UV="972,0" Name="Trapped Frozen Chest" Variety="Locked" />
+				<Frame UV="828,0" Name="Trapped Jungle Chest (unused - DO NOT USE)" Variety="Locked" />
+				<Frame UV="864,0" Name="Trapped Corruption Chest (unused - DO NOT USE)" Variety="Locked" />
+				<Frame UV="900,0" Name="Trapped Crimson Chest (unused - DO NOT USE)" Variety="Locked" />
+				<Frame UV="936,0" Name="Trapped Hallowed Chest (unused - DO NOT USE)" Variety="Locked" />
+				<Frame UV="972,0" Name="Trapped Frozen Chest (unused - DO NOT USE)" Variety="Locked" />
 				<Frame UV="1008,0" Name="Trapped Dynasty Chest" />
 				<Frame UV="1044,0" Name="Trapped Honey Chest" />
 				<Frame UV="1080,0" Name="Trapped Steampunk Chest" />
@@ -7275,11 +7275,11 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="1188,0" Name="Trapped Boreal Wood Chest" />
 				<Frame UV="1224,0" Name="Trapped Slime Chest" />
 				<Frame UV="1260,0" Name="Trapped Green Dungeon Chest" />
-				<Frame UV="1296,0" Name="Trapped Green Dungeon Chest" Variety="Locked" />
+				<Frame UV="1296,0" Name="Trapped Green Dungeon Chest (unused - DO NOT USE)" Variety="Locked" />
 				<Frame UV="1332,0" Name="Trapped Pink Dungeon Chest" />
-				<Frame UV="1368,0" Name="Trapped Pink Dungeon Chest" Variety="Locked" />
+				<Frame UV="1368,0" Name="Trapped Pink Dungeon Chest (unused - DO NOT USE)" Variety="Locked" />
 				<Frame UV="1404,0" Name="Trapped Blue Dungeon Chest" />
-				<Frame UV="1440,0" Name="Trapped Blue Dungeon Chest" Variety="Locked" />
+				<Frame UV="1440,0" Name="Trapped Blue Dungeon Chest (unused - DO NOT USE)" Variety="Locked" />
 				<Frame UV="1476,0" Name="Trapped Bone Chest" />
 				<Frame UV="1512,0" Name="Trapped Cactus Chest" />
 				<Frame UV="1548,0" Name="Trapped Flesh Chest" />
@@ -7291,8 +7291,8 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="1764,0" Name="Trapped Meteorite Chest" />
 				<Frame UV="1800,0" Name="Trapped Granite Chest" />
 				<Frame UV="1836,0" Name="Trapped Marble Chest" />
-				<Frame UV="1872,0" Name="Trapped Crystal Chest" />
-				<Frame UV="1908,0" Name="Trapped Golden Chest" />
+				<Frame UV="1872,0" Name="Trapped Crystal Chest (unused - DO NOT USE)" />
+				<Frame UV="1908,0" Name="Trapped Golden Chest (unused - DO NOT USE)" />
 			</Frames>
 		</Tile>
 		<Tile Id="442" Color="#FF0390c9" Name="Teal Pressure Pad" Framed="true" TextureGrid="20,20">
@@ -7357,7 +7357,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="464" Color="#FFE9B780" Name="War Table" Framed="true" Size="5,4" IsAnimated="true" />
 		<Tile Id="465" Color="#FF3354C3" Name="War Table Banner" Framed="true" Size="2,3" />
 		<Tile Id="466" Color="#FFCD9949" Name="Elder Cystal Stand" Framed="true" Size="5,4" />
-		<Tile Id="467" Color="#FFE9CF5E" Name="Chest (Group 2)" Framed="true" Size="2,2" Placement="floor" UseFrameName="true" IsAnimated="true">
+		<Tile Id="467" Color="#FFE9CF5E" Name="Chests (Group 2)" Framed="true" Size="2,2" Placement="floor" UseFrameName="true" IsAnimated="true">
 			<Frames>
 				<Frame UV="0,0" Name="Crystal Chest" />
 				<Frame UV="36,0" Name="Golden Chest" />
@@ -7384,7 +7384,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="36,0" Name="Trapped Golden Chest" />
 				<Frame UV="72,0" Name="Trapped Spider Chest" />
 				<Frame UV="108,0" Name="Trapped Lesion Chest" />
-				<Frame UV="144,0" Name="Trapped Dead Man's Chest" />
+				<Frame UV="144,0" Name="Trapped Dead Man's Chest (unused - DO NOT USE)" />
 				<Frame UV="180,0" Name="Trapped Solar Chest" />
 				<Frame UV="216,0" Name="Trapped Vortex Chest" />
 				<Frame UV="252,0" Name="Trapped Nebula Chest" />
@@ -7393,7 +7393,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="360,0" Name="Trapped Sandstone Chest" />
 				<Frame UV="396,0" Name="Trapped Bamboo Chest" />
 				<Frame UV="432,0" Name="Trapped Desert Chest" />
-				<Frame UV="468,0" Name="Trapped Desert Chest" Variety="Locked" />
+				<Frame UV="468,0" Name="Trapped Desert Chest (unused - DO NOT USE)" Variety="Locked" />
 				<Frame UV="504,0" Name="Trapped Reef Chest" />
 				<Frame UV="540,0" Name="Trapped Balloon Chest" />
 				<Frame UV="576,0" Name="Trapped Ash Wood Chest" />

--- a/src/TEdit/settings.xml
+++ b/src/TEdit/settings.xml
@@ -183,7 +183,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="738,0" Variety="Red Flower G" />
 			</Frames>
 		</Tile>
-		<Tile Id="4" Color="#FFFDDD03" Name="Torch" Framed="true" Size="1,1" TextureGrid="20,20" Placement="wallFloor" Light="true">
+		<Tile Id="4" Color="#FFFDDD03" Name="Torches" Framed="true" Size="1,1" TextureGrid="20,20" Placement="wallFloor" Light="true">
 			<Frames>
 				<Frame UV="0,0" Name="Torch" Variety="On" Anchor="Bottom" />
 				<Frame UV="22,0" Name="Torch" Variety="On" Anchor="Left" />
@@ -924,7 +924,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="7" Color="#FF964316" Name="Copper Ore" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="8" Color="#FFB9A417" Name="Gold Ore" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="9" Color="#FFB9C2C3" Name="Silver Ore" Solid="true" Blends="true" MergeWith="0" />
-		<Tile Id="10" Color="#FF77694F" Name="Door Closed" Solid="true" Framed="true" Size="1,3" Placement="CFBoth">
+		<Tile Id="10" Color="#FF77694F" Name="Doors (Closed)" Solid="true" Framed="true" Size="1,3" Placement="CFBoth">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Door" Variety="A" />
 				<Frame UV="18,0" Name="Wooden Door" Variety="B" />
@@ -1075,7 +1075,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="90,648" Name="Ash Wood Door" Variety="C" />
 			</Frames>
 		</Tile>
-		<Tile Id="11" Color="#FF77694F" Name="Door Open" Framed="true" Size="2,3" Placement="CFBoth">
+		<Tile Id="11" Color="#FF77694F" Name="Doors (Open)" Framed="true" Size="2,3" Placement="CFBoth">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Door" Anchor="Right" />
 				<Frame UV="36,0" Name="Wooden Door" Anchor="Left" />
@@ -1180,7 +1180,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="12" Color="#FFAE1845" Name="Crystal Heart" Framed="true" Size="2,2" IsAnimated="true" Placement="floor" />
-		<Tile Id="13" Color="#FF85D5F7" Name="Placed Bottle" Framed="true" Placement="surface">
+		<Tile Id="13" Color="#FF85D5F7" Name="Placed Bottles" Framed="true" Placement="surface">
 			<Frames>
 				<Frame UV="0,0" Name="Bottle" />
 				<Frame UV="18,0" Name="Healing Potion" />
@@ -1193,7 +1193,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="144,0" Name="Chalice" />
 			</Frames>
 		</Tile>
-		<Tile Id="14" Color="#FFBF8E6F" Name="Table" Framed="true" Size="3,2" TextureGrid="16,16" Placement="floor" SolidTop="true">
+		<Tile Id="14" Color="#FFBF8E6F" Name="Tables" Framed="true" Size="3,2" TextureGrid="16,16" Placement="floor" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Table" />
 				<Frame UV="54,0" Name="Ebonwood Table" />
@@ -1233,7 +1233,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,36" Name="Crystal Table" />
 			</Frames>
 		</Tile>
-		<Tile Id="15" Color="#FFBF8E6F" Name="Chair" Framed="true" Size="1,2" Placement="floor" TextureGrid="16,16" FrameGap="0,4">
+		<Tile Id="15" Color="#FFBF8E6F" Name="Chairs" Framed="true" Size="1,2" Placement="floor" TextureGrid="16,16" FrameGap="0,4">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Chair" Anchor="Left" />
 				<Frame UV="18,0" Name="Wooden Chair" Anchor="Right" />
@@ -1333,14 +1333,14 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="18,1880" Name="Ash Wood Chair" Anchor="Right" />
 			</Frames>
 		</Tile>
-		<Tile Id="16" Color="#FF8C8274" Name="Iron Anvil" Framed="true" Size="2,1" TextureGrid="16,18" Placement="floor" SolidTop="true">
+		<Tile Id="16" Color="#FF8C8274" Name="Anvils" Framed="true" Size="2,1" TextureGrid="16,18" Placement="floor" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Iron Anvil" />
 				<Frame UV="36,0" Name="Lead Anvil" />
 			</Frames>
 		</Tile>
 		<Tile Id="17" Color="#FF909490" Name="Furnace" Framed="true" Size="3,2" Placement="floor" Light="true" IsAnimated="true" />
-		<Tile Id="18" Color="#FFBF8E6F" Name="Work Bench" Framed="true" Size="2,1" TextureGrid="16,18" Placement="floor" SolidTop="true">
+		<Tile Id="18" Color="#FFBF8E6F" Name="Work Benches" Framed="true" Size="2,1" TextureGrid="16,18" Placement="floor" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Work Bench" />
 				<Frame UV="36,0" Name="Ebonwood Work Bench" />
@@ -1388,7 +1388,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="1548,0" Name="Ash Wood Work Bench" />
 			</Frames>
 		</Tile>
-		<Tile Id="19" Color="#FFBF8E6F" Name="Platform" Solid="true" Framed="true" TextureGrid="16,16" Placement="wall" Special="Platform" Light="true" SolidTop="true">
+		<Tile Id="19" Color="#FFBF8E6F" Name="Platforms" Solid="true" Framed="true" TextureGrid="16,16" Placement="wall" Special="Platform" Light="true" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Wood Platform" Variety="Flat" />
 				<Frame UV="18,0" Name="Wood Platform" Variety="Endcap Right" />
@@ -2715,7 +2715,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="468,864" Name="Echo Platform" Variety="Stair Inverted Left" />
 			</Frames>
 		</Tile>
-		<Tile Id="20" Color="#FFA37451" Name="Sapling" Framed="true" Size="1,2">
+		<Tile Id="20" Color="#FFA37451" Name="Saplings" Framed="true" Size="1,2">
 			<Frames>
 				<Frame UV="0,0" Name="Forest Sapling" Variety="A" />
 				<Frame UV="18,0" Name="Forest Sapling" Variety="B" />
@@ -2840,7 +2840,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="25" Color="#FF6D5A80" Name="Ebonstone Block" Solid="true" Blends="true" MergeWith="0" />
-		<Tile Id="26" Color="#FF77657D" Name="Altar" Framed="true" Size="3,2" Placement="floor" Light="true">
+		<Tile Id="26" Color="#FF77657D" Name="Altars" Framed="true" Size="3,2" Placement="floor" Light="true">
 			<Frames>
 				<Frame UV="0,0" Name="Demon Altar" />
 				<Frame UV="54,0" Name="Crimson Altar" />
@@ -2853,7 +2853,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="72,0" Variety="C" />
 			</Frames>
 		</Tile>
-		<Tile Id="28" Color="#FF974F50" Name="Pot" Framed="true" Size="2,2" Placement="floor">
+		<Tile Id="28" Color="#FF974F50" Name="Pots" Framed="true" Size="2,2" Placement="floor">
 			<Frames>
 				<Frame UV="0,0" Name="Forest Pot" Variety="A1" />
 				<Frame UV="36,0" Name="Forest Pot" Variety="A2" />
@@ -2969,11 +2969,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="72,1296" Name="Underground Desert Pot" Variety="C3" />
 			</Frames>
 		</Tile>
-		<Tile Id="29" Color="#FFAF6980" Name="Piggy Bank" Framed="True" Size="2,1" Placement="surface">
-			<Frames>
-				<Frame UV="0,0" Variety="Default" />
-			</Frames>
-		</Tile>
+		<Tile Id="29" Color="#FFAF6980" Name="Piggy Bank" Framed="True" Size="2,1" Placement="surface" />
 		<Tile Id="30" Color="#FFAA7854" Name="Wood" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="31" Color="#FF8D78A8" Name="Orb Heart" Framed="true" Size="2,2" Placement="floor" IsAnimated="true" Light="true">
 			<Frames>
@@ -2982,7 +2978,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="32" Color="#FF9787B7" Name="Corruption Thorns" Blends="true" />
-		<Tile Id="33" Color="#FFFDDD03" Name="Candle" Framed="true" TextureGrid="16,20" Placement="surface" Light="true">
+		<Tile Id="33" Color="#FFFDDD03" Name="Candles" Framed="true" TextureGrid="16,20" Placement="surface" Light="true">
 			<Frames>
 				<Frame UV="0,0" Name="Candle" Variety="On" />
 				<Frame UV="18,0" Name="Candle" Variety="Off" />
@@ -3070,7 +3066,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="18,902" Name="Ash Wood Candle" Variety="Off" />
 			</Frames>
 		</Tile>
-		<Tile Id="34" Color="#FFEBA687" Name="Chandelier" Framed="true" Size="3,3" Placement="ceiling" Light="true">
+		<Tile Id="34" Color="#FFEBA687" Name="Chandeliers" Framed="true" Size="3,3" Placement="ceiling" Light="true">
 			<Frames>
 				<Frame UV="0,0" Name="Copper Chandelier" Variety="On" />
 				<Frame UV="54,0" Name="Copper Chandelier" Variety="Off" />
@@ -3194,7 +3190,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="36,288" Variety="I Off" />
 			</Frames>
 		</Tile>
-		<Tile Id="36" Color="#FFE6595C" Name="Present" Framed="true">
+		<Tile Id="36" Color="#FFE6595C" Name="Presents" Framed="true">
 			<Frames>
 				<Frame UV="0,0" Variety="Red with White Ribbon" />
 				<Frame UV="18,0" Variety="Red with Blue Ribbon" />
@@ -3211,7 +3207,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="39" Color="#FFB53E3B" Name="Red Brick" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="40" Color="#FF925144" Name="Clay Block" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="41" Color="#FF42546D" Name="Blue Brick" Solid="true" Blends="true" MergeWith="0" />
-		<Tile Id="42" Color="#FFFBEB7F" Name="Chain Lantern" Framed="true" Size="1,2" Placement="ceiling" Light="true">
+		<Tile Id="42" Color="#FFFBEB7F" Name="Lanterns" Framed="true" Size="1,2" Placement="ceiling" Light="true">
 			<Frames>
 				<Frame UV="0,0" Name="Chain Lantern" Variety="On" />
 				<Frame UV="18,0" Name="Chain Lantern" Variety="Off" />
@@ -3325,7 +3321,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="18,0" Variety="Off" />
 			</Frames>
 		</Tile>
-		<Tile Id="50" Color="#FFAA3072" Name="Book" Framed="true" Placement="surface">
+		<Tile Id="50" Color="#FFAA3072" Name="Books" Framed="true" Placement="surface">
 			<Frames>
 				<Frame UV="0,0" Variety="Blue Red Brown" />
 				<Frame UV="18,0" Variety="Yellow Pink" />
@@ -3480,7 +3476,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="76" Color="#FF8E4242" Name="Hellstone Brick" Solid="true" Blends="true" Light="true" />
 		<Tile Id="77" Color="#FFEE5546" Name="Hellforge" Framed="true" Size="3,2" Placement="floor" Light="true" IsAnimated="true" />
 		<Tile Id="78" Color="#FF796E61" Name="Clay Pot" Framed="true" Size="1,1" Placement="floor" />
-		<Tile Id="79" Color="#FFBF8E6F" Name="Bed" Framed="true" Size="4,2" Placement="floor">
+		<Tile Id="79" Color="#FFBF8E6F" Name="Beds" Framed="true" Size="4,2" Placement="floor">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Bed" Variety="Left" />
 				<Frame UV="72,0" Name="Wooden Bed" Variety="Right" />
@@ -3570,7 +3566,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="72,1512" Name="Ash Wood Bed" Variety="Right" />
 			</Frames>
 		</Tile>
-		<Tile Id="80" Color="#FF497811" Name="Cactus plant" Special="Cactus" />
+		<Tile Id="80" Color="#FF497811" Name="Cactus Plant" Special="Cactus" />
 		<Tile Id="81" Color="#FFF585BF" Name="Coral" Framed="true" TextureGrid="24,26">
 			<Frames>
 				<Frame UV="0,0" Variety="Red" Anchor="Bottom" />
@@ -3614,7 +3610,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="108,0" Name="Shiverthorn" growsOn="147,161" />
 			</Frames>
 		</Tile>
-		<Tile Id="85" Color="#FFC0C0C0" Name="Tombstone" Framed="true" Size="2,2" Placement="floor">
+		<Tile Id="85" Color="#FFC0C0C0" Name="Tombstones" Framed="true" Size="2,2" Placement="floor">
 			<Frames>
 				<Frame UV="0,0" Variety="Tombstone" />
 				<Frame UV="36,0" Variety="Grave Marker" />
@@ -3630,7 +3626,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="86" Color="#FFBF8E6F" Name="Loom" Framed="true" Size="3,2" Placement="floor" />
-		<Tile Id="87" Color="#FFBF8E6F" Name="Piano" Framed="true" Size="3,2" Placement="floor" SolidTop="true">
+		<Tile Id="87" Color="#FFBF8E6F" Name="Pianos" Framed="true" Size="3,2" Placement="floor" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Piano" />
 				<Frame UV="54,0" Name="Ebonwood Piano" />
@@ -3677,7 +3673,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="270,36" Name="Ash Wood Piano" />
 			</Frames>
 		</Tile>
-		<Tile Id="88" Color="#FFBF8E6F" Name="Dresser" Framed="true" Size="3,2" Placement="floor" SolidTop="true">
+		<Tile Id="88" Color="#FFBF8E6F" Name="Dressers" Framed="true" Size="3,2" Placement="floor" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Dresser" />
 				<Frame UV="54,0" Name="Ebonwood Dresser" />
@@ -3724,7 +3720,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="270,36" Name="Ash Wood Dresser" />
 			</Frames>
 		</Tile>
-		<Tile Id="89" Color="#FFBF8E6F" Name="Bench" Framed="true" Size="3,2" Placement="floor">
+		<Tile Id="89" Color="#FFBF8E6F" Name="Benches" Framed="true" Size="3,2" Placement="floor">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Bench" />
 				<Frame UV="54,0" Name="Wooden Sofa" />
@@ -3775,7 +3771,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="486,36" Name="Ash Wood Sofa" />
 			</Frames>
 		</Tile>
-		<Tile Id="90" Color="#FF909490" Name="Bathtub" Framed="true" Size="4,2" Placement="floor">
+		<Tile Id="90" Color="#FF909490" Name="Bathtubs" Framed="true" Size="4,2" Placement="floor">
 			<Frames>
 				<Frame UV="0,0" Name="Metal Bathtub" Variety="Left" />
 				<Frame UV="72,0" Name="Metal Bathtub" Variety="Right" />
@@ -3865,7 +3861,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,1512" Name="Ash Wood Bathtub" Variety="Right" />
 			</Frames>
 		</Tile>
-		<Tile Id="91" Color="#FF0D5882" Name="Banner" Framed="true" Size="1,3" Placement="ceiling">
+		<Tile Id="91" Color="#FF0D5882" Name="Banners" Framed="true" Size="1,3" Placement="ceiling">
 			<Frames>
 				<Frame UV="0,0" Name="Craftable Banner" Variety="Red Banner" />
 				<Frame UV="18,0" Name="Craftable Banner" Variety="Green Banner" />
@@ -4186,7 +4182,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="18,0" Variety="Off" />
 			</Frames>
 		</Tile>
-		<Tile Id="93" Color="#FFFDDD03" Name="Lamp" Framed="true" Size="1,3" Placement="floor" Light="true">
+		<Tile Id="93" Color="#FFFDDD03" Name="Lamps" Framed="true" Size="1,3" Placement="floor" Light="true">
 			<Frames>
 				<Frame UV="0,0" Name="Tiki Torch" Variety="On" />
 				<Frame UV="18,0" Name="Tiki Torch" Variety="Off" />
@@ -4283,7 +4279,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="36,0" Variety="Off" />
 			</Frames>
 		</Tile>
-		<Tile Id="96" Color="#FF909490" Name="Cooking Pot" Framed="true" Size="2,2" Placement="floorSurface" IsAnimated="true" Light="true">
+		<Tile Id="96" Color="#FF909490" Name="Cooking Pots" Framed="true" Size="2,2" Placement="floorSurface" IsAnimated="true" Light="true">
 			<Frames>
 				<Frame UV="0,0" Name="Cooking Pot" />
 				<Frame UV="36,0" Name="Cauldron" />
@@ -4292,7 +4288,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="97" Color="#FF909490" Name="Safe" Framed="true" Size="2,2" Placement="floor" />
 		<Tile Id="98" Color="#FFFDDD03" Name="Skull Lantern" Framed="true" Size="2,2" Placement="floorSurface" Light="true" />
 		<Tile Id="99" Color="#FF909490" Name="Trash Can" Framed="true" Size="2,2" Placement="floor" />
-		<Tile Id="100" Color="#FFFDDD03" Name="Candelabra" Framed="true" Size="2,2" Placement="surface" Light="true">
+		<Tile Id="100" Color="#FFFDDD03" Name="Candelabras" Framed="true" Size="2,2" Placement="surface" Light="true">
 			<Frames>
 				<Frame UV="0,0" Name="Candelabra" Variety="On" />
 				<Frame UV="36,0" Name="Candelabra" Variety="Off" />
@@ -4382,7 +4378,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="36,1512" Name="Ash Wood Candelabra" Variety="Off" />
 			</Frames>
 		</Tile>
-		<Tile Id="101" Color="#FFBF8E6F" Name="Bookcase" Framed="true" Size="3,4" Placement="floor" SolidTop="true">
+		<Tile Id="101" Color="#FFBF8E6F" Name="Bookcases" Framed="true" Size="3,4" Placement="floor" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Bookcase" />
 				<Frame UV="54,0" Name="Blue Dungeon Bookcase" />
@@ -4431,7 +4427,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="102" Color="#FFE5D449" Name="Throne" Framed="true" Size="3,4" Placement="floor" />
-		<Tile Id="103" Color="#FF8D624D" Name="Bowl" Framed="true" Size="2,1" Placement="surface">
+		<Tile Id="103" Color="#FF8D624D" Name="Bowls" Framed="true" Size="2,1" Placement="surface">
 			<Frames>
 				<Frame UV="0,0" Name="Bowl" />
 				<Frame UV="36,0" Name="Dynasty Bowl" />
@@ -4439,7 +4435,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="108,0" Name="Glass Bowl" />
 			</Frames>
 		</Tile>
-		<Tile Id="104" Color="#FFBF8E6F" Name="Clock" Framed="true" Size="2,5" Placement="floor">
+		<Tile Id="104" Color="#FFBF8E6F" Name="Clocks" Framed="true" Size="2,5" Placement="floor">
 			<Frames>
 				<Frame UV="0,0" Name="Grandfather Clock" />
 				<Frame UV="36,0" Name="Dynasty Clock" />
@@ -4487,7 +4483,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="1548,0" Name="Ash Wood Clock" />
 			</Frames>
 		</Tile>
-		<Tile Id="105" Color="#FF909490" Name="Statue" Framed="true" Size="2,3" Placement="floor">
+		<Tile Id="105" Color="#FF909490" Name="Statues" Framed="true" Size="2,3" Placement="floor">
 			<Frames>
 				<Frame UV="0,0" Name="Armor Statue" Variety="Left" />
 				<Frame UV="0,162" Name="Armor Statue" Variety="Right" />
@@ -4817,19 +4813,19 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="108,0" Variety="Down" Anchor="Center" />
 			</Frames>
 		</Tile>
-		<Tile Id="133" Color="#FFE73538" Name="Adamantite Forge" Framed="true" Size="3,2" Light="true" IsAnimated="true">
+		<Tile Id="133" Color="#FFE73538" Name="Forges" Framed="true" Size="3,2" Light="true" IsAnimated="true">
 			<Frames>
 				<Frame UV="0,0" Name="Adamantite Forge" />
 				<Frame UV="54,0" Name="Titanium Forge" />
 			</Frames>
 		</Tile>
-		<Tile Id="134" Color="#FFA6BB99" Name="Mythril Anvil" Framed="true" Size="2,1" SolidTop="true">
+		<Tile Id="134" Color="#FFA6BB99" Name="Anvils (Hardmode)" Framed="true" Size="2,1" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Mythril Anvil" />
 				<Frame UV="36,0" Name="Orichalcum Anvil" />
 			</Frames>
 		</Tile>
-		<Tile Id="135" Color="#FFFD7272" Name="Pressure Plate" Framed="true">
+		<Tile Id="135" Color="#FFFD7272" Name="Pressure Plates" Framed="true">
 			<Frames>
 				<Frame UV="0,0" Name="Red Pressure Plate" />
 				<Frame UV="0,18" Name="Green Pressure Plate" />
@@ -4853,7 +4849,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="54,18" Variety="Setting Two" Anchor="Center" />
 			</Frames>
 		</Tile>
-		<Tile Id="137" Color="#FF909490" Name="Dart Trap" Solid="true" Framed="true" UseFrameName="true">
+		<Tile Id="137" Color="#FF909490" Name="Traps" Solid="true" Framed="true" UseFrameName="true">
 			<Frames>
 				<Frame UV="0,0" Name="Dart Trap" Variety="Left" />
 				<Frame UV="18,0" Name="Dart Trap" Variety="Right" />
@@ -4892,7 +4888,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="138" Color="#FF606060" Name="Boulder" Framed="true" Size="2,2" Solid="true" />
-		<Tile Id="139" Color="#FFBF8E6F" Name="Music Box" Framed="true" Size="2,2" IsAnimated="true">
+		<Tile Id="139" Color="#FFBF8E6F" Name="Music Boxes" Framed="true" Size="2,2" IsAnimated="true">
 			<Frames>
 				<Frame UV="0,0" Name="Music Box (Overworld Day)" Variety="Off" />
 				<Frame UV="36,0" Name="Music Box (Overworld Day)" Variety="On" />
@@ -4987,7 +4983,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		</Tile>
 		<Tile Id="142" Color="#FF909490" Name="Inlet Pump" Framed="true" Size="2,2" />
 		<Tile Id="143" Color="#FF909490" Name="Outlet Pump" Framed="true" Size="2,2" />
-		<Tile Id="144" Color="#FF909490" Name="Timer" Framed="true" UseFrameName="true">
+		<Tile Id="144" Color="#FF909490" Name="Timers" Framed="true" UseFrameName="true">
 			<Frames>
 				<Frame UV="0,0" Name="1 Second Timer" Variety="Inactive" />
 				<Frame UV="0,18" Name="1 Second Timer" Variety="Active" />
@@ -5005,7 +5001,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="146" Color="#FF2BC01E" Name="Green Candy Cane Block" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="147" Color="#FFD3ECF1" Name="Snow Block" Solid="true" Blends="true" />
 		<Tile Id="148" Color="#FFB5D3D2" Name="Snow Brick" Solid="true" Blends="true" MergeWith="0" />
-		<Tile Id="149" Color="#FFDC3232" Name="Holiday Light" Framed="true" Size="1,1" Light="true">
+		<Tile Id="149" Color="#FFDC3232" Name="Holiday Lights" Framed="true" Size="1,1" Light="true">
 			<Frames>
 				<Frame UV="0,0" Name="Blue Light" Variety="On" Anchor="Bottom" />
 				<Frame UV="0,18" Name="Blue Light" Variety="On" Anchor="Top" />
@@ -5048,7 +5044,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="162" Color="#FFB8DBF0" Name="Thin Ice Block" Solid="true" Blends="true" />
 		<Tile Id="163" Color="#FFAE91D6" Name="Purple Ice Block" Solid="true" Blends="true" />
 		<Tile Id="164" Color="#FFDAB6CC" Name="Pink Ice Block" Solid="true" Blends="true" />
-		<Tile Id="165" Color="#FF646464" Name="Cave Deco" Framed="true" Size="[1,2 1,2 1,1 1,1]">
+		<Tile Id="165" Color="#FF646464" Name="Cave Decos" Framed="true" Size="[1,2 1,2 1,1 1,1]">
 			<Frames>
 				<Frame UV="0,0" Name="Icicle 1x2" Variety="A" />
 				<Frame UV="18,0" Name="Icicle 1x2" Variety="B" />
@@ -5175,7 +5171,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="169" Color="#FF98ABC6" Name="Platinum Ore" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="170" Color="#FFE4DBA2" Name="Pine Tree Block" Solid="true" />
 		<Tile Id="171" Color="#FF218755" Name="Christmas Tree" Framed="true" Light="true" Size="4,8" />
-		<Tile Id="172" Color="#FFB5C2D9" Name="Sink" Framed="true" Size="2,2" Placement="floor">
+		<Tile Id="172" Color="#FFB5C2D9" Name="Sinks" Framed="true" Size="2,2" Placement="floor">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Sink" />
 				<Frame UV="0,38" Name="Ebonwood Sink" />
@@ -5751,7 +5747,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="204" Color="#FF7D3741" Name="Crimtane Ore" Solid="true" Blends="true" MergeWith="0" Light="true" />
 		<Tile Id="205" Color="#FFBA3234" Name="Crimson Vines" Solid="true" Blends="true" />
 		<Tile Id="206" Color="#FF7CAFC9" Name="Ice Brick" Solid="true" Blends="true" MergeWith="0" />
-		<Tile Id="207" Color="#FF909490" Name="Water Fountain" Framed="true" Size="2,4" IsAnimated="true">
+		<Tile Id="207" Color="#FF909490" Name="Water Fountains" Framed="true" Size="2,4" IsAnimated="true">
 			<Frames>
 				<Frame UV="0,0" Name="Pure Water Fountain" Variety="Off" />
 				<Frame UV="0,72" Name="Pure Water Fountain" Variety="On" />
@@ -5776,7 +5772,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="208" Color="#FF586976" Name="Shadewood" Solid="true" Blends="true" MergeWith="0" />
-		<Tile Id="209" Color="#FF909490" Name="Cannon" Framed="true" Size="4,3">
+		<Tile Id="209" Color="#FF909490" Name="Cannons" Framed="true" Size="4,3">
 			<Frames>
 				<Frame UV="0,0" Name="Cannon" Variety="0 deg Right" />
 				<Frame UV="0,54" Name="Cannon" Variety="22.5 deg Right" />
@@ -5835,7 +5831,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		</Tile>
 		<Tile Id="213" Color="#FF897843" Name="Rope" Blends="true" />
 		<Tile Id="214" Color="#FF676767" Name="Chain" Blends="true" />
-		<Tile Id="215" Color="#FFFE7902" Name="Campfire" Framed="true" Size="3,2" Light="true" IsAnimated="true">
+		<Tile Id="215" Color="#FFFE7902" Name="Campfires" Framed="true" Size="3,2" Light="true" IsAnimated="true">
 			<Frames>
 				<Frame UV="0,0" Name="Campfire" Variety="Lit" />
 				<Frame UV="0,288" Name="Campfire" Variety="Unlit" />
@@ -5871,7 +5867,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="810,288" Name="Aether Campfire" Variety="Unlit" />
 			</Frames>
 		</Tile>
-		<Tile Id="216" Color="#FFBF8E6F" Name="Rocket" Framed="true" Size="1,2">
+		<Tile Id="216" Color="#FFBF8E6F" Name="Rockets" Framed="true" Size="1,2">
 			<Frames>
 				<Frame UV="0,0" Name="Rocket" Variety="Red Rocket" />
 				<Frame UV="0,40" Name="Rocket" Variety="Green Rocket" />
@@ -5949,7 +5945,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		</Tile>
 		<Tile Id="237" Color="#FFFFF133" Name="Lihzahrd Altar" Framed="true" Size="3,2" Light="true" />
 		<Tile Id="238" Color="#FFE180CE" Name="Plantera's Bulb" Framed="true" Size="2,2" Light="true" IsAnimated="true" />
-		<Tile Id="239" Color="#FFE0C265" Name="Ore Bar" Solid="true" Framed="true" SolidTop="true">
+		<Tile Id="239" Color="#FFE0C265" Name="Ore Bars" Solid="true" Framed="true" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Variety="Copper Bar" />
 				<Frame UV="18,0" Variety="Tin Bar" />
@@ -5976,7 +5972,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="396,0" Variety="Luminite Bar" />
 			</Frames>
 		</Tile>
-		<Tile Id="240" Color="#FF63321E" Name="3x3 Wall Hangings" Framed="true" Size="3,3">
+		<Tile Id="240" Color="#FF63321E" Name="Wall Hangings 3x3" Framed="true" Size="3,3">
 			<Frames>
 				<Frame UV="0,0" Name="Boss Trophy" Variety="Eye of Cthulhu" />
 				<Frame UV="54,0" Name="Boss Trophy" Variety="Eater of Worlds" />
@@ -6073,7 +6069,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="1080,108" Name="Painting" Variety="Eye of the Sun" />
 			</Frames>
 		</Tile>
-		<Tile Id="241" Color="#FF4D4A48" Name="Catacomb" Framed="true" Size="4,3">
+		<Tile Id="241" Color="#FF4D4A48" Name="Catacombs" Framed="true" Size="4,3">
 			<Frames>
 				<Frame UV="0,0" Variety="A" />
 				<Frame UV="0,54" Variety="B" />
@@ -6086,7 +6082,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,432" Variety="I" />
 			</Frames>
 		</Tile>
-		<Tile Id="242" Color="#FF63321E" Name="6x4 Painting" Framed="true" Size="6,4">
+		<Tile Id="242" Color="#FF63321E" Name="Paintings 6x4" Framed="true" Size="6,4">
 			<Frames>
 				<Frame UV="0,0" Name="Painting" Variety="The Eye Sees the End" />
 				<Frame UV="0,72" Name="Painting" Variety="Something Evil is Watching You" />
@@ -6158,7 +6154,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		</Tile>
 		<Tile Id="243" Color="#FF8CB3FE" Name="Imbuing Station" Framed="true" Size="3,3" IsAnimated="true" />
 		<Tile Id="244" Color="#FFC8F5FD" Name="Bubble Machine" Framed="true" Size="3,2" IsAnimated="true" />
-		<Tile Id="245" Color="#FF63321E" Name="2x3 Painting" Framed="true" Size="2,3">
+		<Tile Id="245" Color="#FF63321E" Name="Paintings 2x3" Framed="true" Size="2,3">
 			<Frames>
 				<Frame UV="0,0" Name="Painting" Variety="Waldo" />
 				<Frame UV="36,0" Name="Painting" Variety="Darkness" />
@@ -6191,7 +6187,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="1008,0" Name="Painting" Variety="Hail to the King" />
 			</Frames>
 		</Tile>
-		<Tile Id="246" Color="#FF63321E" Name="3x2 Painting" Framed="true" Size="3,2">
+		<Tile Id="246" Color="#FF63321E" Name="Paintings 3x2" Framed="true" Size="3,2">
 			<Frames>
 				<Frame UV="0,0" Name="Painting" Variety="Demon's Eye" />
 				<Frame UV="0,36" Name="Painting" Variety="Finding Gold" />
@@ -6346,7 +6342,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="320" Color="#FFCBB997" Name="Seaweed Planter" Framed="true" Size="2,3" />
 		<Tile Id="321" Color="#FF604D40" Name="Boreal Wood" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="322" Color="#FFC6AA68" Name="Palm Wood" Solid="true" Blends="true" MergeWith="0" />
-		<Tile Id="323" Color="#FFB68D56" Name="Palm Tree" Framed="true" Blends="true" TextureGrid="20,20">
+		<Tile Id="323" Color="#FFB68D56" Name="Palm Trees" Framed="true" Blends="true" TextureGrid="20,20">
 			<Frames>
 				<Frame UV="0,22" Name="Palm Tree" Variety="Trunk A" />
 				<Frame UV="22,22" Name="Palm Tree" Variety="Trunk B" />
@@ -6438,7 +6434,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="220,154" Name="Corrupt Palm Tree" Variety="Base Only B" />
 			</Frames>
 		</Tile>
-		<Tile Id="324" Color="#FFE4D5AD" Name="Seashell" Framed="true" TextureGrid="20,20">
+		<Tile Id="324" Color="#FFE4D5AD" Name="Seashells" Framed="true" TextureGrid="20,20">
 			<Frames>
 				<Frame UV="0,0" Name="Seashell" Variety="A" />
 				<Frame UV="22,0" Name="Seashell" Variety="B" />
@@ -6474,7 +6470,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		</Tile>
 		<Tile Id="335" Color="#FFD9AE89" Name="Fireworks Box" Framed="true" Size="2,2" />
 		<Tile Id="336" Color="#FFFD3E03" Name="Living Fire Block" Solid="true" Blends="true" />
-		<Tile Id="337" Color="#FF909490" Name="Text Statue" Framed="true" Size="2,3" Placement="floor">
+		<Tile Id="337" Color="#FF909490" Name="Text Statues" Framed="true" Size="2,3" Placement="floor">
 			<Frames>
 				<Frame UV="0,0" Variety="0 Statue" />
 				<Frame UV="36,0" Variety="1 Statue" />
@@ -6564,7 +6560,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="373" Color="#FF093DBF" Name="Water Drip" Framed="true" Size="1,1" />
 		<Tile Id="374" Color="#FFFD2003" Name="Lava Drip" Framed="true" Size="1,1" />
 		<Tile Id="375" Color="#FFFF9C0C" Name="Honey Drip" Framed="true" Size="1,1" />
-		<Tile Id="376" Color="#FFA0785C" Name="Fishing Crate" Framed="true" Size="2,2" SolidTop="true">
+		<Tile Id="376" Color="#FFA0785C" Name="Fishing Crates" Framed="true" Size="2,2" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Wooden Crate" />
 				<Frame UV="36,0" Name="Iron Crate" />
@@ -6607,7 +6603,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="379" Color="#FFFBD1F0" Name="Bubble" Solid="true" Blends="true" />
-		<Tile Id="380" Color="#FFBF8E6F" Name="Planter Box" Framed="true" Size="[1,1]" SolidTop="true" Solid="true">
+		<Tile Id="380" Color="#FFBF8E6F" Name="Planter Boxes" Framed="true" Size="[1,1]" SolidTop="true" Solid="true">
 			<Frames>
 				<Frame UV="0,0" Name="Daybloom Planter" Variety="Left" />
 				<Frame UV="18,0" Name="Daybloom Planter" Variety="Middle" />
@@ -6648,23 +6644,28 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="383" Color="#FFDD8890" Name="Living Mahogany Block" Solid="true" Blends="true" />
 		<Tile Id="384" Color="#FF83CE0C" Name="Living Mahogany Leaves Block" Solid="true" Blends="true" />
 		<Tile Id="385" Color="#FF571590" Name="Crystal Block" Solid="true" Blends="true" />
-		<Tile Id="386" Color="#FF7F5C45" Name="Trapdoor Open" Framed="true" Size="2,2">
+		<Tile Id="386" Color="#FF7F5C45" Name="Trapdoor (Open)" Framed="true" Size="2,2">
 			<Frames>
-				<Frame UV="0,0" Name="Trapdoor Open" Variety="Up" />
-				<Frame UV="36,0" Name="Trapdoor Open" Variety="Down" />
+				<Frame UV="0,0" Variety="Up" />
+				<Frame UV="36,0" Variety="Down" />
 			</Frames>
 		</Tile>
-		<Tile Id="387" Color="#FF7F5C45" Name="Trapdoor Closed" Framed="true" Size="2,1" Solid="true" />
-		<Tile Id="388" Color="#FF7F5C45" Name="Tall Gate Closed" TextureGrid="16,18" Framed="true" Size="1,5" Solid="true">
+        <Tile Id="387" Color="#FF7F5C45" Name="Trapdoor (Closed)" Framed="true" Size="2,1" Solid="true">
+            <Frames>
+				<Frame UV="0,0" Variety="Up" />
+				<Frame UV="36,0" Variety="Down" />
+			</Frames>
+        </Tile>
+		<Tile Id="388" Color="#FF7F5C45" Name="Tall Gate (Closed)" TextureGrid="16,18" Framed="true" Size="1,5" Solid="true">
 			<Frames>
-				<Frame UV="0,0" Variety="A" />
-				<Frame UV="0,100" Variety="B" />
+				<Frame UV="0,0" Variety="Right" />
+				<Frame UV="0,100" Variety="Left" />
 			</Frames>
 		</Tile>
-		<Tile Id="389" Color="#FF7F5C45" Name="Tall Gate Open" TextureGrid="16,18" Framed="true" Size="1,5">
+		<Tile Id="389" Color="#FF7F5C45" Name="Tall Gate (Open)" TextureGrid="16,18" Framed="true" Size="1,5">
 			<Frames>
-				<Frame UV="0,0" Variety="A" />
-				<Frame UV="0,100" Variety="B" />
+				<Frame UV="0,0" Variety="Right" />
+				<Frame UV="0,100" Variety="Left" />
 			</Frames>
 		</Tile>
 		<Tile Id="390" Color="#FFFD2003" Name="Lava Lamp" Framed="true" Size="1,2" IsAnimated="true" />
@@ -6732,7 +6733,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="36,0" Variety="Faulty" />
 			</Frames>
 		</Tile>
-		<Tile Id="420" Color="#FFFFFFFF" Name="Logic Gate" Framed="true" UseFrameName="true">
+		<Tile Id="420" Color="#FFFFFFFF" Name="Logic Gates" Framed="true" UseFrameName="true">
 			<Frames>
 				<Frame UV="0,0" Name="Logic Gate (AND)" Variety="Off" />
 				<Frame UV="18,0" Name="Logic Gate (AND)" Variety="On" />
@@ -6849,7 +6850,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="468,18" Variety="Stair Inverted Left B" />
 			</Frames>
 		</Tile>
-		<Tile Id="428" Color="#FFFFFFFF" Name="Weighted Pressure Plate" Framed="true">
+		<Tile Id="428" Color="#FFFFFFFF" Name="Weighted Pressure Plates" Framed="true">
 			<Frames>
 				<Frame UV="0,0" Variety="Orange Off" />
 				<Frame UV="0,18" Variety="Cyan Off" />
@@ -7300,18 +7301,18 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="452" Color="#FFff96b5" Name="Silly Balloon Machine" Framed="true" Size="3,2" IsAnimated="true" />
 		<Tile Id="453" Color="#FFFFFFFF" Name="Silly Tied Balloon" Framed="true" Size="1,3" IsAnimated="true">
 			<Frames>
-				<Frame UV="0,0" Name="Purple" Variety="Left" />
-				<Frame UV="18,0" Name="Purple" Variety="Right" />
-				<Frame UV="36,0" Name="Green" Variety="Left" />
-				<Frame UV="54,0" Name="Green" Variety="Right" />
-				<Frame UV="72,0" Name="Pink" Variety="Left" />
-				<Frame UV="90,0" Name="Pink" Variety="Right" />
+				<Frame UV="0,0" Variety="Purple Left" />
+				<Frame UV="18,0" Variety="Purple Right" />
+				<Frame UV="36,0" Variety="Green Left" />
+				<Frame UV="54,0" Variety="Green Right" />
+				<Frame UV="72,0" Variety="Pink Left" />
+				<Frame UV="90,0" Variety="Pink Right" />
 			</Frames>
 		</Tile>
 		<Tile Id="454" Color="#FFae10b0" Name="Pigronata" Framed="true" Size="4,3" IsAnimated="true" />
 		<Tile Id="455" Color="#FF30ff6e" Name="Party Center" Framed="true" Size="3,3" IsAnimated="true" />
 		<Tile Id="456" Color="#FFb384ff" Name="Silly Tied Bundle of Balloons" Framed="true" Size="2,3" IsAnimated="true" />
-		<Tile Id="457" Color="#FFFFFFFF" Name="Party Present" Framed="true" Size="2,2">
+		<Tile Id="457" Color="#FFFFFFFF" Name="Party Presents" Framed="true" Size="2,2">
 			<Frames>
 				<Frame UV="0,0" Variety="Blue with Green Ribbon" />
 				<Frame UV="36,0" Variety="Pink with Blue Ribbon" />
@@ -7371,7 +7372,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="576,0" Name="Trapped Ash Wood Chest" />
 			</Frames>
 		</Tile>
-		<Tile Id="469" Color="#FFBF8E6F" Name="Table (Group 2)" Framed="true" Size="3,2" TextureGrid="16,16" Placement="floor" SolidTop="true">
+		<Tile Id="469" Color="#FFBF8E6F" Name="Tables (Group 2)" Framed="true" Size="3,2" TextureGrid="16,16" Placement="floor" SolidTop="true">
 			<Frames>
 				<Frame UV="0,0" Name="Crystal Table" />
 				<Frame UV="54,0" Name="Spider Table" />
@@ -7387,7 +7388,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="594,0" Name="Ash Wood Table" />
 			</Frames>
 		</Tile>
-		<Tile Id="470" Name="Mannequin" Framed="true" Size="2,3" Color="#FF7B5B44">
+		<Tile Id="470" Name="Mannequins" Framed="true" Size="2,3" Color="#FF7B5B44">
 			<Frames>
 				<Frame UV="0,0" Name="Mannequin" Variety="A" Anchor="Left" />
 				<Frame UV="36,0" Name="Womannequin" Variety="A" Anchor="Right" />
@@ -7430,7 +7431,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="484" Name="Rolling Cactus" Solid="true" Framed="true" Size="2,2" Color="#FF737E3D" />
 		<Tile Id="485" Name="Antlion Larva" Framed="true" Size="2,2" IsAnimated="true" Color="#FFA17956" />
 		<Tile Id="486" Name="Drum Set" Framed="true" Size="3,2" Color="#FF7A775C" />
-		<Tile Id="487" Name="Picnic Table" Framed="true" Size="4,2" Color="#FF8D5A57">
+		<Tile Id="487" Name="Picnic Tables" Framed="true" Size="4,2" Color="#FF8D5A57">
 			<Frames>
 				<Frame UV="0, 0" Name="Picnic Table" />
 				<Frame UV="72, 0" Name="Fancy Picnic Table" />
@@ -7441,7 +7442,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="490" Name="Weather Vane" Framed="true" Size="2,2" IsAnimated="true" Color="#FF808789" />
 		<Tile Id="491" Name="Void Vault" Light="true" Framed="true" Size="3,3" IsAnimated="true" Color="#FF8149B1" />
 		<Tile Id="492" Name="Hallowed Mowed Grass Block" Solid="true" Color="#FF686C63" Special="Grass" MergeWith="0"/>
-		<Tile Id="493" Name="Pin Flag" Framed="true" Size="1,2" IsAnimated="true" Color="#FF8855A1">
+		<Tile Id="493" Name="Pin Flags" Framed="true" Size="1,2" IsAnimated="true" Color="#FF8855A1">
 			<Frames>
 				<Frame UV="0,0" Name="White Pin Flag" />
 				<Frame UV="18,0" Name="Red Pin Flag" />
@@ -7454,7 +7455,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="494" Name="Golf Tee" Framed="true" Size="1,1" Color="#FFA5A4B6" />
 		<Tile Id="495" Name="Shell Pile Block" Solid="true" Color="#FFAF976E" />
 		<Tile Id="496" Name="Anti-Portal Block" Solid="true" Color="#FF655A54" />
-		<Tile Id="497" Name="Ebonwood Toilet" Framed="true" Size="1,2" FrameGap="2,4" Color="#FF356D40">
+		<Tile Id="497" Name="Toilets" Framed="true" Size="1,2" FrameGap="2,4" Color="#FF356D40">
 			<Frames>
 				<Frame UV="0,0" Name="Ebonwood Toilet" Anchor="Left" />
 				<Frame UV="18,0" Name="Ebonwood Toilet" Anchor="Right" />
@@ -7662,7 +7663,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="515" Name="Blue Moss Brick" Solid="true" Color="#FF4C6470" Special="Grass" MergeWith="0" />
 		<Tile Id="516" Name="Purple Moss Brick" Solid="true" Color="#FF6A5278" Special="Grass" MergeWith="0" />
 		<Tile Id="517" Name="Lava Moss Brick" Light="true" Solid="true" Color="#FFA1704F" Special="Grass" MergeWith="0" />
-		<Tile Id="518" Name="Lily Pad" Framed="true" Color="#FF6C5F84">
+		<Tile Id="518" Name="Lily Pads" Framed="true" Color="#FF6C5F84">
 			<Frames>
 				<Frame UV="0,0" Name="Forest Lily Pad" Variety="A" />
 				<Frame UV="18,0" Name="Forest Lily Pad" Variety="B" />
@@ -7756,7 +7757,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="306,72" Name="Corruption Lily Pad" Variety="R" />
 			</Frames>
 		</Tile>
-		<Tile Id="519" Name="Cattail" Light="true" Framed="true" Color="#FF7F7F99">
+		<Tile Id="519" Name="Cattails" Light="true" Framed="true" Color="#FF7F7F99">
 			<Frames>
 				<Frame UV="0,0" Name="Forest Cattail" Variety="Base A" />
 				<Frame UV="18,0" Name="Forest Cattail" Variety="Base B" />
@@ -7994,7 +7995,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="546" Name="Grate Block" Solid="true" Color="#FF87695E" />
-		<Tile Id="547" Name="Potted Tree" Framed="true" Size="2,5" Color="#FF505D21">
+		<Tile Id="547" Name="Potted Trees" Framed="true" Size="2,5" Color="#FF505D21">
 			<Frames>
 				<Frame UV="0,0" Name="Potted Forest Cedar" />
 				<Frame UV="36,0" Name="Potted Jungle Cedar" />
@@ -8003,7 +8004,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="144,0" Name="Potted Jungle Tree" />
 			</Frames>
 		</Tile>
-		<Tile Id="548" Name="Potted Tree (Group 2)" Light="true" Framed="true" Size="3,6" Color="#FF866036">
+		<Tile Id="548" Name="Potted Trees (Group 2)" Light="true" Framed="true" Size="3,6" Color="#FF866036">
 			<Frames>
 				<Frame UV="0,0" Name="Potted Hallow Tree" />
 				<Frame UV="54,0" Name="Potted Forest Palm" />
@@ -8016,7 +8017,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="432,0" Name="Potted Brimstone Bush" />
 			</Frames>
 		</Tile>
-		<Tile Id="549" Name="Seaweed" Framed="true" Color="#FF385806">
+		<Tile Id="549" Name="Seaweeds" Framed="true" Color="#FF385806">
 			<Frames>
 				<Frame UV="0,0" Variety="A" />
 				<Frame UV="18,0" Variety="B" />
@@ -8050,7 +8051,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="557" Name="Grate Block closed" Solid="true" Color="#FF624840" />
 		<Tile Id="558" Name="Seahorse Cage" Framed="true" Size="6,3" IsAnimated="true" Color="#FF657F89" />
 		<Tile Id="559" Name="Gold Seahorse Cage" Framed="true" Size="6,3" IsAnimated="true" Color="#FF71927E" />
-		<Tile Id="560" Name="Golf Trophy" Framed="true" Size="2,3" Color="#FF907F3B">
+		<Tile Id="560" Name="Golf Trophies" Framed="true" Size="2,3" Color="#FF907F3B">
 			<Frames>
 				<Frame UV="0,0" Name="Bronze Golf Trophy" />
 				<Frame UV="36,0" Name="Silver Golf Trophy" />
@@ -8109,7 +8110,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="342,0" Variety="Top F" />
 			</Frames>
 		</Tile>
-		<Tile Id="572" Name="Soul in a Bottle" Light="true" Framed="true" Size="1,2" IsAnimated="true" Color="#FF827995">
+		<Tile Id="572" Name="Souls in a Bottle" Light="true" Framed="true" Size="1,2" IsAnimated="true" Color="#FF827995">
 			<Frames>
 				<Frame UV="0,0" Name="Soul of Light in a Bottle" />
 				<Frame UV="0,36" Name="Soul of Night in a Bottle" />
@@ -8676,7 +8677,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,242" Variety="Top Jagged C" />
 			</Frames>
 		</Tile>
-		<Tile Id="590" Name="Gem Sapling" Framed="true" Size="1,2" Color="#FF8E714F">
+		<Tile Id="590" Name="Gem Saplings" Framed="true" Size="1,2" Color="#FF8E714F">
 			<Frames>
 				<Frame UV="0,0" Name="Topaz Sapling" Variety="A" />
 				<Frame UV="18,0" Name="Topaz Sapling" Variety="B" />
@@ -8704,7 +8705,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="414,0" Name="Amber Sapling" Variety="F" />
 			</Frames>
 		</Tile>
-		<Tile Id="591" Name="Hanging Pot" Framed="true" Size="2,3" Color="#FF915438">
+		<Tile Id="591" Name="Hanging Pots" Framed="true" Size="2,3" Color="#FF915438">
 			<Frames>
 				<Frame UV="0,0" Name="Hanging Pot" />
 				<Frame UV="36,0" Name="Hanging Daybloom" />
@@ -8803,7 +8804,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="0,242" Variety="Top Jagged C" />
 			</Frames>
 		</Tile>
-		<Tile Id="597" Name="Pylon" Light="true" Framed="true" Size="3,4" Color="#FF787F4B">
+		<Tile Id="597" Name="Pylons" Light="true" Framed="true" Size="3,4" Color="#FF787F4B">
 			<Frames>
 				<Frame Name="Forest Pylon" UV="0, 0" Anchor="Bottom" />
 				<Frame Name="Jungle Pylon" UV="54,0" Anchor="Bottom" />

--- a/src/TEdit/settings.xml
+++ b/src/TEdit/settings.xml
@@ -3573,12 +3573,12 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="80" Color="#FF497811" Name="Cactus plant" Special="Cactus" />
 		<Tile Id="81" Color="#FFF585BF" Name="Coral" Framed="true" TextureGrid="24,26">
 			<Frames>
-				<Frame UV="0,0" Variety="Red" />
-				<Frame UV="26,0" Variety="Pink" />
-				<Frame UV="52,0" Variety="Yellow" />
-				<Frame UV="78,0" Variety="Green" />
-				<Frame UV="104,0" Variety="Blue" />
-				<Frame UV="130,0" Variety="Sponge" />
+				<Frame UV="0,0" Variety="Red" Anchor="Bottom" />
+				<Frame UV="26,0" Variety="Pink" Anchor="Bottom" />
+				<Frame UV="52,0" Variety="Yellow" Anchor="Bottom" />
+				<Frame UV="78,0" Variety="Green" Anchor="Bottom" />
+				<Frame UV="104,0" Variety="Blue" Anchor="Bottom" />
+				<Frame UV="130,0" Variety="Sponge" Anchor="Bottom" />
 			</Frames>
 		</Tile>
 		<Tile Id="82" Color="#FFFF7800" Name="Herbs (Sprout)" Framed="true" UseFrameName="true" FrameNamePostfix="seed">

--- a/src/TEdit/settings.xml
+++ b/src/TEdit/settings.xml
@@ -14927,9 +14927,9 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Item Id="5040" Name="Otherworldly Music Box (Hallow)" Accessory="True" />
 		<Item Id="5041" Name="Carton of Milk" IsFood="True" />
 		<Item Id="5042" Name="Coffee" IsFood="True" />
-		<Item Id="5043" Name="Torch God's Favor"      />
-		<Item Id="5044" Name="Music Box (Journey's End)"     Accessory="True"  />
-		<Item Id="5045" Name="Plaguebringer's Skull"  Head="266"     />
+		<Item Id="5043" Name="Torch God's Favor" />
+		<Item Id="5044" Name="Music Box (Journey's End)" Accessory="True" />
+		<Item Id="5045" Name="Plaguebringer's Skull" Head="266" />
 		<Item Id="5046" Name="Plaguebringer's Cloak"   Body="235"    />
 		<Item Id="5047" Name="Plaguebringer's Treads"    Legs="218"   />
 		<Item Id="5048" Name="Wandering Jingasa"  Head="267"     />

--- a/src/TEdit/settings.xml
+++ b/src/TEdit/settings.xml
@@ -4657,12 +4657,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="972,216" Name="Cockatiel Statue" Variety="Right" />
 			</Frames>
 		</Tile>
-		<Tile Id="106" Color="#FFBF8E6F" Name="Sawmill" Framed="true" Size="3,3" Placement="floor">
-			<Frames>
-				<Frame UV="0,0" Variety="A" />
-				<Frame UV="0,54" Variety="B" />
-			</Frames>
-		</Tile>
+		<Tile Id="106" Color="#FFBF8E6F" Name="Sawmill" Framed="true" Size="3,3" Placement="floor" IsAnimated="true" />
 		<Tile Id="107" Color="#FF0B508F" Name="Cobalt Ore" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="108" Color="#FF5BA9A9" Name="Mythril Ore" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="109" Color="#FF4EC1E3" Name="Hallowed Grass Block" Solid="true" Blends="true" MergeWith="0" Special="Grass" Light="true" />
@@ -4806,54 +4801,10 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="306,18" Variety="Large Purple B" Anchor="Top" />
 				<Frame UV="306,36" Variety="Large Purple B" Anchor="Right" />
 				<Frame UV="306,54" Variety="Large Purple B" Anchor="Left" />
-				<Frame UV="324,0" Variety="Gelatin Crystal A1" Anchor="Bottom" />
-				<Frame UV="342,0" Variety="Gelatin Crystal B1" Anchor="Bottom" />
-				<Frame UV="360,0" Variety="Gelatin Crystal C1" Anchor="Bottom" />
-				<Frame UV="378,0" Variety="Gelatin Crystal D1" Anchor="Bottom" />
-				<Frame UV="396,0" Variety="Gelatin Crystal E1" Anchor="Bottom" />
-				<Frame UV="414,0" Variety="Gelatin Crystal F1" Anchor="Bottom" />
-				<Frame UV="324,18" Variety="Gelatin Crystal A1" Anchor="Top" />
-				<Frame UV="342,18" Variety="Gelatin Crystal B1" Anchor="Top" />
-				<Frame UV="360,18" Variety="Gelatin Crystal C1" Anchor="Top" />
-				<Frame UV="378,18" Variety="Gelatin Crystal D1" Anchor="Top" />
-				<Frame UV="396,18" Variety="Gelatin Crystal E1" Anchor="Top" />
-				<Frame UV="414,18" Variety="Gelatin Crystal F1" Anchor="Top" />
-				<Frame UV="324,36" Variety="Gelatin Crystal A1" Anchor="Right" />
-				<Frame UV="342,36" Variety="Gelatin Crystal B1" Anchor="Right" />
-				<Frame UV="360,36" Variety="Gelatin Crystal C1" Anchor="Right" />
-				<Frame UV="378,36" Variety="Gelatin Crystal D1" Anchor="Right" />
-				<Frame UV="396,36" Variety="Gelatin Crystal E1" Anchor="Right" />
-				<Frame UV="414,36" Variety="Gelatin Crystal F1" Anchor="Right" />
-				<Frame UV="324,54" Variety="Gelatin Crystal A1" Anchor="Left" />
-				<Frame UV="342,54" Variety="Gelatin Crystal B1" Anchor="Left" />
-				<Frame UV="360,54" Variety="Gelatin Crystal C1" Anchor="Left" />
-				<Frame UV="378,54" Variety="Gelatin Crystal D1" Anchor="Left" />
-				<Frame UV="396,54" Variety="Gelatin Crystal E1" Anchor="Left" />
-				<Frame UV="414,54" Variety="Gelatin Crystal F1" Anchor="Left" />
-				<Frame UV="324,72" Variety="Gelatin Crystal A2" Anchor="Bottom" />
-				<Frame UV="342,72" Variety="Gelatin Crystal B2" Anchor="Bottom" />
-				<Frame UV="360,72" Variety="Gelatin Crystal C2" Anchor="Bottom" />
-				<Frame UV="378,72" Variety="Gelatin Crystal D2" Anchor="Bottom" />
-				<Frame UV="396,72" Variety="Gelatin Crystal E2" Anchor="Bottom" />
-				<Frame UV="414,72" Variety="Gelatin Crystal F2" Anchor="Bottom" />
-				<Frame UV="324,90" Variety="Gelatin Crystal A2" Anchor="Top" />
-				<Frame UV="342,90" Variety="Gelatin Crystal B2" Anchor="Top" />
-				<Frame UV="360,90" Variety="Gelatin Crystal C2" Anchor="Top" />
-				<Frame UV="378,90" Variety="Gelatin Crystal D2" Anchor="Top" />
-				<Frame UV="396,90" Variety="Gelatin Crystal E2" Anchor="Top" />
-				<Frame UV="414,90" Variety="Gelatin Crystal F2" Anchor="Top" />
-				<Frame UV="324,108" Variety="Gelatin Crystal A2" Anchor="Right" />
-				<Frame UV="342,108" Variety="Gelatin Crystal B2" Anchor="Right" />
-				<Frame UV="360,108" Variety="Gelatin Crystal C2" Anchor="Right" />
-				<Frame UV="378,108" Variety="Gelatin Crystal D2" Anchor="Right" />
-				<Frame UV="396,108" Variety="Gelatin Crystal E2" Anchor="Right" />
-				<Frame UV="414,108" Variety="Gelatin Crystal F2" Anchor="Right" />
-				<Frame UV="324,126" Variety="Gelatin Crystal A2" Anchor="Left" />
-				<Frame UV="342,126" Variety="Gelatin Crystal B2" Anchor="Left" />
-				<Frame UV="360,126" Variety="Gelatin Crystal C2" Anchor="Left" />
-				<Frame UV="378,126" Variety="Gelatin Crystal D2" Anchor="Left" />
-				<Frame UV="396,126" Variety="Gelatin Crystal E2" Anchor="Left" />
-				<Frame UV="414,126" Variety="Gelatin Crystal F2" Anchor="Left" />
+				<Frame UV="324,0" Name="Gelatin Crystal" Anchor="Bottom" />
+				<Frame UV="324,18" Name="Gelatin Crystal" Anchor="Top" />
+				<Frame UV="324,36" Name="Gelatin Crystal" Anchor="Right" />
+				<Frame UV="324,54" Name="Gelatin Crystal" Anchor="Left" />
 			</Frames>
 		</Tile>
 		<Tile Id="130" Color="#FFA0A0A0" Name="Active Stone Block" Solid="true" Blends="true" Stone="true" />
@@ -5802,16 +5753,26 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="206" Color="#FF7CAFC9" Name="Ice Brick" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="207" Color="#FF909490" Name="Water Fountain" Framed="true" Size="2,4" IsAnimated="true">
 			<Frames>
-				<Frame UV="0,0" Name="Pure Water Fountain" />
-				<Frame UV="36,0" Name="Desert Water Fountain" />
-				<Frame UV="72,0" Name="Jungle Water Fountain" />
-				<Frame UV="108,0" Name="Icy Water Fountain" />
-				<Frame UV="144,0" Name="Corrupt Water Fountain" />
-				<Frame UV="180,0" Name="Crimson Water Fountain" />
-				<Frame UV="216,0" Name="Hallowed Water Fountain" />
-				<Frame UV="252,0" Name="Blood Water Fountain" />
-				<Frame UV="288,0" Name="Cavern Water Fountain" />
-				<Frame UV="324,0" Name="Oasis Water Fountain" />
+				<Frame UV="0,0" Name="Pure Water Fountain" Variety="Off" />
+				<Frame UV="0,72" Name="Pure Water Fountain" Variety="On" />
+				<Frame UV="36,0" Name="Desert Water Fountain" Variety="Off" />
+				<Frame UV="36,72" Name="Desert Water Fountain" Variety="On" />
+				<Frame UV="72,0" Name="Jungle Water Fountain" Variety="Off" />
+				<Frame UV="72,72" Name="Jungle Water Fountain" Variety="On" />
+				<Frame UV="108,0" Name="Icy Water Fountain" Variety="Off" />
+				<Frame UV="108,72" Name="Icy Water Fountain" Variety="On" />
+				<Frame UV="144,0" Name="Corrupt Water Fountain" Variety="Off" />
+				<Frame UV="144,72" Name="Corrupt Water Fountain" Variety="On" />
+				<Frame UV="180,0" Name="Crimson Water Fountain" Variety="Off" />
+				<Frame UV="180,72" Name="Crimson Water Fountain" Variety="On" />
+				<Frame UV="216,0" Name="Hallowed Water Fountain" Variety="Off" />
+				<Frame UV="216,72" Name="Hallowed Water Fountain" Variety="On" />
+				<Frame UV="252,0" Name="Blood Water Fountain" Variety="Off" />
+				<Frame UV="252,72" Name="Blood Water Fountain" Variety="On" />
+				<Frame UV="288,0" Name="Cavern Water Fountain" Variety="Off" />
+				<Frame UV="288,72" Name="Cavern Water Fountain" Variety="On" />
+				<Frame UV="324,0" Name="Oasis Water Fountain" Variety="Off" />
+				<Frame UV="324,72" Name="Oasis Water Fountain" Variety="On" />
 			</Frames>
 		</Tile>
 		<Tile Id="208" Color="#FF586976" Name="Shadewood" Solid="true" Blends="true" MergeWith="0" />
@@ -6564,7 +6525,14 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="346" Color="#FF95D459" Name="Chlorophyte Brick" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="347" Color="#FFEC4A4F" Name="Crimtane Brick" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="348" Color="#FF2C1AE9" Name="Shroomite Plating" Solid="true" Blends="true" MergeWith="0" />
-		<Tile Id="349" Color="#FF909490" Name="Mushroom Statue" Framed="true" Size="2,3" IsAnimated="true" />
+		<Tile Id="349" Color="#FF909490" Name="Mushroom Statue" Framed="true" Size="2,3" IsAnimated="true">
+			<Frames>
+				<Frame UV="0,0" Variety="Left Off" />
+				<Frame UV="216,0" Variety="Left On" />
+				<Frame UV="0,54" Variety="Right Off" />
+				<Frame UV="216,54" Variety="Right On" />
+			</Frames>
+		</Tile>
 		<Tile Id="350" Color="#FF37619B" Name="Martian Conduit Plating" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="351" Color="#FF1F1F1F" Name="Smoke Block" Solid="true" Blends="true" />
 		<Tile Id="352" Color="#FFEE615E" Name="Crimtane Thorns" Solid="true" Blends="true" />
@@ -6732,12 +6700,16 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="407" Color="#FFFFE384" Name="Sturdy Fossil Block" Solid="true" Blends="true" />
 		<Tile Id="408" Color="#FF555352" Name="Luminite Ore" Solid="true" Blends="true" MergeWith="0" />
 		<Tile Id="409" Color="#FF555352" Name="Luminite Brick" Solid="true" Blends="true" />
-		<Tile Id="410" Color="#FF4B8BA6" Name="Lunar Monolith" Framed="true" Size="2,3" IsAnimated="true">
+		<Tile Id="410" Color="#FF4B8BA6" Name="Lunar Monoliths" Framed="true" Size="2,3" IsAnimated="true">
 			<Frames>
-				<Frame UV="0,0" Variety="Vortex" />
-				<Frame UV="36,0" Variety="Nebula" />
-				<Frame UV="72,0" Variety="Stardust" />
-				<Frame UV="108,0" Variety="Solar" />
+				<Frame UV="0,0" Name="Vortex Monolith" Variety="Off" />
+				<Frame UV="0,56" Name="Vortex Monolith" Variety="On" />
+				<Frame UV="36,0" Name="Nebula Monolith" Variety="Off" />
+				<Frame UV="36,56" Name="Nebula Monolith" Variety="On" />
+				<Frame UV="72,0" Name="Stardust Monolith" Variety="Off" />
+				<Frame UV="72,56" Name="Stardust Monolith" Variety="On" />
+				<Frame UV="108,0" Name="Solar Monolith" Variety="Off" />
+				<Frame UV="108,56" Name="Solar Monolith" Variety="On" />
 			</Frames>
 		</Tile>
 		<Tile Id="411" Color="#FFE32E2E" Name="Detonator" Framed="true" Size="2,2">
@@ -7446,19 +7418,17 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="477" Name="Mowed Grass Block" Solid="true" Color="#FF607044" MergeWith="0" />
 		<Tile Id="478" Name="Crimstone Brick" Solid="true" Color="#FFA55557" />
 		<Tile Id="479" Name="Smooth Sandstone Block" Solid="true" Color="#FFBC7347" />
-		<Tile Id="480" Name="Blood Moon Monolith" Framed="true" Size="2,3" IsAnimated="true" Color="#FF827C7F" />
+		<Tile Id="480" Name="Blood Moon Monolith" Framed="true" Size="2,3" IsAnimated="true" Color="#FF827C7F">
+			<Frames>
+				<Frame UV="0,0" Variety="Off" />
+				<Frame UV="0,54" Variety="On" />
+			</Frames>
+		</Tile>
 		<Tile Id="481" Name="Cracked Blue Brick" Solid="true" Color="#FF383E50" />
 		<Tile Id="482" Name="Cracked Green Brick" Solid="true" Color="#FF3E4D47" />
 		<Tile Id="483" Name="Cracked Pink Brick" Solid="true" Color="#FF7A405F" />
 		<Tile Id="484" Name="Rolling Cactus" Solid="true" Framed="true" Size="2,2" Color="#FF737E3D" />
-		<Tile Id="485" Name="Antlion Larva" Framed="true" Size="2,2" IsAnimated="true" Color="#FFA17956">
-			<Frames>
-				<Frame UV="0,0" Variety="A" />
-				<Frame UV="36,0" Variety="B" />
-				<Frame UV="72,0" Variety="C" />
-				<Frame UV="108,0" Variety="D" />
-			</Frames>
-		</Tile>
+		<Tile Id="485" Name="Antlion Larva" Framed="true" Size="2,2" IsAnimated="true" Color="#FFA17956" />
 		<Tile Id="486" Name="Drum Set" Framed="true" Size="3,2" Color="#FF7A775C" />
 		<Tile Id="487" Name="Picnic Table" Framed="true" Size="4,2" Color="#FF8D5A57">
 			<Frames>
@@ -7592,7 +7562,12 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		</Tile>
 		<Tile Id="507" Name="Gold Starry Block" Solid="true" Color="#FF66503D" />
 		<Tile Id="508" Name="Blue Starry Block" Solid="true" Color="#FF1F3862" />
-		<Tile Id="509" Name="Void Monolith" Framed="true" Size="2,3" IsAnimated="true" Color="#FF36363A" />
+		<Tile Id="509" Name="Void Monolith" Framed="true" Size="2,3" IsAnimated="true" Color="#FF36363A">
+			<Frames>
+				<Frame UV="0,0" Variety="Off" />
+				<Frame UV="0,54" Variety="On" />
+			</Frames>
+		</Tile>
 		<Tile Id="510" Name="Arrow Sign" Framed="true" Size="2,2" Color="#FF73533C">
 			<Frames>
 				<Frame UV="0,0" Variety="Right" Anchor="Bottom" />
@@ -8085,8 +8060,18 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="561" Name="Marble Column" Color="#FF6E7482" />
 		<Tile Id="562" Name="Bamboo Block" Solid="true" Color="#FF737A2D" />
 		<Tile Id="563" Name="Large Bamboo Block" Solid="true" Color="#FF737A2D" />
-		<Tile Id="564" Name="Plasma Lamp" Light="true" Framed="true" Size="2,2" IsAnimated="true" Color="#FF575C70" />
-		<Tile Id="565" Name="Fog Machine" Framed="true" Size="2,2" IsAnimated="true" Color="#FF628195" />
+		<Tile Id="564" Name="Plasma Lamp" Light="true" Framed="true" Size="2,2" Color="#FF575C70">
+			<Frames>
+				<Frame UV="0,0" Variety="On" />
+				<Frame UV="36,0" Variety="Off" />
+			</Frames>
+		</Tile>
+		<Tile Id="565" Name="Fog Machine" Framed="true" Size="2,2" IsAnimated="true" Color="#FF628195">
+			<Frames>
+				<Frame UV="0,0" Variety="On" />
+				<Frame UV="36,0" Variety="Off" />
+			</Frames>
+		</Tile>
 		<Tile Id="566" Name="Amber Stone Block" Solid="true" Color="#FFA88A64" />
 		<Tile Id="567" Name="Garden Gnome" Framed="true" TextureGrid="26,18" Size="1,2" Color="#FF938381">
 			<Frames>
@@ -8127,11 +8112,11 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="572" Name="Soul in a Bottle" Light="true" Framed="true" Size="1,2" IsAnimated="true" Color="#FF827995">
 			<Frames>
 				<Frame UV="0,0" Name="Soul of Light in a Bottle" />
-				<Frame UV="18,0" Name="Soul of Night in a Bottle" />
-				<Frame UV="36,0" Name="Soul of Flight in a Bottle" />
-				<Frame UV="54,0" Name="Soul of Sight in a Bottle" />
-				<Frame UV="72,0" Name="Soul of Might in a Bottle" />
-				<Frame UV="90,0" Name="Soul of Fright in a Bottle" />
+				<Frame UV="0,36" Name="Soul of Night in a Bottle" />
+				<Frame UV="0,72" Name="Soul of Flight in a Bottle" />
+				<Frame UV="0,108" Name="Soul of Sight in a Bottle" />
+				<Frame UV="0,144" Name="Soul of Might in a Bottle" />
+				<Frame UV="0,180" Name="Soul of Fright in a Bottle" />
 			</Frames>
 		</Tile>
 		<Tile Id="573" Name="Tattered Wood Sign" Framed="true" Size="2,2" Color="#FF5E4736">
@@ -8955,7 +8940,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 				<Frame UV="108,0" Name="Potted Crystal Tree" />
 			</Frames>
 		</Tile>
-		<Tile Id="624" Name="Abigail's Flower" Framed="true" Size="2,1" Color="#FFBC5543" />
+		<Tile Id="624" Name="Abigail's Flower" Framed="true" TextureGrid="20,18" Color="#FFBC5543" />
 		<Tile Id="625" Name="Neon Moss Block" Light="true" Solid="true" Color="#FF906094" />
 		<Tile Id="626" Name="Neon Moss Brick" Light="true" Solid="true" Color="#FF86598D" />
 		<Tile Id="627" Name="Helium Moss Block" Light="true" Solid="true" Color="#FF969696" />
@@ -9075,7 +9060,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 			</Frames>
 		</Tile>
 		<Tile Id="638" Name="Ash Vines" Light="true" Color="#FF844A3C" />
-		<Tile Id="639" Name="Mana Crystal" Framed="true" Size="2,2" Color="#FF5357A1" />
+		<Tile Id="639" Name="Mana Crystal" Framed="true" Size="2,2" IsAnimated="true" Color="#FF5357A1" />
 		<Tile Id="640" Name="Blue Macaw Cage" SolidTop="true" Framed="true" Size="6,3" IsAnimated="true" Color="#FF678478" />
 		<Tile Id="641" Name="Reef Block" Solid="true" Color="#FFCD7987" />
 		<Tile Id="642" Name="Chlorophyte Extractinator" Framed="true" Size="3,3" Color="#FF6E8B81" IsAnimated="true" />
@@ -9485,7 +9470,13 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
 		<Tile Id="655" Name="Plantera Thorns" Color="#FFA85386" />
 		<Tile Id="656" Name="Glow Tulip" Light="true" Framed="true" Size="2,2" Color="#FF3995B3" />
 		<Tile Id="657" Name="Echo Chamber" Framed="true" Size="2,3" Color="#FF3D3F4B" IsAnimated="true" />
-		<Tile Id="658" Name="Aether Monolith" Light="true" Framed="true" Size="2,3" Color="#FFAB8DCE" IsAnimated="true"/>
+		<Tile Id="658" Name="Aether Monolith" Light="true" Framed="true" Size="2,3" Color="#FFAB8DCE" IsAnimated="true">
+			<Frames>
+				<Frame UV="0,0" Variety="Off (Flowing)" />
+				<Frame UV="0,540" Variety="On" />
+				<Frame UV="0,1080" Variety="Off" />
+			</Frames>
+		</Tile>
 		<Tile Id="659" Name="Aetherium Block" Light="true" Solid="true" Color="#FFC7C9CB" />
 		<Tile Id="660" Name="Faeling in a Bottle" Light="true" Framed="true" Size="1,2" IsAnimated="true" Color="#FF5F688E" />
 		<Tile Id="661" Name="Corrupt Jungle Grass Block" Solid="true" Color="#FF5D4F67" Blends="true" MergeWith="0" Stone="true" />


### PR DESCRIPTION
Added plurals to tile names where applicable. Makes the sprite selection grid more intuitive in my opinion. But it'll no problem at all if you guys reject the changes.

Non-exhaustive list of TODOs

* 129 Crystal Shard — Subsprite Gelatin Crystal horizontal animation
* 139 Music Box — Most sprites missing from styles grid
* 207 Water Fountain — Only off sprites are showing in styles grid
* 270 Firefly in a Bottle — Horizontal animation
* 271 Lightning Bug in a Bottle — Horizontal animation
* 349 Mushroom Statue — Horizontal animation
* 373 Water Drip — Doesn't have a sprite, when selected fallbacks to last selected sprite
* 374 Lava Drip — Doesn't have a sprite, when selected fallbacks to last selected sprite
* 375 Honey Drip — Doesn't have a sprite, when selected fallbacks to last selected sprite
* 388 Tall Gate (Closed) — Fix left variety rendering.
* * 388 Tall Gate (Open) — Fix left variety rendering.
* 410 Lunar Monoliths — Only off states are showing in styles grid
* 480 Blood Moon Monolith — Only off state is showing in styles grid
* 509 Void Monolith — Only off state is showing in styles grid
* 572 Souls in a Bottle — Only Soul of Light is showing on styles grid. Horizontal animation sprites
* 581 Lavafly in a Bottle — Horizontal animation
* 614 Potted Ember Tendrils — Horizontal animation
* 658 Aether Monolith — Only the first one state (off flowing) is showing in styles grid
* 660 Faeling in a Bottle — Horizontal animation