### PR TITLE
Fixed Chinese world checkbox, version bump, and fixed the news for multiple versions.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
 param(
-    [string] $VersionPrefix = "4.15.0",
+    [string] $VersionPrefix = "4.16.0",
     [string] $VersionSuffix = ""
 )
 

--- a/src/TEdit/TEdit.csproj
+++ b/src/TEdit/TEdit.csproj
@@ -9,7 +9,7 @@
     <DefaultNamespace>TEdit</DefaultNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>4.15.0</VersionPrefix>
+    <VersionPrefix>4.16.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Platforms>AnyCPU</Platforms>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/TEdit/View/Popups/NotificationsWindow.xaml
+++ b/src/TEdit/View/Popups/NotificationsWindow.xaml
@@ -33,7 +33,40 @@
                     <Paragraph>
                         <Bold>Release Notes</Bold>
                     </Paragraph>
-					
+
+                    <Paragraph>Version 4.16</Paragraph>
+                    <List>
+                        <ListItem>
+                            <Paragraph>Added support to console worlds. Now save between formats!</Paragraph>
+                        </ListItem>
+                    </List>
+                    
+                    <Paragraph>Version 4.15</Paragraph>
+                    <List>
+                        <ListItem>
+                            <Paragraph>Fixes for boss rendering crash</Paragraph>
+                        </ListItem>
+                        <ListItem>
+                            <Paragraph>Fix for tile search crash</Paragraph>
+                        </ListItem>
+                    </List>
+                    
+                    <Paragraph>Version 4.14</Paragraph>
+                    <List>
+                        <ListItem>
+                            <Paragraph>Added a block shuffle plugin</Paragraph>
+                        </ListItem>
+                        <ListItem>
+                            <Paragraph>Fixed issues with saving and rendering of wall coatings</Paragraph>
+                        </ListItem>
+                        <ListItem>
+                            <Paragraph>Fixed the generate text statues plugin</Paragraph>
+                        </ListItem>
+                        <ListItem>
+                            <Paragraph>Fixed an exception caused from adding bound NPCs</Paragraph>
+                        </ListItem>
+                    </List>
+                    
                     <Paragraph>Version 4.13</Paragraph>
                     <List>
                         <ListItem>

--- a/src/TEdit/View/Popups/NotificationsWindow.xaml
+++ b/src/TEdit/View/Popups/NotificationsWindow.xaml
@@ -47,26 +47,26 @@
                     <Paragraph>Version 4.15</Paragraph>
                     <List>
                         <ListItem>
-                            <Paragraph>Fixes for boss rendering crash</Paragraph>
+                            <Paragraph>Fixes for boss rendering crash.</Paragraph>
                         </ListItem>
                         <ListItem>
-                            <Paragraph>Fix for tile search crash</Paragraph>
+                            <Paragraph>Fix for tile search crash.</Paragraph>
                         </ListItem>
                     </List>
                     
                     <Paragraph>Version 4.14</Paragraph>
                     <List>
                         <ListItem>
-                            <Paragraph>Added a block shuffle plugin</Paragraph>
+                            <Paragraph>Added a block shuffle plugin.</Paragraph>
                         </ListItem>
                         <ListItem>
-                            <Paragraph>Fixed issues with saving and rendering of wall coatings</Paragraph>
+                            <Paragraph>Fixed issues with saving and rendering of wall coatings.</Paragraph>
                         </ListItem>
                         <ListItem>
-                            <Paragraph>Fixed the generate text statues plugin</Paragraph>
+                            <Paragraph>Fixed the generate text statues plugin.</Paragraph>
                         </ListItem>
                         <ListItem>
-                            <Paragraph>Fixed an exception caused from adding bound NPCs</Paragraph>
+                            <Paragraph>Fixed an exception caused from adding bound NPCs.</Paragraph>
                         </ListItem>
                     </List>
                     
@@ -80,39 +80,39 @@
                     <Paragraph>Version 4.12</Paragraph>
                     <List>
                         <ListItem>
-                            <Paragraph>Added a coating editor and added further coating functionality</Paragraph>
+                            <Paragraph>Added a coating editor and added further coating functionality.</Paragraph>
                     	</ListItem>
                     	<ListItem>
-                            <Paragraph>Updated masks, more use cases and masks on paint/coatings</Paragraph>
+                            <Paragraph>Updated masks, more use cases and masks on paint/coatings.</Paragraph>
                     	</ListItem>
                     	<ListItem>
-                            <Paragraph>Fix masks not working for dirt</Paragraph>
+                            <Paragraph>Fix masks not working for dirt.</Paragraph>
                     	</ListItem>
                     </List>
                     
                     <Paragraph>Version 4.11</Paragraph>
                     <List>
                         <ListItem>
-                            <Paragraph>File compatibility for worlds up to 1.4.4 - 1.4.4.5</Paragraph>
+                            <Paragraph>File compatibility for worlds up to 1.4.4 - 1.4.4.5.</Paragraph>
                     	</ListItem>
                     	<ListItem>
-                            <Paragraph>Updated configurations for new items, tiles, walls and NPCs</Paragraph>
+                            <Paragraph>Updated configurations for new items, tiles, walls and NPCs.</Paragraph>
                     	</ListItem>
                     	<ListItem>
-                            <Paragraph>New world property items for 1.4.4.5 features</Paragraph>
+                            <Paragraph>New world property items for 1.4.4.5 features.</Paragraph>
                     	</ListItem>
                         <ListItem>
