### PR TITLE
Fixed Eater of Worlds being wiped from bestiary when saving in TEdit

### DIFF
--- a/src/TEdit/npcData.json
+++ b/src/TEdit/npcData.json
@@ -211,7 +211,7 @@
     "BestiaryId": "EaterofWorldsHead",
     "CanTalk": false,
     "IsCritter": false,
-    "IsKillCredit": false,
+    "IsKillCredit": true,
     "IsTownNpc": false,
     "BestiaryDisplayIndex": 507
   },


### PR DESCRIPTION
Eater of Worlds data would be wiped from a player's bestiary upon saving it, even if no edits were made at all, and any previous kills would also be removed. This fixes that issue.