### PR TITLE
Block Shuffle Plugin

### DIFF
--- a/src/TEdit/Editor/Plugins/BlockShufflePlugin.cs
+++ b/src/TEdit/Editor/Plugins/BlockShufflePlugin.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using TEdit.Terraria;
+using TEdit.ViewModel;
+
+namespace TEdit.Editor.Plugins
+{
+    public sealed class BlockShufflePlugin : BasePlugin //Originally: HackedPlugin, BlockShuffle
+    {
+        public BlockShufflePlugin(WorldViewModel worldViewModel) : base(worldViewModel) { Name = "Shuffle Block Locations"; }
+
+        public override void Execute()
+        {
+            //Check if a world is loaded
+            if (_wvm.CurrentWorld == null)
+                return;
+
+            //Show settings window / get settings
+            BlockShufflePluginView settingsView = new(_wvm.Selection.IsActive);
+            if (settingsView.ShowDialog() == false)
+                return;
+            if (settingsView.ReplaceEmptyPercentage == 0 && settingsView.ConsiderEverything)
+                return;
+
+            //Get affected area
+            Rectangle selectionArea = settingsView.OnlySelection ? _wvm.Selection.SelectionArea : new(0, 0, _wvm.CurrentWorld.Size.X, _wvm.CurrentWorld.Size.Y);
+
+            //Randomizer with Seed
+            Random rng = new(settingsView.Seed);
+
+            //Select all affected tiles
+            List<Tile> selectedTiles = new();
+            for (int x = selectionArea.Left; x < selectionArea.Right; x++) //From left to right
+                for (int y = selectionArea.Top; y < selectionArea.Bottom; y++) //From top to bottom
+                    if (!IsSensitiveGroup(_wvm.CurrentWorld.Tiles[x, y].Type))
+                    {
+                        //Extra Check for "Sensitive" Tiles
+                        if (settingsView.SensitivePlatform)
+                            if ((y - 1) > 0 && IsSensitiveGroup(_wvm.CurrentWorld.Tiles[x, y - 1].Type))
+                                continue;
+                        if ((EmptyCheck(_wvm.CurrentWorld.Tiles[x, y], settingsView.ConsiderWallEmpty, settingsView.ConsiderLiquidEmpty)
+                            && settingsView.ReplaceEmptyPercentage != 100) || settingsView.ConsiderEverything)
+                            if (settingsView.ReplaceEmptyPercentage == 0) continue;
+                            else
+                            {
+                                if (rng.Next(0, 100) < settingsView.ReplaceEmptyPercentage)
+                                    selectedTiles.Add(_wvm.CurrentWorld.Tiles[x, y]);
+                                else continue;
+                            }
+                        else selectedTiles.Add(_wvm.CurrentWorld.Tiles[x, y]);
+                    }
+            if (selectedTiles == null || selectedTiles.Count <= 1)
+                return;
+
+            //Randomize Tiles (Simple algorithm)
+            int shufflesize = selectedTiles.Count;
+            while (shufflesize > 1)
+            {
+                int k = rng.Next(shufflesize--);
+                Tile temp = selectedTiles[shufflesize];
+                selectedTiles[shufflesize] = selectedTiles[k];
+                selectedTiles[k] = temp;
+            }
+
+            //Randomize Selection/World
+            int lstIndex = 0;
+            for (int x = selectionArea.Left; x < selectionArea.Right; x++)
+                for (int y = selectionArea.Top; y < selectionArea.Bottom; y++)
+                    if (!IsSensitiveGroup(_wvm.CurrentWorld.Tiles[x, y].Type))
+                    {
+                        //Extra Check for "Sensitive" Tiles
+                        if (settingsView.SensitivePlatform)
+                            if ((y - 1) > 0 && IsSensitiveGroup(_wvm.CurrentWorld.Tiles[x, y - 1].Type))
+                                continue;
+
+                        //Air Replace Options
+                        if ((EmptyCheck(_wvm.CurrentWorld.Tiles[x, y], settingsView.ConsiderWallEmpty, settingsView.ConsiderLiquidEmpty)
+                            && settingsView.ReplaceEmptyPercentage != 100) || settingsView.ConsiderEverything)
+                            if (settingsView.ReplaceEmptyPercentage == 0) continue;
+                            else if (rng.Next(0, 100) >= settingsView.ReplaceEmptyPercentage)
+                                continue;
+
+                        //Safe Block before updating it!
+                        if (settingsView.EnableUndo)
+                            _wvm.UndoManager.SaveTile(x, y);
+                        //HACK: Edits the World-View (_wvm) directly!
+                        _wvm.CurrentWorld.Tiles[x, y] = selectedTiles[lstIndex];
+
+                        //Safety: The worldborder does NOT like visual waterfalls -> Remove all Slopes.
+                        if (x <= 20 || x >= _wvm.CurrentWorld.TilesWide - 20 || y <= 20 || y >= _wvm.CurrentWorld.TilesHigh - 20)
+                            _wvm.CurrentWorld.Tiles[x, y].BrickStyle = BrickStyle.Full;
+
+                        //Use "Random" Index:
+                        lstIndex++;
+                        if (lstIndex >= selectedTiles.Count)
+                            lstIndex = 0; //Loop back
+                    }
+
+            if (settingsView.EnableUndo)
+                _wvm.UndoManager.SaveUndo();
+            _wvm.UpdateRenderRegion(selectionArea); // Re-render map
+            _wvm.MinimapImage = Render.RenderMiniMap.Render(_wvm.CurrentWorld); // Update Minimap
+        }
+
+        private static bool EmptyCheck(Tile pTile, bool pConsiderWallEmpty, bool pConsiderLiquidEmpty)
+        {
+            if (pConsiderWallEmpty && pConsiderLiquidEmpty) return !pTile.IsActive;
+            else if (pConsiderWallEmpty) return !pTile.IsActive && !pTile.HasLiquid;
+            else if (pConsiderLiquidEmpty) return !pTile.IsActive && pTile.Wall == 0 && !pTile.HasWire;
+            else return pTile.IsEmpty;
+        }
+
+        private static bool IsSensitive(int pTileType)
+        {
+            return pTileType == 12 //Heart Crystal
+                || pTileType == 26 //Demon Altar
+                || pTileType == 31 //Orb/Heart
+                || pTileType == 231 //Larva
+                || pTileType == 237 //Lihzahrd Altar
+                || pTileType == 238 //Plantera Bulb
+                || pTileType == 488 //Fallen Log (Fairys)
+                ;
+            //|| tileType == 28 //Pot
+            //|| tileType == 444 //Bee Hive
+        }
+
+        private static bool IsSensitiveGroup(int pTileType)
+        {
+            if (Tile.IsChest(pTileType)
+               || Tile.IsSign(pTileType)
+               || Tile.IsTileEntity(pTileType)
+               || IsSensitive(pTileType)
+                ) return true;
+            else return false;
+        }
+    }
+}

