### PR TITLE
Added an liquid amount dropdown to liquid mode.

### DIFF
--- a/src/TEdit/Editor/PaintMode.cs
+++ b/src/TEdit/Editor/PaintMode.cs
@@ -40,6 +40,32 @@ namespace TEdit.Editor
         Right = 36
     }
 
+    public enum LiquidAmountMode : byte
+    {
+        [Description("0%")]
+        ZeroPercent = 0x0,
+        [Description("10%")]
+        TenPercent = 0x1A,
+        [Description("20%")]
+        TwentyPercent = 0x33,
+        [Description("30%")]
+        ThirtyPercent = 0x4D,
+        [Description("40%")]
+        FourtyPercent = 0x66,
+        [Description("50%")]
+        FiftyPercent = 0x80,
+        [Description("60%")]
+        SixtyPercent = 0x99,
+        [Description("70%")]
+        SeventyPercent = 0xB3,
+        [Description("80%")]
+        EightyPercent = 0xCC,
+        [Description("90%")]
+        NinteyPercent = 0xE6,
+        [Description("100%")]
+        OneHundredPercent = 0xFF
+    }
+
     [Flags]
     public enum WireReplaceMode : byte
     {

--- a/src/TEdit/Editor/TilePicker.cs
+++ b/src/TEdit/Editor/TilePicker.cs
@@ -41,6 +41,7 @@ namespace TEdit.Editor
         private bool _wallStyleActive = ToolDefaultData.PaintWallActive;
         private TrackMode _trackMode = TrackMode.Track;
         private JunctionBoxMode _junctionboxMode = JunctionBoxMode.None;
+        private LiquidAmountMode _liquidAmountMode = LiquidAmountMode.OneHundredPercent;
 
         private WireReplaceMode _wireReplaceModeRed = WireReplaceMode.Red;
         private WireReplaceMode _wireReplaceModeBlue = WireReplaceMode.Blue;
@@ -105,7 +106,11 @@ namespace TEdit.Editor
             set { Set(nameof(WireReplaceModeYellow), ref _wireReplaceModeYellow, value); }
         }
 
-
+        public LiquidAmountMode LiquidAmountMode
+        {
+            get { return _liquidAmountMode; }
+            set { Set(nameof(LiquidAmountMode), ref _liquidAmountMode, value); }
+        }
 
         public bool WallCoatingIlluminant
         {

--- a/src/TEdit/Editor/Tools/PickerTool.cs
+++ b/src/TEdit/Editor/Tools/PickerTool.cs
@@ -83,6 +83,32 @@ namespace TEdit.Editor.Tools
             {
                 _wvm.TilePicker.JunctionBoxMode = JunctionBoxMode.Right;
             }
+
+            // Get Picker For Liquid Amount.
+            if (curTile.LiquidAmount == 0)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.ZeroPercent;
+            else if (curTile.LiquidAmount <= 0x1A)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.TenPercent;
+            else if (curTile.LiquidAmount <= 0x33)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.TwentyPercent;
+            else if (curTile.LiquidAmount <= 0x4D)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.ThirtyPercent;
+            else if (curTile.LiquidAmount <= 0x66)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.FourtyPercent;
+            else if (curTile.LiquidAmount <= 0x80)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.FiftyPercent;
+            else if (curTile.LiquidAmount <= 0x99)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.SixtyPercent;
+            else if (curTile.LiquidAmount <= 0xB3)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.SeventyPercent;
+            else if (curTile.LiquidAmount <= 0xCC)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.EightyPercent;
+            else if (curTile.LiquidAmount <= 0xE6)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.NinteyPercent;
+            else if (curTile.LiquidAmount <= 0xFF)
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.OneHundredPercent;
+            else
+                _wvm.TilePicker.LiquidAmountMode = LiquidAmountMode.OneHundredPercent;
         }
 
         private void PickmaskTile(int x, int y)

