### PR TITLE
Collapsible Custom World-Gen + Toggle All Wires Layer.

### DIFF
--- a/src/TEdit/MainWindow.xaml
+++ b/src/TEdit/MainWindow.xaml
@@ -112,6 +112,7 @@
                     <MenuItem Header="{x:Static p:Language.menu_layers_wire_blue}" IsCheckable="True" IsChecked="{Binding ShowBlueWires}" />
                     <MenuItem Header="{x:Static p:Language.menu_layers_wire_green}" IsCheckable="True" IsChecked="{Binding ShowGreenWires}" />
                     <MenuItem Header="{x:Static p:Language.menu_layers_wire_yellow}" IsCheckable="True" IsChecked="{Binding ShowYellowWires}" />
+                    <MenuItem Header="{x:Static p:Language.menu_layers_wire_all}" IsCheckable="True" IsChecked="{Binding ShowAllWires}" />
                     <MenuItem Header="{x:Static p:Language.menu_layers_wire_transparency}" IsCheckable="True" IsChecked="{Binding ShowWireTransparency}" />
                     <Separator Margin="1" />
                     <MenuItem Header="{x:Static p:Language.menu_layers_points}" IsCheckable="True" IsChecked="{Binding ShowPoints}" />

--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -944,6 +944,15 @@ public class Language {
     }
     
     /// <summary>
+    ///   Looks up a localized string similar to All Wires.
+    /// </summary>
+    public static string menu_layers_wire_all {
+        get {
+            return ResourceManager.GetString("menu_layers_wire_all", resourceCulture);
+        }
+    }
+    
+    /// <summary>
     ///   Looks up a localized string similar to Plugins.
     /// </summary>
     public static string menu_plugins {

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -384,6 +384,9 @@
   <data name="menu_layers_wire_yellow" xml:space="preserve">
     <value>سلك أصفر</value>
   </data>
+  <data name="menu_layers_wire_all" xml:space="preserve">
+    <value>جميع الأسلاك</value>
+  </data>
   <data name="menu_plugins" xml:space="preserve">
     <value>الإضافات</value>
   </data>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -344,6 +344,9 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="menu_layers_wire_yellow" xml:space="preserve">
     <value>Gelbe Kabel</value>
   </data>
+  <data name="menu_layers_wire_all" xml:space="preserve">
+    <value>Alle draden</value>
+  </data>
   <data name="menu_plugins" xml:space="preserve">
     <value>Plugins</value>
   </data>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -347,6 +347,9 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_layers_wire_yellow" xml:space="preserve">
     <value>Yellow Wire</value>
   </data>
+  <data name="menu_layers_wire_all" xml:space="preserve">
+    <value>All Wires</value>
+  </data>
   <data name="menu_plugins" xml:space="preserve">
     <value>Plugins</value>
   </data>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -344,6 +344,9 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="menu_layers_wire_yellow" xml:space="preserve">
     <value>Żółte Kable</value>
   </data>
+  <data name="menu_layers_wire_all" xml:space="preserve">
+    <value>Wszystkie przewody</value>
+  </data>
   <data name="menu_plugins" xml:space="preserve">
     <value>Pluginy</value>
   </data>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -344,6 +344,9 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="menu_layers_wire_yellow" xml:space="preserve">
     <value>Fio amarelo</value>
   </data>
+  <data name="menu_layers_wire_all" xml:space="preserve">
+    <value>Todos os fios</value>
+  </data>
   <data name="menu_plugins" xml:space="preserve">
     <value>Plugins</value>
   </data>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -350,6 +350,9 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_layers_wire_yellow" xml:space="preserve">
     <value>Yellow Wire</value>
   </data>
+  <data name="menu_layers_wire_all" xml:space="preserve">
+    <value>All Wires</value>
+  </data>
   <data name="menu_plugins" xml:space="preserve">
     <value>Plugins</value>
   </data>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -332,6 +332,9 @@
   <data name="menu_layers_wire_yellow" xml:space="preserve">
     <value>Жёлтые провода</value>
   </data>
+  <data name="menu_layers_wire_all" xml:space="preserve">
+    <value>Все провода</value>
+  </data>
   <data name="menu_plugins" xml:space="preserve">
     <value>Плагины</value>
   </data>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -347,6 +347,9 @@
   <data name="menu_layers_wire_yellow" xml:space="preserve">
     <value>黄电线</value>
   </data>
+  <data name="menu_layers_wire_all" xml:space="preserve">
+    <value>所有电线</value>
+  </data>
   <data name="menu_plugins" xml:space="preserve">
     <value>插件</value>
   </data>

--- a/src/TEdit/View/Popups/NewWorldView.xaml
+++ b/src/TEdit/View/Popups/NewWorldView.xaml
@@ -1,4 +1,5 @@
 ﻿<Window x:Class="TEdit.View.Popups.NewWorldView"
+        x:Name="NewWorldWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:tedit="clr-namespace:TEdit.UI.Xaml"
@@ -8,7 +9,7 @@
         Background="{StaticResource WindowBackgroundBrush}"
         Foreground="{DynamicResource TextBrush}"
         Icon="/TEdit;component/Images/tedit.ico"
-        Height="560"
+        Height="250"
         Width="330">
     <Window.Resources>
         <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
@@ -17,7 +18,7 @@
         </Style>
     </Window.Resources>
     <StackPanel Orientation="Vertical">
-        <tedit:AutoGrid HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="2">
+        <tedit:AutoGrid x:Name="WorldProperties" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="2">
             <tedit:AutoGrid.ColumnDefinitions>
                 <ColumnDefinition Width="1*" />
                 <ColumnDefinition Width="1.6*" />
@@ -50,6 +51,13 @@
                 <TextBlock Text="{Binding RockLevel, StringFormat={}{0:0}}" Width="30" DockPanel.Dock="Right" />
                 <Slider Value="{Binding RockLevel, Mode=TwoWay}" VerticalAlignment="Center" Minimum="0" Maximum="{Binding Path=MaxCavernLevel}" SmallChange="1" />
             </DockPanel>
+        </tedit:AutoGrid>
+
+        <tedit:AutoGrid x:Name="WorldGeneration" Visibility="Collapsed" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="0">
+            <tedit:AutoGrid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1.6*" />
+            </tedit:AutoGrid.ColumnDefinitions>
 
             <!-- Hills -->
             <Separator Grid.ColumnSpan="2" />
@@ -62,7 +70,7 @@
             <CheckBox IsChecked="{Binding GenerateGrass, Mode=TwoWay}" Margin="1" />
             <TextBlock Text="Add Walls" HorizontalAlignment="Right" />
             <CheckBox IsChecked="{Binding GenerateWalls, Mode=TwoWay}" Margin="1" />
-            
+
             <!-- Caves -->
             <Separator Grid.ColumnSpan="2" />
             <TextBlock Text="Generate Caves (slow)" HorizontalAlignment="Right" />
@@ -160,11 +168,17 @@
             <Separator Grid.ColumnSpan="2" />
             <TextBlock Text="Generate Ores" HorizontalAlignment="Right" />
             <CheckBox IsChecked="{Binding GenerateOres, Mode=TwoWay}" Margin="1" Content="(Launches ore-gen plugin)" />
-
-            <!-- Bottom Buttons -->
-            <Separator Grid.ColumnSpan="2" />
         </tedit:AutoGrid>
-        <UniformGrid Columns="2" Margin="2">
+
+        <!-- Expand Worldgen Button -->
+        <Separator Grid.ColumnSpan="2" />
+        <UniformGrid Columns="1" Margin="2">
+            <Button x:Name="ToggleWorldGeneration" Content="↓ Expand World Generation ↓" Padding="4" Margin="2" Click="ToggleWorldGenerationClick" />
+        </UniformGrid>
+        
+        <!-- Bottom Buttons -->
+        <Separator Grid.ColumnSpan="2" />
+        <UniformGrid Columns="2" Margin="1">
             <Button Content="Cancel" Padding="4" Margin="2" Click="CancelClick" />
             <Button Content="Ok" Padding="4" Margin="2" Click="OkClick" />
         </UniformGrid>

--- a/src/TEdit/View/Popups/NewWorldView.xaml.cs
+++ b/src/TEdit/View/Popups/NewWorldView.xaml.cs
@@ -111,5 +111,32 @@ namespace TEdit.View.Popups
             DialogResult = true;
             Close();
         }