--- a/src/TEdit/Editor/Plugins/BlockShufflePluginView.xaml
+++ b/src/TEdit/Editor/Plugins/BlockShufflePluginView.xaml
@@ -1,36 +1,41 @@
 ﻿<Window x:Class="TEdit.Editor.Plugins.BlockShufflePluginView"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:view="clr-namespace:TEdit.View"
-        ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico" Title="Shuffle Block Locations" SizeToContent="WidthAndHeight">
-    <Grid Background="{StaticResource ControlBackgroundBrush}" Width="300" Height="215">
-        <Label VerticalAlignment="Top" Height="16" Margin="5,5,5,5">
-            <TextBlock>Seed: <TextBlock Foreground="#66FFFFFF">(Leave blank for random)</TextBlock></TextBlock>
-        </Label>
-        <TextBox x:Name="SeedTextBox" VerticalAlignment="Top" Margin="5,22,5,0" Height="20"></TextBox>
-        <CheckBox x:Name="SensitivePlatformCheckBox" Content="Keep blocks below Tile-Entities" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,45,0,0" IsChecked="True"/>
-        <Label VerticalAlignment="Top" Height="16" Margin="5,62,0,0" Content="Randomize:" HorizontalAlignment="Left"/>
-        <RadioButton x:Name="SelectionRadio" Content="Selection" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="75,62,0,0"/>
-        <RadioButton x:Name="WorldRadio" Content="World" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="150,62,0,0" IsChecked="False"/>
-        <CheckBox x:Name="UndoCheckBox" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,79,0,0" IsChecked="True">
-            <TextBlock>Enable undo <TextBlock Foreground="#66FFFFFF">(Slow)</TextBlock></TextBlock>
-        </CheckBox>
-        <Border BorderBrush="#7F000000" BorderThickness="1,1,1,1" Margin="3,100,3,0" VerticalAlignment="Top" Height="85"/>
-        <Label VerticalAlignment="Top" Height="16" Margin="5,100,5,0">
-            <TextBlock>% of empty blocks to be swapped: <TextBlock Foreground="#66FFFFFF">(Slow under 100%)</TextBlock></TextBlock>
-        </Label>
-        <Slider x:Name="ReplaceEmptySlider" Margin="5,115,45,0" VerticalAlignment="Top" Maximum="100" SmallChange="5" LargeChange="10" TickFrequency="5" TickPlacement="BottomRight" IsSnapToTickEnabled="True" Value="100"/>
-        <Label x:Name="ReplaceEmptyLabel" Content="{Binding Value, ElementName=ReplaceEmptySlider}" HorizontalAlignment="Right" Margin="0,120,20,0" VerticalAlignment="Top" Width="20" HorizontalContentAlignment="Right"/>
-        <Label Content="%" HorizontalAlignment="Right" Margin="0,120,10,0" VerticalAlignment="Top" Width="10"/>
-        <CheckBox x:Name="ReplaceWallCheckBox" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,135,0,0" IsChecked="True">
-            <TextBlock>Also include walls <TextBlock Foreground="#66FFFFFF">(and wires)</TextBlock></TextBlock>
-        </CheckBox>
-        <CheckBox x:Name="ReplaceLiquidCheckBox" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,151,0,0">
-            <TextBlock>Also include liquids <TextBlock Foreground="#66FFFFFF">(best paired with walls)</TextBlock></TextBlock>
-        </CheckBox>
-        <CheckBox x:Name="ReplaceEverythingCheckBox" Content="Include everything" Foreground="#66FFFFFF" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,167,0,0" Checked="ReplaceEverythingCheckBox_Checked" Unchecked="ReplaceEverythingCheckBox_Unchecked"/>
-        <!--Border End-->
-        <Button Margin="5" Content="Cancel" HorizontalAlignment="Left" Padding="20,3" VerticalAlignment="Bottom" Click="CancelButtonClick"/>
-        <Button Margin="5" Content="Shuffle" HorizontalAlignment="Right" Padding="20,3" VerticalAlignment="Bottom" Click="OkButtonClick"/>
+        xmlns:view="clr-namespace:TEdit.View" SizeToContent="WidthAndHeight" ResizeMode="NoResize" 
+        WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico"
+        Title="Shuffle Block Locations">
+    <Grid Background="{StaticResource ControlBackgroundBrush}">
+        <StackPanel Margin="5">
+            <Label Content="Seed: (Leave blank for random)"/>
+            <TextBox x:Name="SeedTextBox"/>
+            <StackPanel Orientation="Horizontal">
+                <Label Content="Shuffle:" Margin="0,0,5,0"/>
+                <RadioButton x:Name="SelectionRadio" Content="Selection" Margin="5,0"/>
+                <RadioButton x:Name="WorldRadio" Content="World" Margin="5,0"/>
+            </StackPanel>
+            <CheckBox x:Name="IncludeTileEntitiesCheckBox" Content="Include Tile-Entities" Checked="IncludeTileEntitiesCheckBox_Checked"/>
+            <CheckBox x:Name="SensitivePlatformCheckBox" Content="Keep blocks below special Tile-Entities" IsChecked="True"/>
+            <CheckBox x:Name="UndoCheckBox" Content="Enable undo (Slow)" IsChecked="True"/>
+            <Border BorderBrush="Black" BorderThickness="1" CornerRadius="3" Margin="0,5">
+                <StackPanel Margin="2,0,2,2">
+                    <Label Content="% of empty blocks to be swapped:"/>
+                    <Grid Margin="0,0,0,5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="30"/>
+                        </Grid.ColumnDefinitions>
+                        <Slider x:Name="ReplaceEmptySlider" Minimum="5" Maximum="100" Value="100" SmallChange="5" LargeChange="10" TickFrequency="5" TickPlacement="BottomRight" IsSnapToTickEnabled="True"/>
+                        <Label Content="{Binding Value, ElementName=ReplaceEmptySlider}" ContentStringFormat="{}{0}%" Grid.Column="1" VerticalContentAlignment="Center" HorizontalContentAlignment="Right"/>
+                    </Grid>
+                    <CheckBox x:Name="ReplaceWallCheckBox" Content ="Also count walls (and wires) as empty" IsChecked="True"/>
+                    <CheckBox x:Name="ReplaceLiquidCheckBox" Content="Also count liquids as empty (best with walls)"/>
+                    <CheckBox x:Name="ReplaceEverythingCheckBox" Content="Apply %-chance to everything" Checked="ReplaceEverythingCheckBox_Checked" Unchecked="ReplaceEverythingCheckBox_Unchecked"/>
+                </StackPanel>
+            </Border>
+            <Grid>
+                <Button Content="Cancel" HorizontalAlignment="Left" Padding="20,3" Click="CancelButtonClick"/>
+                <Button Content="Shuffle" HorizontalAlignment="Right" Padding="20,3" Click="OkButtonClick"/>
+            </Grid>
+        </StackPanel>
     </Grid>
 </Window>

