### PR TITLE
Fix reading an int where a uint should be read

### DIFF
--- a/src/TEdit/Terraria/World.FileV2.cs
+++ b/src/TEdit/Terraria/World.FileV2.cs
@@ -2511,7 +2511,7 @@ namespace TEdit.Terraria
         {
             tileFrameImportant = null;
             sectionPointers = null;
-            int versionNumber = r.ReadInt32();
+            uint versionNumber = r.ReadUInt32();
 
             if (versionNumber >= 140) // 135
             {


### PR DESCRIPTION
In the world loading routine the world version should be read as a `uint`, not an `int`.

This probably won't ever become a problem, but it's better to fix now than cause a headache years down the line...