### PR TITLE
World randomizer update

### DIFF
--- a/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
+++ b/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
@@ -196,7 +196,7 @@ namespace TEdit.Editor.Plugins
 
                     Tile tBelow = _wvm.CurrentWorld.Tiles[x, y + 1];
 
-                    if (tBelow.IsActive && Terraria.World.TileBricks.Where(x => x.Id == tBelow.Type).First().IsSolid)
+                    if (tBelow.IsActive)
                         continue;
 
                     if (Sands.Contains(t.Type))

--- a/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
+++ b/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
@@ -46,8 +46,7 @@ namespace TEdit.Editor.Plugins
             {
                 // Set the randomizationArea to the selected area
                 randomizationArea = _wvm.Selection.SelectionArea;
-            }
-            else
+            } else
             {
                 // Set the randomizationArea to the whole world
                 randomizationArea = new(0, 0, _wvm.CurrentWorld.Size.X, _wvm.CurrentWorld.Size.Y);
@@ -129,15 +128,14 @@ namespace TEdit.Editor.Plugins
             return mapping;
         }
 
-        private class BlockRandomizerSettings
+        private struct BlockRandomizerSettings
         {
             public int Seed { get; set; }
         }
 
-        private class WallRandomizerSetting
+        private struct WallRandomizerSetting
         {
             public int Seed { get; set; }
         }
     }
-
 }

--- a/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
+++ b/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
@@ -131,11 +131,18 @@ namespace TEdit.Editor.Plugins
         private struct BlockRandomizerSettings
         {
             public int Seed { get; set; }
+            public bool NoDisappearingBlocks { get; set; }
+            public bool NoNonSolidBlocks { get; set; }
+            public bool NoGravityBlocks { get; set; }
         }
 
         private struct WallRandomizerSetting
         {
             public int Seed { get; set; }
+            public bool NoDungeonWalls { get; set; }
+            // By dungeon walls I mean any kind of wall that's needed for a biome
+            // - Dungeon (all kinds)
+            // - Lihzahrd Temple
         }
     }
 }

--- a/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
+++ b/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
@@ -196,7 +196,7 @@ namespace TEdit.Editor.Plugins
 
                     Tile tBelow = _wvm.CurrentWorld.Tiles[x, y + 1];
 
-                    if (tBelow.IsActive)
+                    if (tBelow.IsActive && Terraria.World.TileBricks.Where(x => x.Id == tBelow.Type).First().IsSolid)
                         continue;
 
                     if (Sands.Contains(t.Type))

--- a/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
+++ b/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
@@ -39,7 +39,7 @@ namespace TEdit.Editor.Plugins
                 Seed = view.Seed,
             };
 
-            var blockMapping = GetRandomBlockMapping(blockSettings);
+            var tileMapping = GetRandomTileMapping(blockSettings);
             var wallMapping = GetRandomWallMapping(wallSettings);
 
             Rectangle randomizationArea;
@@ -65,8 +65,8 @@ namespace TEdit.Editor.Plugins
 
                     Tile t = _wvm.CurrentWorld.Tiles[x, y];
 
-                    if (blockMapping.ContainsKey(t.Type))
-                        t.Type = (ushort)blockMapping[t.Type];
+                    if (tileMapping.ContainsKey(t.Type))
+                        t.Type = (ushort)tileMapping[t.Type];
 
                     if (view.EnableWallRandomize && wallMapping.ContainsKey(t.Wall))
                         t.Wall = (ushort)wallMapping[t.Wall];
@@ -196,7 +196,7 @@ namespace TEdit.Editor.Plugins
 
                     Tile tBelow = _wvm.CurrentWorld.Tiles[x, y + 1];
 
-                    if (!tBelow.IsEmpty)
+                    if (tBelow.IsActive)
                         continue;
 
                     if (Sands.Contains(t.Type))
@@ -214,12 +214,13 @@ namespace TEdit.Editor.Plugins
             }
         }
 
