### PR TITLE
Fix for gap between layer backgrounds Zenith wlds.

### DIFF
--- a/src/TEdit/Terraria/World.Properties.cs
+++ b/src/TEdit/Terraria/World.Properties.cs
@@ -1037,7 +1037,7 @@ namespace TEdit.Terraria
             {
                 if (!UnsafeGroundLayers)
                 {
-                    return Math.Min(_tilesHigh, 1239);
+                    return (Seed == "get fixed boi" || Seed == "getfixedboi" || Seed == "don't dig up" || Seed == "dont dig up" || Seed == "dontdigup") ? Math.Min(_tilesHigh, 1571) : Math.Min(_tilesHigh, 1239);
                 }
                 else
                 {
@@ -1053,7 +1053,7 @@ namespace TEdit.Terraria
             {
                 if (!UnsafeGroundLayers)
                 {
-                    return Math.Min(_tilesHigh, 1239);
+                    return (Seed == "get fixed boi" || Seed == "getfixedboi" || Seed == "don't dig up" || Seed == "dont dig up" || Seed == "dontdigup") ? Math.Min(_tilesHigh, 1571) : Math.Min(_tilesHigh, 1239);
                 }
                 else
                 {


### PR DESCRIPTION
This issue will close issue #1534 - Gap Between Layer Backgrounds on TEdit Generated Worlds.

This issue is caused by the `MaxCavernLevel` reaching a hardcoded maximum for the cavern slider control. On the remix and zenith world seeds the maximum was found to be higher.
![02](https://user-images.githubusercontent.com/33048298/204155993-b52e1a49-835c-44a2-88b1-766d49d97c78.PNG)

Bellow I have hard coded a mod to show the readings from Terraria on the layer depths. 
![large](https://user-images.githubusercontent.com/33048298/204155985-26a9bfb8-49fe-4f54-90bf-90faa11d1332.PNG)