--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -458,6 +458,15 @@ namespace TEdit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Liquid Amount:.
+        /// </summary>
+        public static string liquid_amount {
+            get {
+                return ResourceManager.GetString("liquid_amount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Honey.
         /// </summary>
         public static string LiquidType_Honey {
@@ -2582,15 +2591,6 @@ namespace TEdit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Console World Version.
-        /// </summary>
-        public static string tool_wp_console {
-            get {
-                return ResourceManager.GetString("tool_wp_console", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cobalt Tier.
         /// </summary>
         public static string tool_wp_cobalt {
@@ -2614,6 +2614,15 @@ namespace TEdit.Properties {
         public static string tool_wp_combatbooktwo {
             get {
                 return ResourceManager.GetString("tool_wp_combatbooktwo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Console World Version.
+        /// </summary>
+        public static string tool_wp_console {
+            get {
+                return ResourceManager.GetString("tool_wp_console", resourceCulture);
             }
         }
         

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -1347,4 +1347,7 @@
   <data name="tool_paint_illuminantcoating" xml:space="preserve">
     <value>مضيئة</value>
   </data>
+  <data name="liquid_amount" xml:space="preserve">
+    <value>الكمية السائلة:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -1347,4 +1347,7 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="tool_paint_illuminantcoating" xml:space="preserve">
     <value>Leuchtmittel</value>
   </data>
+  <data name="liquid_amount" xml:space="preserve">
+    <value>Flüssigkeitsmenge:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -1347,4 +1347,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="tool_paint_illuminantcoating" xml:space="preserve">
     <value>Illuminant</value>
   </data>
+  <data name="liquid_amount" xml:space="preserve">
+    <value>Liquid Amount:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -1347,4 +1347,7 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="tool_paint_illuminantcoating" xml:space="preserve">
     <value>Oświetlenie</value>
   </data>
+  <data name="liquid_amount" xml:space="preserve">
+    <value>Płynna ilość:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -1347,4 +1347,7 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="tool_paint_illuminantcoating" xml:space="preserve">
     <value>Iluminante</value>
   </data>
+  <data name="liquid_amount" xml:space="preserve">
+    <value>Quantidade Líquida:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -1350,4 +1350,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
     <value>Illuminant</value>
     <comment>Illuminant</comment>
   </data>
+  <data name="liquid_amount" xml:space="preserve">
+    <value>Liquid Amount:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -1347,4 +1347,7 @@
   <data name="tool_paint_illuminantcoating" xml:space="preserve">
     <value>Источник света</value>
   </data>
+  <data name="liquid_amount" xml:space="preserve">
+    <value>Количество жидкости:</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1347,4 +1347,7 @@
   <data name="tool_paint_illuminantcoating" xml:space="preserve">
     <value>光源</value>
   </data>
+  <data name="liquid_amount" xml:space="preserve">
+    <value>液体量：</value>
+  </data>
 </root>

--- a/src/TEdit/Themes/Templates.xaml
+++ b/src/TEdit/Themes/Templates.xaml
@@ -13,6 +13,7 @@
     <enum:EnumItemList x:Key="HalfBlockMode" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:HalfBlockMode}" x:Shared="false" SortBy="Value" />
     <enum:EnumItemList x:Key="BrickStyle" ResourceType="{x:Type p:Language}" EnumType="{x:Type Terraria:BrickStyle}" x:Shared="false" SortBy="Value" />
     <enum:EnumItemList x:Key="LiquidType" ResourceType="{x:Type p:Language}" EnumType="{x:Type Terraria:LiquidType}" x:Shared="false" SortBy="Value" />
+    <enum:EnumItemList x:Key="LiquidAmountEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:LiquidAmountMode}" SortBy="Value" />
     <enum:EnumItemList x:Key="WireReplaceModeEnum" ResourceType="{x:Type p:Language}" EnumType="{x:Type Editor:WireReplaceMode}" SortBy="Value"  />
 
     <DataTemplate x:Key="ColorPickerTemplate" >

--- a/src/TEdit/View/Popups/NotificationsWindow.xaml
+++ b/src/TEdit/View/Popups/NotificationsWindow.xaml
@@ -42,6 +42,9 @@
                         <ListItem>
                             <Paragraph>Fixed the checkbox for old Chinese world formats.</Paragraph>
                         </ListItem>
+                        <ListItem>
+                            <Paragraph>Added an liquid amount dropdown to liquids.</Paragraph>
+                        </ListItem>
                     </List>
                     
                     <Paragraph>Version 4.15</Paragraph>

--- a/src/TEdit/View/TopPanel/PaintModeView.xaml
+++ b/src/TEdit/View/TopPanel/PaintModeView.xaml
@@ -194,9 +194,14 @@
                 </tedit:AutoGrid>
             </GroupBox>
             <GroupBox Header="Liquid" Style="{StaticResource LiquidVisibleStyle}">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
+                <StackPanel VerticalAlignment="Top">
                     <ComboBox ItemsSource="{StaticResource LiquidType}" 
                           SelectedValue="{Binding TilePicker.LiquidType}" 
+                          SelectedValuePath="Value" Width="100"
+                          ItemTemplate="{StaticResource EnumTemplate}" />
+                    <TextBlock Text="{x:Static p:Language.liquid_amount}" HorizontalAlignment="Left"/>
+                    <ComboBox ItemsSource="{StaticResource LiquidAmountEnum}" 
+                          SelectedValue="{Binding TilePicker.LiquidAmountMode}" 
                           SelectedValuePath="Value" Width="100"
                           ItemTemplate="{StaticResource EnumTemplate}" />
                 </StackPanel>

--- a/src/TEdit/ViewModel/WorldViewModel.Editor.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Editor.cs
@@ -441,7 +441,7 @@ namespace TEdit.ViewModel
                 case PaintMode.Liquid:
                     SetPixelAutomatic(
                         curTile,
-                        liquid: (isErase || TilePicker.LiquidType == LiquidType.None) ? (byte)0 : (byte)255,
+                        liquid: (isErase || TilePicker.LiquidType == LiquidType.None) ? (byte)0 : (byte)TilePicker.LiquidAmountMode,
                         liquidType: TilePicker.LiquidType);
                     break;
                 case PaintMode.Track:


### PR DESCRIPTION
This PR adds an liquid amount dropdown to the liquid mode.
![WaterLevels](https://github.com/TEdit/Terraria-Map-Editor/assets/33048298/32fd7b92-0d84-4ce9-b24f-037c6a78f7d6)

Furthermore, the picker tool will now select the percent of water and correctly update the dropdown. Levels are done in 10% increments from 0 to 255. 
![PickerTool](https://github.com/TEdit/Terraria-Map-Editor/assets/33048298/776108b6-2d52-46a0-9715-d53bbf11814b)