### PR TITLE
Fix FindTileLocation results zoom

### DIFF
--- a/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/FindTileLocationResultView.xaml.cs
@@ -35,7 +35,8 @@ namespace TEdit.Editor.Plugins
                 TextBlock item = e.OriginalSource as TextBlock;
                 if ( !string.IsNullOrEmpty(item.Text) )
                 {
-                    string[] positions = item.Text.Split(':')[1].Trim().Split(splitters);
+                    string[] split = item.Text.Split(':');
+                    string[] positions = split[split.Length - 1].Trim().Split(splitters);
                     if (positions.Length == 2)
                     {
                         int x = 0;


### PR DESCRIPTION
After 253be23424fc097d3c714aed52e865b7692e748a item string can have two colons. Now we make sure we're always getting the last split element