--- a/src/TEdit/Editor/Plugins/BlockShufflePluginView.xaml
+++ b/src/TEdit/Editor/Plugins/BlockShufflePluginView.xaml
@@ -1,0 +1,36 @@
+﻿<Window x:Class="TEdit.Editor.Plugins.BlockShufflePluginView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="clr-namespace:TEdit.View"
+        ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Icon="/TEdit;component/Images/tedit.ico" Title="Shuffle Block Locations" SizeToContent="WidthAndHeight">
+    <Grid Background="{StaticResource ControlBackgroundBrush}" Width="300" Height="215">
+        <Label VerticalAlignment="Top" Height="16" Margin="5,5,5,5">
+            <TextBlock>Seed: <TextBlock Foreground="#66FFFFFF">(Leave blank for random)</TextBlock></TextBlock>
+        </Label>
+        <TextBox x:Name="SeedTextBox" VerticalAlignment="Top" Margin="5,22,5,0" Height="20"></TextBox>
+        <CheckBox x:Name="SensitivePlatformCheckBox" Content="Keep blocks below Tile-Entities" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,45,0,0" IsChecked="True"/>
+        <Label VerticalAlignment="Top" Height="16" Margin="5,62,0,0" Content="Randomize:" HorizontalAlignment="Left"/>
+        <RadioButton x:Name="SelectionRadio" Content="Selection" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="75,62,0,0"/>
+        <RadioButton x:Name="WorldRadio" Content="World" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="150,62,0,0" IsChecked="False"/>
+        <CheckBox x:Name="UndoCheckBox" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,79,0,0" IsChecked="True">
+            <TextBlock>Enable undo <TextBlock Foreground="#66FFFFFF">(Slow)</TextBlock></TextBlock>
+        </CheckBox>
+        <Border BorderBrush="#7F000000" BorderThickness="1,1,1,1" Margin="3,100,3,0" VerticalAlignment="Top" Height="85"/>
+        <Label VerticalAlignment="Top" Height="16" Margin="5,100,5,0">
+            <TextBlock>% of empty blocks to be swapped: <TextBlock Foreground="#66FFFFFF">(Slow under 100%)</TextBlock></TextBlock>
+        </Label>
+        <Slider x:Name="ReplaceEmptySlider" Margin="5,115,45,0" VerticalAlignment="Top" Maximum="100" SmallChange="5" LargeChange="10" TickFrequency="5" TickPlacement="BottomRight" IsSnapToTickEnabled="True" Value="100"/>
+        <Label x:Name="ReplaceEmptyLabel" Content="{Binding Value, ElementName=ReplaceEmptySlider}" HorizontalAlignment="Right" Margin="0,120,20,0" VerticalAlignment="Top" Width="20" HorizontalContentAlignment="Right"/>
+        <Label Content="%" HorizontalAlignment="Right" Margin="0,120,10,0" VerticalAlignment="Top" Width="10"/>
+        <CheckBox x:Name="ReplaceWallCheckBox" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,135,0,0" IsChecked="True">
+            <TextBlock>Also include walls <TextBlock Foreground="#66FFFFFF">(and wires)</TextBlock></TextBlock>
+        </CheckBox>
+        <CheckBox x:Name="ReplaceLiquidCheckBox" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,151,0,0">
+            <TextBlock>Also include liquids <TextBlock Foreground="#66FFFFFF">(best paired with walls)</TextBlock></TextBlock>
+        </CheckBox>
+        <CheckBox x:Name="ReplaceEverythingCheckBox" Content="Include everything" Foreground="#66FFFFFF" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,167,0,0" Checked="ReplaceEverythingCheckBox_Checked" Unchecked="ReplaceEverythingCheckBox_Unchecked"/>
+        <!--Border End-->
+        <Button Margin="5" Content="Cancel" HorizontalAlignment="Left" Padding="20,3" VerticalAlignment="Bottom" Click="CancelButtonClick"/>
+        <Button Margin="5" Content="Shuffle" HorizontalAlignment="Right" Padding="20,3" VerticalAlignment="Bottom" Click="OkButtonClick"/>
+    </Grid>
+</Window>