-        private Dictionary<int, int> GetRandomBlockMapping(BlockRandomizerSettings settings)
+        private Dictionary<int, int> GetRandomTileMapping(BlockRandomizerSettings settings)
         {
             Random rng = new(settings.Seed);
 
             // Set up lists
             List<int> fromTiles = new(Terraria.World.TileBricks.Select(x => x.Id));
+            fromTiles.Remove(-1);
 
             if (settings.NoDisappearingBlocks)
                 fromTiles = fromTiles.Where(x => !DisappearingTiles.Contains(x)).ToList();

--- a/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
+++ b/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
@@ -91,7 +91,7 @@ namespace TEdit.Editor.Plugins
         /// </summary>
         private void AddSupportsToDependentBlocks(Rectangle randomizationArea)
         {
-            Dictionary<int, int> VineHangBlock = new()
+            Dictionary<int, int> VineHangTile = new()
             {
                 { 52, 2 },// Vine
                 { 205, 199 },// Crimson vine
@@ -109,7 +109,7 @@ namespace TEdit.Editor.Plugins
                 {
                     Tile t = _wvm.CurrentWorld.Tiles[x, y];
 
-                    if (VineHangBlock.ContainsKey(t.Type))
+                    if (VineHangTile.ContainsKey(t.Type))
                     {
                         int currentY = y;
                         while (true)
@@ -122,13 +122,13 @@ namespace TEdit.Editor.Plugins
                                     currentY--;
                                     continue;
                                 }
-                                else if (tAbove.Type == VineHangBlock[t.Type])
+                                else if (tAbove.Type == VineHangTile[t.Type])
                                 {
                                     break;
                                 }
                             }
 
-                            t.Type = (ushort)VineHangBlock[t.Type];
+                            t.Type = (ushort)VineHangTile[t.Type];
                             break;
                         }
                     }
@@ -161,7 +161,57 @@ namespace TEdit.Editor.Plugins
 
         private void AddSupportsToGravityBlocks(Rectangle randomizationArea)
         {
-            throw new NotImplementedException();
+            Dictionary<int, int> GravitySupportTile = new()
+            {
+                { 53, 397 },// Sand, Hardened sand
+                { 112, 398 }, // Ebonsand, Corrupt hardened sand
+                { 234, 399 }, // Crimsand, Crimson hardened sand
+                { 116, 402 }, // Pearlsand, hallow hardened sand
+                { 123, 1 }, // Silt, stone
+                { 224, 161 }, // Slush, ice
+                { 330, 7 }, // Copper coin pile, copper ore
+                { 331, 9 }, // Silver coin pile, silver ore
+                { 332, 8 }, // Gold coin pile, gold ore
+                { 333, 169 }, // Plat coin pile, plat ore
+            };
+
+            HashSet<int> Sands = new()
+            {
+                53,
+                112,
+                234,
+                116,
+            };
+
+            for (int x = randomizationArea.Left; x < randomizationArea.Right; x++)
+            {
+                for (int y = randomizationArea.Top; y < randomizationArea.Bottom; y++)
+                {
+                    Tile t = _wvm.CurrentWorld.Tiles[x, y];
+                    if (!GravitySupportTile.Keys.Contains(t.Type))
+                        continue;
+
+                    if (y + 1 > randomizationArea.Bottom)
+                        continue;
+
+                    Tile tBelow = _wvm.CurrentWorld.Tiles[x, y + 1];
+
+                    if (!tBelow.IsEmpty)
+                        continue;
+
+                    if (Sands.Contains(t.Type))
+                    {
+                        if (y + 1 > randomizationArea.Bottom)
+                            continue;
+
+                        Tile tAbove = _wvm.CurrentWorld.Tiles[x, y - 1];
+                        if (tAbove.Type == 80)
+                            continue;
+                    }
+
+                    t.Type = (ushort)GravitySupportTile[t.Type];
+                }
+            }
         }
 
         private Dictionary<int, int> GetRandomBlockMapping(BlockRandomizerSettings settings)

--- a/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
+++ b/src/TEdit/Editor/Plugins/RandomizerPlugin.cs
@@ -134,7 +134,26 @@ namespace TEdit.Editor.Plugins
                     }
                     else if (t.Type == 80) // A cactus
                     {
+                        int currentY = y;
+                        while (true)
+                        {
+                            if (currentY + 1 >= 0)
+                            {
+                                Tile tAbove = _wvm.CurrentWorld.Tiles[x, currentY];
+                                if (tAbove.Type == t.Type)
+                                {
+                                    currentY++;
+                                    continue;
+                                }
+                                else if (tAbove.Type == 53)
+                                {
+                                    break;
+                                }
+                            }
 
+                            t.Type = 53;
+                            break;
+                        }
                     }
                 }
             }