-                            <Paragraph>Updated bestiary to include missing 1.4.4.5 content</Paragraph>
+                            <Paragraph>Updated bestiary to include missing 1.4.4.5 content.</Paragraph>
                     	</ListItem>
                     </List>
                     
                     <Paragraph>Version 4.10</Paragraph>
                     <List>
                         <ListItem>
-                            <Paragraph>All desktop version support added</Paragraph>
+                            <Paragraph>All desktop version support added.</Paragraph>
                     	</ListItem>
                     	<ListItem>
-                            <Paragraph>Android support added</Paragraph>
+                            <Paragraph>Android support added.</Paragraph>
                     	</ListItem>
                     </List>
                     
@@ -150,7 +150,7 @@
                             <Paragraph>Bugfix: Save as version fixes and improvements.</Paragraph>
                         </ListItem>
                         <ListItem>
-                            <Paragraph>Bugfix: Sign limit error</Paragraph>
+                            <Paragraph>Bugfix: Sign limit error.</Paragraph>
                         </ListItem>
                     </List>
 
@@ -204,10 +204,10 @@
                     <Paragraph>Version 4.2.8</Paragraph>
                     <List>
                         <ListItem>
-                            <Paragraph>Version bump for Terraria 1.4.1.2</Paragraph>
+                            <Paragraph>Version bump for Terraria 1.4.1.2.</Paragraph>
                         </ListItem>
                         <ListItem>
-                            <Paragraph>Procedural House Generator Plugin</Paragraph>
+                            <Paragraph>Procedural House Generator Plugin.</Paragraph>
                         </ListItem>
                     </List>
 

--- a/src/TEdit/View/Popups/NotificationsWindow.xaml
+++ b/src/TEdit/View/Popups/NotificationsWindow.xaml
@@ -39,6 +39,9 @@
                         <ListItem>
                             <Paragraph>Added support to console worlds. Now save between formats!</Paragraph>
                         </ListItem>
+                        <ListItem>
+                            <Paragraph>Fixed the checkbox for old Chinese world formats.</Paragraph>
+                        </ListItem>
                     </List>
                     
                     <Paragraph>Version 4.15</Paragraph>

--- a/src/TEdit/View/Sidebar/WorldPropertiesView.xaml
+++ b/src/TEdit/View/Sidebar/WorldPropertiesView.xaml
@@ -287,7 +287,7 @@
         <TextBlock Text="{x:Static p:Language.tool_wp_seed}" HorizontalAlignment="Right" />
         <TextBox Text="{Binding CurrentWorld.Seed}" HorizontalAlignment="Stretch" IsReadOnly="true" />
         <TextBlock />
-        <CheckBox x:Name="mobileCb" Content="{x:Static p:Language.tool_wp_chinese}" VerticalAlignment="Center" Grid.Row="12" Grid.Column="1" IsChecked="{Binding CurrentWorld.IsAndroid, Mode=TwoWay}"/>
+        <CheckBox x:Name="mobileCb" Content="{x:Static p:Language.tool_wp_chinese}" VerticalAlignment="Center" Grid.Row="12" Grid.Column="1" IsChecked="{Binding CurrentWorld.IsChinese, Mode=TwoWay}"/>
         <TextBlock />
         <CheckBox x:Name="consoleCb" Content="{x:Static p:Language.tool_wp_console}" VerticalAlignment="Center" Grid.Row="12" Grid.Column="1" IsChecked="{Binding CurrentWorld.IsConsole, Mode=TwoWay}"/>
 

--- a/src/TEdit/View/Sidebar/WorldPropertiesView.xaml
+++ b/src/TEdit/View/Sidebar/WorldPropertiesView.xaml
@@ -287,7 +287,7 @@
         <TextBlock Text="{x:Static p:Language.tool_wp_seed}" HorizontalAlignment="Right" />
         <TextBox Text="{Binding CurrentWorld.Seed}" HorizontalAlignment="Stretch" IsReadOnly="true" />
         <TextBlock />
-        <CheckBox x:Name="mobileCb" Content="{x:Static p:Language.tool_wp_chinese}" VerticalAlignment="Center" Grid.Row="12" Grid.Column="1" IsChecked="{Binding CurrentWorld.IsChinese, Mode=TwoWay}"/>
+        <CheckBox x:Name="chineseCb" Content="{x:Static p:Language.tool_wp_chinese}" VerticalAlignment="Center" Grid.Row="12" Grid.Column="1" IsChecked="{Binding CurrentWorld.IsChinese, Mode=TwoWay}"/>
         <TextBlock />
         <CheckBox x:Name="consoleCb" Content="{x:Static p:Language.tool_wp_console}" VerticalAlignment="Center" Grid.Row="12" Grid.Column="1" IsChecked="{Binding CurrentWorld.IsConsole, Mode=TwoWay}"/>
 


### PR DESCRIPTION
* Fixed `WorldPropertiesView` using `IsAndroid` and not `IsChinese`. Found by @pharuxtan. - Tested and now working.
* Bump version.
* Bump version 4.16.
* Update NotificationsWindow.xaml (`4.14`, `4.15`, `4.16`)

![TeditConsole](https://github.com/TEdit/Terraria-Map-Editor/assets/33048298/6687a4f6-6f02-47d9-8528-155064f96bcd)