--- a/src/TEdit/Editor/Plugins/BlockShufflePluginView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/BlockShufflePluginView.xaml.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Windows;
+
+namespace TEdit.Editor.Plugins
+{
+    public partial class BlockShufflePluginView : Window
+    {
+        public int Seed { get; private set; }
+        public bool SensitivePlatform { get; private set; }
+        public bool OnlySelection { get; private set; }
+        public bool EnableUndo { get; private set; }
+        public int ReplaceEmptyPercentage { get; private set; }
+        public bool ConsiderWallEmpty { get; private set; }
+        public bool ConsiderLiquidEmpty { get; private set; }
+        public bool ConsiderEverything { get; private set; }
+
+        public BlockShufflePluginView(bool activeSelection)
+        {
+            InitializeComponent();
+            if (activeSelection)
+                SelectionRadio.IsChecked = true;
+            else
+            {
+                SelectionRadio.IsEnabled = false;
+                WorldRadio.IsChecked = true; //Doesn't update when set in .xaml
+            }
+        }
+
+        private void OkButtonClick(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (SeedTextBox.Text == "") Seed = (int)DateTime.Now.Ticks;
+                else Seed = SeedTextBox.Text.GetHashCode();
+                SensitivePlatform = SensitivePlatformCheckBox.IsChecked ?? false;
+                OnlySelection = SelectionRadio.IsChecked ?? false;
+                EnableUndo = UndoCheckBox.IsChecked ?? false;
+                ReplaceEmptyPercentage = (int)ReplaceEmptySlider.Value;
+                if (ReplaceEmptyPercentage > 100) ReplaceEmptyPercentage = 100;
+                if (ReplaceEmptyPercentage < 0) ReplaceEmptyPercentage = 0;
+                ConsiderWallEmpty = ReplaceWallCheckBox.IsChecked ?? false;
+                ConsiderLiquidEmpty = ReplaceLiquidCheckBox.IsChecked ?? false;
+                ConsiderEverything = ReplaceEverythingCheckBox.IsChecked ?? false;
+                this.DialogResult = true;
+                this.Close();
+            }
+            catch (System.Exception)
+            {
+                this.DialogResult = false;
+                this.Close();
+            }
+        }
+
+        private void CancelButtonClick(object sender, RoutedEventArgs e)
+        {
+            this.DialogResult = false;
+            this.Close();
+        }
+
+        private void ReplaceEverythingCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            ReplaceWallCheckBox.IsEnabled = false;
+            ReplaceLiquidCheckBox.IsEnabled = false;
+        }
+        private void ReplaceEverythingCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            ReplaceWallCheckBox.IsEnabled = true;
+            ReplaceLiquidCheckBox.IsEnabled = true;
+        }
+    }
+}