--- a/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml
+++ b/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml
@@ -19,10 +19,10 @@
                 <RowDefinition />
                 <RowDefinition />
             </Grid.RowDefinitions>
-            <CheckBox Grid.Column="0" Grid.Row="0" x:Name="NoNonSolidBlocks" Content="Don't randomize (into) non-solid blocks" HorizontalAlignment="Left" />
-            <CheckBox Grid.Column="0" Grid.Row="1" x:Name="NoGravityBlocks" Content="Don't randomize (into) gravity-blocks" HorizontalAlignment="Left" />
-            <CheckBox Grid.Column="0" Grid.Row="2" x:Name="NoDisappearingBlocks" Content="Don't randomize (into) disappearing blocks" HorizontalAlignment="Left" />
-            <CheckBox Grid.Column="1" Grid.Row="0" x:Name="NoDungeonWalls" Content="Don't randomize (into) dungeon walls" HorizontalAlignment="Left" />
+            <CheckBox Grid.Column="0" Grid.Row="0" x:Name="NoNonSolidBlocksCheckBox" Content="Don't randomize (into) non-solid blocks" HorizontalAlignment="Left" />
+            <CheckBox Grid.Column="0" Grid.Row="1" x:Name="NoGravityBlocksCheckBox" Content="Don't randomize (into) gravity-blocks" HorizontalAlignment="Left" />
+            <CheckBox Grid.Column="0" Grid.Row="2" x:Name="NoDisappearingBlocksCheckBox" Content="Don't randomize (into) disappearing blocks" HorizontalAlignment="Left" />
+            <CheckBox Grid.Column="1" Grid.Row="0" x:Name="NoDungeonWallsCheckBox" Content="Don't randomize (into) dungeon walls" HorizontalAlignment="Left" />
         </Grid>
         <Grid>
             <Grid.ColumnDefinitions>

--- a/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml
+++ b/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml
@@ -2,17 +2,32 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:view="clr-namespace:TEdit.View" SizeToContent="WidthAndHeight"
-        Title="Randomize World" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico" Height="200" Width="300">
+        Title="Randomize World" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico" Height="200" Width="500">
     <StackPanel Background="{StaticResource ControlBackgroundBrush}" >
         <Label Content="Seed: (Leave blank for random)"></Label>
         <TextBox x:Name="SeedTextBox"></TextBox>
         <CheckBox x:Name="OnlySelectionCheckBox" Content="Only randomize selection" HorizontalAlignment="Center" />
         <CheckBox x:Name="UndoCheckBox" Content="Enable undo (very slow)" HorizontalAlignment="Center" />
         <CheckBox x:Name="RandomizeWallsCheckBox" Content="Randomize background walls" HorizontalAlignment="Center" />
+        <Grid Height="59">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="250" />
+                <ColumnDefinition Width="250"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <CheckBox Grid.Column="0" Grid.Row="0" x:Name="NoNonSolidBlocks" Content="Don't randomize (into) non-solid blocks" HorizontalAlignment="Left" />
+            <CheckBox Grid.Column="0" Grid.Row="1" x:Name="NoGravityBlocks" Content="Don't randomize (into) gravity-blocks" HorizontalAlignment="Left" />
+            <CheckBox Grid.Column="0" Grid.Row="2" x:Name="NoDisappearingBlocks" Content="Don't randomize (into) disappearing blocks" HorizontalAlignment="Left" />
+            <CheckBox Grid.Column="1" Grid.Row="0" x:Name="NoDungeonWalls" Content="Don't randomize (into) dungeon walls" HorizontalAlignment="Left" />
+        </Grid>
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="150" />
-                <ColumnDefinition Width="150"/>
+                <ColumnDefinition Width="250" />
+                <ColumnDefinition Width="250"/>
             </Grid.ColumnDefinitions>
             <Button Margin="5,5,0,5" Content="Cancel" HorizontalAlignment="Left" Padding="20, 3" VerticalAlignment="Center" Click="CancelButtonClick" Grid.ColumnSpan="2" />
             <Button Margin="0,5,5,5" Content="Randomize" HorizontalAlignment="Right" Padding="20, 3" VerticalAlignment="Center" Click="OkButtonClick" Grid.Column="1" />

