### PR TITLE
Fixes for 1.0 (v0) worlds.

### DIFF
--- a/src/TEdit/Terraria/World.FileV1.cs
+++ b/src/TEdit/Terraria/World.FileV1.cs
@@ -1519,7 +1519,7 @@ namespace TEdit.Terraria
         public static void SaveV0(World world, BinaryWriter bw, bool ForceLighting)
         {
             // Get the max values from json.
-            var saveData = World.SaveConfiguration.GetData(1);
+            var saveData = World.SaveConfiguration.GetData(38);
 
             var version = world.Version;
             bw.Write(38); // Should be 38?

--- a/src/TEdit/TerrariaVersionTileData.json
+++ b/src/TEdit/TerrariaVersionTileData.json
@@ -81,8 +81,8 @@
     "1.4.4.9": 279
   },
   "saveVersions": {
-    "1": {
-      "saveVersion": 1,
+    "38": {
+      "saveVersion": 38,
       "gameVersion": "v1.0",
       "maxTileId": 75,
       "maxWallId": 12,

--- a/src/TEdit/View/Popups/SaveAsVersion.xaml
+++ b/src/TEdit/View/Popups/SaveAsVersion.xaml
@@ -7,17 +7,21 @@
         WindowStartupLocation="CenterOwner"
         mc:Ignorable="d"
         Background="{StaticResource ControlBackgroundBrush}" Foreground="{DynamicResource TextBrush}"
-        Title="Select World Version" Height="420" Width="420">
+        Title="Select World Version" Height="464" Width="420">
     <Grid>
-        <ScrollViewer>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="109*"/>
+            <ColumnDefinition Width="97*"/>
+        </Grid.ColumnDefinitions>
+        <ScrollViewer Grid.ColumnSpan="2">
             <StackPanel>
                 <UniformGrid Rows="1" HorizontalAlignment="Stretch" Margin="5">
-					<Button Content="1.4.4.9" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
-				</UniformGrid>
+                    <Button Content="1.4.4.9" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
+                </UniformGrid>
                 <UniformGrid Rows="1" HorizontalAlignment="Stretch" Margin="5">
-					<Button Content="1.4.4.8.1" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
-					<Button Content="1.4.4.8" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
-					<Button Content="1.4.4.7" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
+                    <Button Content="1.4.4.8.1" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
+                    <Button Content="1.4.4.8" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
+                    <Button Content="1.4.4.7" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
                     <Button Content="1.4.4.6" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
                     <Button Content="1.4.4.5" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />
                     <Button Content="1.4.4.4" Height="20" VerticalAlignment="Top" Width="50" Command="{Binding SaveAsVersionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Content}" />


### PR DESCRIPTION
**About This PR:**

- This PR fixed issues regarding not being able to edit V0 worlds once downgraded or saved. 
- Furthermore, it also fixes crashes related to downgrading or editing V0 worlds.