--- a/src/TEdit/Editor/Plugins/BlockShufflePluginView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/BlockShufflePluginView.xaml.cs
@@ -6,8 +6,9 @@ namespace TEdit.Editor.Plugins
     public partial class BlockShufflePluginView : Window
     {
         public int Seed { get; private set; }
-        public bool SensitivePlatform { get; private set; }
         public bool OnlySelection { get; private set; }
+        public bool IncludeTileEntities { get; private set; }
+        public bool SensitivePlatform { get; private set; }
         public bool EnableUndo { get; private set; }
         public int ReplaceEmptyPercentage { get; private set; }
         public bool ConsiderWallEmpty { get; private set; }
@@ -32,12 +33,13 @@ namespace TEdit.Editor.Plugins
             {
                 if (SeedTextBox.Text == "") Seed = (int)DateTime.Now.Ticks;
                 else Seed = SeedTextBox.Text.GetHashCode();
-                SensitivePlatform = SensitivePlatformCheckBox.IsChecked ?? false;
                 OnlySelection = SelectionRadio.IsChecked ?? false;
+                IncludeTileEntities = IncludeTileEntitiesCheckBox.IsChecked ?? false;
+                SensitivePlatform = SensitivePlatformCheckBox.IsChecked ?? false;
                 EnableUndo = UndoCheckBox.IsChecked ?? false;
                 ReplaceEmptyPercentage = (int)ReplaceEmptySlider.Value;
                 if (ReplaceEmptyPercentage > 100) ReplaceEmptyPercentage = 100;
-                if (ReplaceEmptyPercentage < 0) ReplaceEmptyPercentage = 0;
+                if (ReplaceEmptyPercentage < 5) ReplaceEmptyPercentage = 5;
                 ConsiderWallEmpty = ReplaceWallCheckBox.IsChecked ?? false;
                 ConsiderLiquidEmpty = ReplaceLiquidCheckBox.IsChecked ?? false;
                 ConsiderEverything = ReplaceEverythingCheckBox.IsChecked ?? false;
@@ -66,6 +68,12 @@ namespace TEdit.Editor.Plugins
         {
             ReplaceWallCheckBox.IsEnabled = true;
             ReplaceLiquidCheckBox.IsEnabled = true;
+        }
+
+        private void IncludeTileEntitiesCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            MessageBox.Show("Some special Tile-Entities (like chests or signs) are still protected and can't be shuffled.",
+                            "Include Information", MessageBoxButton.OK, MessageBoxImage.Information);
         }
     }
 }