+		
+	    private void ToggleWorldGenerationClick(object sender, RoutedEventArgs e)
+        {
+            // Check if the property is currently visible.
+            if (WorldGeneration.Visibility == Visibility.Collapsed)
+            {
+                // Change the window size.
+                NewWorldWindow.Height = 592;
+
+                // Toggle the property state.
+                WorldGeneration.Visibility = Visibility.Visible;
+
+                // Change button name.
+                ToggleWorldGeneration.Content = "↑ Collapse World Generation ↑";
+            }
+            else if (WorldGeneration.Visibility == Visibility.Visible)
+            {
+                // Change the window size.
+                NewWorldWindow.Height = 250;
+
+                // Toggle the property state.
+                WorldGeneration.Visibility = Visibility.Collapsed;
+
+                // Change button name.
+                ToggleWorldGeneration.Content = "↓ Expand World Generation ↓";
+            }
+        }
     }
 }

--- a/src/TEdit/ViewModel/WorldViewModel.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.cs
@@ -94,6 +94,7 @@ public partial class WorldViewModel : ViewModelBase
     private bool _showBlueWires = true;
     private bool _showGreenWires = true;
     private bool _showYellowWires = true;
+    private bool _showAllWires = true;
     private bool _showWireTransparency = true;
     private string _spriteFilter;
     private ushort _spriteTileFilter;
@@ -580,7 +581,26 @@ public partial class WorldViewModel : ViewModelBase
             UpdateRenderWorld();
         }
     }
-
+    
+    public bool ShowAllWires
+    {
+        get { return _showAllWires; }
+        set
+        {
+            Set(nameof(ShowAllWires), ref _showAllWires, value);
+            ToggleWireStates(_showAllWires);
+            UpdateRenderWorld();
+        }
+    }
+    
+    public void ToggleWireStates(bool state)
+    {
+        ShowRedWires = state;
+        ShowBlueWires = state;
+        ShowGreenWires = state;
+        ShowYellowWires = state;
+    }
+    
     public bool ShowWireTransparency
     {
         get { return _showWireTransparency; }


### PR DESCRIPTION
## Changed The World Generation Options To Be Collapsible
Made a simple change to make the `new world` GUI less intimidating to new users who are used to the old TEdit new world layout.
  - The GUI is collapsed by default.

![TE-WorldGen](https://github.com/user-attachments/assets/4ee6d513-3aa0-436a-8afe-53355b09fdb3)

## Added An "All Wires" Toggle To The Layers Tab
This change is an ese of access change for people to simply toggle on or off all the wire states.

![TE-WiresAll](https://github.com/user-attachments/assets/4b073bfb-f71b-4c07-9dec-20b6153d0e74)