--- a/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml
+++ b/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml
@@ -1,33 +1,21 @@
 ﻿<Window x:Class="TEdit.Editor.Plugins.RandomizerPluginView"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:view="clr-namespace:TEdit.View" SizeToContent="WidthAndHeight"
-        Title="Randomize World" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico" Height="200" Width="500">
-    <StackPanel Background="{StaticResource ControlBackgroundBrush}" >
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:view="clr-namespace:TEdit.View" SizeToContent="WidthAndHeight"
+    Title="Randomize World" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico" Height="200" Width="500">
+    <StackPanel Background="{StaticResource ControlBackgroundBrush}">
         <Label Content="Seed: (Leave blank for random)"></Label>
         <TextBox x:Name="SeedTextBox"></TextBox>
         <CheckBox x:Name="OnlySelectionCheckBox" Content="Only randomize selection" HorizontalAlignment="Center" />
         <CheckBox x:Name="UndoCheckBox" Content="Enable undo (very slow)" HorizontalAlignment="Center" />
         <CheckBox x:Name="RandomizeWallsCheckBox" Content="Randomize background walls" HorizontalAlignment="Center" />
-        <Grid Height="59">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="250" />
-                <ColumnDefinition Width="250"/>
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <CheckBox Grid.Column="0" Grid.Row="0" x:Name="NoNonSolidBlocksCheckBox" Content="Don't randomize (into) non-solid blocks" HorizontalAlignment="Left" />
-            <CheckBox Grid.Column="0" Grid.Row="1" x:Name="NoGravityBlocksCheckBox" Content="Don't randomize (into) gravity-blocks" HorizontalAlignment="Left" />
-            <CheckBox Grid.Column="0" Grid.Row="2" x:Name="NoDisappearingBlocksCheckBox" Content="Don't randomize (into) disappearing blocks" HorizontalAlignment="Left" />
-            <CheckBox Grid.Column="1" Grid.Row="0" x:Name="NoDungeonWallsCheckBox" Content="Don't randomize (into) dungeon walls" HorizontalAlignment="Left" />
-        </Grid>
+        <CheckBox x:Name="NoDisappearingBlocksCheckBox" Content="Don't randomize into instantly disappearing blocks" HorizontalAlignment="Center" />
+        <CheckBox x:Name="SupportDependentBlocksCheckBox" Content="Satisfy conditions for disappearing blocks (vines, etc.)" HorizontalAlignment="Center" />
+        <CheckBox x:Name="SupportGravityBlocksCheckBox" Content="Support gravity blocks (sand, etc.)" HorizontalAlignment="Center" />
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="250" />
-                <ColumnDefinition Width="250"/>
+                <ColumnDefinition Width="250" />
             </Grid.ColumnDefinitions>
             <Button Margin="5,5,0,5" Content="Cancel" HorizontalAlignment="Left" Padding="20, 3" VerticalAlignment="Center" Click="CancelButtonClick" Grid.ColumnSpan="2" />
             <Button Margin="0,5,5,5" Content="Randomize" HorizontalAlignment="Right" Padding="20, 3" VerticalAlignment="Center" Click="OkButtonClick" Grid.Column="1" />

--- a/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml.cs
@@ -13,10 +13,9 @@ namespace TEdit.Editor.Plugins
         public bool OnlySelection { get; private set; }
         public bool EnableUndo { get; private set; }
         public bool EnableWallRandomize { get; private set; }
-        public bool NoNonSolidBlocks { get; private set; }
-        public bool NoGravityBlocks { get; private set; }
         public bool NoDisappearingBlocks { get; private set; }