--- a/src/TEdit/ViewModel/ViewModelLocator.cs
+++ b/src/TEdit/ViewModel/ViewModelLocator.cs
@@ -59,10 +59,9 @@ namespace TEdit.ViewModel
             wvm.Plugins.Add(new RemoveTileWithPlugin(wvm));
             wvm.Plugins.Add(new ReplaceAllPlugin(wvm));
             wvm.Plugins.Add(new SandSettlePlugin(wvm));
-            wvm.Plugins.Add(new BlockShufflePlugin(wvm)); //My AddOn
+            wvm.Plugins.Add(new BlockShufflePlugin(wvm));
             wvm.Plugins.Add(new SimplePerlinGeneratorPlugin(wvm));
             wvm.Plugins.Add(new UnlockAllChestsPlugin(wvm));
-
             return wvm;
         }
     }

--- a/src/TEdit/ViewModel/ViewModelLocator.cs
+++ b/src/TEdit/ViewModel/ViewModelLocator.cs
@@ -46,20 +46,23 @@ namespace TEdit.ViewModel
             wvm.Tools.Add(new MorphTool(wvm));
             wvm.ActiveTool = defaultTool;
 
-            wvm.Plugins.Add(new SandSettlePlugin(wvm));
-            wvm.Plugins.Add(new SimplePerlinGeneratorPlugin(wvm));
-            wvm.Plugins.Add(new ReplaceAllPlugin(wvm));
-            wvm.Plugins.Add(new RemoveAllChestsPlugin(wvm));
-            wvm.Plugins.Add(new RemoveAllUnlockedChestsPlugin(wvm));
-            wvm.Plugins.Add(new UnlockAllChestsPlugin(wvm));
+            //Sorted by Plugin-Name
             wvm.Plugins.Add(new FindChestWithPlugin(wvm));
             wvm.Plugins.Add(new FindPlanteraBulbPlugin(wvm));
-            wvm.Plugins.Add(new HouseGenPlugin(wvm));
             wvm.Plugins.Add(new FindTileWithPlugin(wvm));
-            wvm.Plugins.Add(new RemoveTileWithPlugin(wvm));
-            wvm.Plugins.Add(new RandomizerPlugin(wvm));
-            wvm.Plugins.Add(new TextStatuePlugin(wvm));
             wvm.Plugins.Add(new SpriteDebuggerPlugin(wvm));
+            wvm.Plugins.Add(new TextStatuePlugin(wvm));
+            wvm.Plugins.Add(new HouseGenPlugin(wvm));
+            wvm.Plugins.Add(new RandomizerPlugin(wvm));
+            wvm.Plugins.Add(new RemoveAllChestsPlugin(wvm));
+            wvm.Plugins.Add(new RemoveAllUnlockedChestsPlugin(wvm));
+            wvm.Plugins.Add(new RemoveTileWithPlugin(wvm));
+            wvm.Plugins.Add(new ReplaceAllPlugin(wvm));
+            wvm.Plugins.Add(new SandSettlePlugin(wvm));
+            wvm.Plugins.Add(new BlockShufflePlugin(wvm)); //My AddOn
+            wvm.Plugins.Add(new SimplePerlinGeneratorPlugin(wvm));
+            wvm.Plugins.Add(new UnlockAllChestsPlugin(wvm));
+
             return wvm;
         }
     }


### PR DESCRIPTION
Adds a plugin that simply takes all blocks in a selected area, and randomises their position.

The plugin-view also got alphabetically sorted.