### PR TITLE
Reworked the ground levels to use unsafe levels.

### DIFF
--- a/src/TEdit.Terraria/World.Properties.cs
+++ b/src/TEdit.Terraria/World.Properties.cs
@@ -86,9 +86,9 @@ public partial class World : ReactiveObject, ITileData
 
     private void UpdateMaxLayerLevels()
     {
-        bool bypassLimits = UnsafeGroundLayers;
-        if (bypassLimits)
+        if (!SafeGroundLayers)
         {
+			// Defualt: Use unsafe levels.
             MaxCavernLevel = Calc.Clamp(TilesHigh, 0, TilesHigh);
             MaxGroundLevel = Calc.Clamp(TilesHigh - 6, 0, TilesHigh);
         }
@@ -96,10 +96,15 @@ public partial class World : ReactiveObject, ITileData
         {
             MaxCavernLevel = Calc.Clamp(TilesHigh - WorldConfiguration.CavernLevelToBottomOfWorld, 6, TilesHigh);
             MaxGroundLevel = Calc.Clamp(MaxCavernLevel - 6, 0, TilesHigh);
+			
+			// Adjust the sliders to reflect new values if over the max.
+			if (GroundLevel > MaxGroundLevel)
+			    GroundLevel = MaxGroundLevel;
+			if (RockLevel > MaxCavernLevel)
+			    RockLevel = MaxCavernLevel;
         }
     }
-
-
+	
     public uint WorldVersion => Version;
     public Random Rand;
     public int[] TreeBG = new int[3];
@@ -113,7 +118,7 @@ public partial class World : ReactiveObject, ITileData
     private double _groundLevel;
     private double _rockLevel;
     private int _shadowOrbCount;
-    private bool _unsafeGroundLayers;
+	private bool _safeGroundLayers;
     private int _tilesHigh;
     private int _treeX0;
     private int _treeX1;
@@ -283,14 +288,14 @@ public partial class World : ReactiveObject, ITileData
             }
         }
     }
-
-    [Category("Levels")]
-    public bool UnsafeGroundLayers
+	
+	[Category("Levels")]
+    public bool SafeGroundLayers
     {
-        get => _unsafeGroundLayers;
+        get => _safeGroundLayers;
         set
         {
-            this.RaiseAndSetIfChanged(ref _unsafeGroundLayers, value);
+            this.RaiseAndSetIfChanged(ref _safeGroundLayers, value);
             UpdateMaxLayerLevels();
         }
     }

--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -3642,6 +3642,15 @@ public class Language {
             return ResourceManager.GetString("tool_wp_time_sundial_cooldown", resourceCulture);
         }
     }
+	
+	/// <summary>
+    ///   Looks up a localized string similar to Use Safe Values Only.
+    /// </summary>
+    public static string tool_wp_safe_level {
+        get {
+            return ResourceManager.GetString("tool_wp_safe_level", resourceCulture);
+        }
+    }
     
     /// <summary>
     ///   Looks up a localized string similar to Allow Unsafe Values.

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -1164,6 +1164,9 @@
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>شفافية الأسلاك</value>
   </data>
+  <data name="tool_wp_safe_level" xml:space="preserve">
+    <value>استخدم القيم الآمنة فقط</value>
+  </data>
   <data name="tool_wp_unsafe_level" xml:space="preserve">
     <value>السماح بالقيم غير الآمنة</value>
   </data>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -1164,6 +1164,9 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Kabelsichtbarkeit</value>
   </data>
+  <data name="tool_wp_safe_level" xml:space="preserve">
+    <value>Verwenden Sie nur sichere Werte</value>
+  </data>
   <data name="tool_wp_unsafe_level" xml:space="preserve">
     <value>Unsichere Werte zulassen</value>
   </data>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -1164,6 +1164,9 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Wire Transparency</value>
   </data>
+  <data name="tool_wp_safe_level" xml:space="preserve">
+    <value>Use Safe Values Only</value>
+  </data>
   <data name="tool_wp_unsafe_level" xml:space="preserve">
     <value>Allow Unsafe Values</value>
   </data>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -1164,6 +1164,9 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Przezroczystość przewodu</value>
   </data>
+  <data name="tool_wp_safe_level" xml:space="preserve">
+    <value>Używaj tylko bezpiecznych wartości</value>
+  </data>
   <data name="tool_wp_unsafe_level" xml:space="preserve">
     <value>Zezwalaj na niebezpieczne wartości</value>
   </data>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -1164,6 +1164,9 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Transparência aramada</value>
   </data>
+  <data name="tool_wp_safe_level" xml:space="preserve">
+    <value>Use apenas valores seguros</value>
+  </data>
   <data name="tool_wp_unsafe_level" xml:space="preserve">
     <value>Permitir valores inseguros</value>
   </data>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -1170,6 +1170,9 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Wire Transparency</value>
   </data>
+  <data name="tool_wp_safe_level" xml:space="preserve">
+    <value>Use Safe Values Only</value>
+  </data>
   <data name="tool_wp_unsafe_level" xml:space="preserve">
     <value>Allow Unsafe Values</value>
   </data>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -1164,6 +1164,9 @@
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>Прозрачность проводов</value>
   </data>
+  <data name="tool_wp_safe_level" xml:space="preserve">
+    <value>Используйте только безопасные значения</value>
+  </data>
   <data name="tool_wp_unsafe_level" xml:space="preserve">
     <value>Разрешить небезопасные значения</value>
   </data>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1170,6 +1170,9 @@
   <data name="menu_layers_wire_transparency" xml:space="preserve">
     <value>电线透明度</value>
   </data>
+  <data name="tool_wp_safe_level" xml:space="preserve">
+    <value>仅使用安全值</value>
+  </data>
   <data name="tool_wp_unsafe_level" xml:space="preserve">
     <value>允许不安全的值</value>
   </data>

--- a/src/TEdit/View/Sidebar/WorldPropertiesView.xaml
+++ b/src/TEdit/View/Sidebar/WorldPropertiesView.xaml
@@ -391,7 +391,7 @@
         </DockPanel>
         <TextBlock  />
         <DockPanel>
-            <CheckBox IsChecked="{Binding CurrentWorld.UnsafeGroundLayers}" Content="{x:Static p:Language.tool_wp_unsafe_level}" VerticalAlignment="Center" />
+            <CheckBox IsChecked="{Binding CurrentWorld.SafeGroundLayers}" Content="{x:Static p:Language.tool_wp_safe_level}" VerticalAlignment="Center" />
         </DockPanel>
         <TextBlock  />
         <Button Content="{x:Static p:Language.wp_fixbackground}" Padding="3" Command="{Binding CurrentWorld.FixLayerGapCommand}"  />


### PR DESCRIPTION
In this update, the checkbox for `Allow Unsafe Values` has been rebranded into `Use Safe Values Only`. This enables the usage and saving of unsafe values by default and for a toggle to use only the safe values.

![TEdit-Safe-Layers](https://github.com/user-attachments/assets/f9da992c-a7dc-4f0b-bd11-e0c3efe2f88d)