### PR TITLE
Fixed the Generate Text Statues plugin.

### DIFF
--- a/src/TEdit/Editor/Plugins/TextStatuePlugin.cs
+++ b/src/TEdit/Editor/Plugins/TextStatuePlugin.cs
@@ -157,7 +157,7 @@ namespace TEdit.Editor.Plugins
 
                 foreach (var frame in sprite.Styles)
                 {
-                    char c = frame.Value.Name[12];
+                    char c = frame.Value.Name[13]; // [13] - skips the first 13 chars of the string.
                     _textFrames[c] = frame.Value;
                 }
             }

--- a/src/TEdit/settings.xml
+++ b/src/TEdit/settings.xml
@@ -4485,7 +4485,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
                 <Frame UV="1548,0" Name="Ash Wood Clock" />
             </Frames>
         </Tile>
-        <Tile Id="105" Color="#FF909490" Name="Statues" Framed="true" Size="2,3" Placement="floor">
+        <Tile Id="105" Color="#FF909490" Name="Statue" Framed="true" Size="2,3" Placement="floor">
             <Frames>
                 <Frame UV="0,0" Name="Armor Statue" Variety="Left" />
                 <Frame UV="0,162" Name="Armor Statue" Variety="Right" />
@@ -6472,7 +6472,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
         </Tile>
         <Tile Id="335" Color="#FFD9AE89" Name="Fireworks Box" Framed="true" Size="2,2" />
         <Tile Id="336" Color="#FFFD3E03" Name="Living Fire Block" Solid="true" Blends="true" />
-        <Tile Id="337" Color="#FF909490" Name="Text Statues" Framed="true" Size="2,3" Placement="floor">
+        <Tile Id="337" Color="#FF909490" Name="Text Statue" Framed="true" Size="2,3" Placement="floor">
             <Frames>
                 <Frame UV="0,0" Variety="0 Statue" />
                 <Frame UV="36,0" Variety="1 Statue" />


### PR DESCRIPTION
![fixedplugin](https://user-images.githubusercontent.com/33048298/235274659-25b6160a-3c28-4d8d-b659-285d45702523.PNG)

**Issues Found:**
`4.11.4-beta9` - __Settings.xml__ -> Strings `statues` need changed back to `statue`.
`4.11.4-release` - __Terraria/Objects/FrameProperty.cs__ -> The `public override string ToString()` : `return $"{Name} {Variety} {Anchor.ToString()}".Trim();` was changed.

**Solution:**
Since the FrameProperty change, it added an `:`. `Name[12]` needs changed to `Name[13]`.