-        public bool NoDungeonWalls { get; private set; }
+        public bool SupportDependentBlocks { get; private set; }
+        public bool SupportGravityBlocks { get; private set; }
 
         public RandomizerPluginView(bool activeSelection)
         {
@@ -42,10 +41,9 @@ namespace TEdit.Editor.Plugins
                 OnlySelection = OnlySelectionCheckBox.IsChecked ?? false;
                 EnableUndo = UndoCheckBox.IsChecked ?? false;
                 EnableWallRandomize = RandomizeWallsCheckBox.IsChecked ?? false;
-                NoNonSolidBlocks = NoNonSolidBlocksCheckBox.IsChecked ?? false;
-                NoGravityBlocks = NoGravityBlocksCheckBox.IsChecked ?? false;
                 NoDisappearingBlocks = NoDisappearingBlocksCheckBox.IsChecked ?? false;
-                NoDungeonWalls = NoDungeonWallsCheckBox.IsChecked ?? false;
+                SupportDependentBlocks = SupportDependentBlocksCheckBox.IsChecked ?? false;
+                SupportGravityBlocks = SupportGravityBlocksCheckBox.IsChecked ?? false;
 
                 this.DialogResult = true;
                 this.Close();

--- a/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/RandomizerPluginView.xaml.cs
@@ -13,6 +13,10 @@ namespace TEdit.Editor.Plugins
         public bool OnlySelection { get; private set; }
         public bool EnableUndo { get; private set; }
         public bool EnableWallRandomize { get; private set; }
+        public bool NoNonSolidBlocks { get; private set; }
+        public bool NoGravityBlocks { get; private set; }
+        public bool NoDisappearingBlocks { get; private set; }
+        public bool NoDungeonWalls { get; private set; }
 
         public RandomizerPluginView(bool activeSelection)
         {
@@ -38,6 +42,10 @@ namespace TEdit.Editor.Plugins
                 OnlySelection = OnlySelectionCheckBox.IsChecked ?? false;
                 EnableUndo = UndoCheckBox.IsChecked ?? false;
                 EnableWallRandomize = RandomizeWallsCheckBox.IsChecked ?? false;
+                NoNonSolidBlocks = NoNonSolidBlocksCheckBox.IsChecked ?? false;
+                NoGravityBlocks = NoGravityBlocksCheckBox.IsChecked ?? false;
+                NoDisappearingBlocks = NoDisappearingBlocksCheckBox.IsChecked ?? false;
+                NoDungeonWalls = NoDungeonWallsCheckBox.IsChecked ?? false;
 
                 this.DialogResult = true;
                 this.Close();

--- a/src/TEdit/settings.xml
+++ b/src/TEdit/settings.xml
@@ -6640,7 +6640,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
             </Frames>
         </Tile>
         <Tile Id="381" Color="#FFFE7902" Name="Lava Moss" Solid="true" Blends="true" Special="Grass" Stone="True" />
-        <Tile Id="382" Color="#FF1CD85E" Name="Flower Vines" Solid="true" Blends="true" />
+        <Tile Id="382" Color="#FF1CD85E" Name="Flower Vines" Solid="false" Blends="true" />
         <Tile Id="383" Color="#FFDD8890" Name="Living Mahogany Block" Solid="true" Blends="true" />
         <Tile Id="384" Color="#FF83CE0C" Name="Living Mahogany Leaves Block" Solid="true" Blends="true" />
         <Tile Id="385" Color="#FF571590" Name="Crystal Block" Solid="true" Blends="true" />


### PR DESCRIPTION
In this pull request I have fixed a few bugs with the world randomizer, as well as adding a few new options:

New features:
- Added option to not randomize into disappearing tiles. (Ice rod ice, mystical flute snake rope)
- Added option to satisfy conditions for tiles that have them. (Vines have to hang from grass etc.)
- Added option to support gravity blocks. (Sand, slush, money piles)

Fixes:
- Fixed the randomizer rolling tiles into id `-1`, causing them to disappear
- Fixed the randomizer ignoring the "Randomize walls" checkbox and doing it always anyway