### PR TITLE
Added a Live Frame Editor.

### DIFF
--- a/src/TEdit/MainWindow.xaml
+++ b/src/TEdit/MainWindow.xaml
@@ -155,7 +155,7 @@
                         <TextBlock Text="{x:Static p:Language.statusbar_extra_label}" VerticalAlignment="Center" Margin="5,0"/>
                         <TextBox Text="{Binding MouseOverTile.TileExtras, Mode=OneWay}" Width="100" IsReadOnly="True" />
                         <TextBlock Text="{x:Static p:Language.statusbar_frame_label}" VerticalAlignment="Center" Margin="5,0"/>
-                        <TextBox Text="{Binding MouseOverTile.UV, StringFormat={}{0}, Mode=OneWay}" Width="50" IsReadOnly="True" />
+                        <TextBox Text="{Binding MouseOverTile.UV, StringFormat={}{0}, Mode=OneWay}" Width="50" IsReadOnly="True" PreviewMouseDown="TextBox_PreviewMouseDown"/>
                         <TextBlock Text="{x:Static p:Language.statusbar_paint_label}" VerticalAlignment="Center" Margin="5,0"/>
                         <TextBox Text="{Binding MouseOverTile.Paint, Mode=OneWay}" Width="180" IsReadOnly="True" />
                         <TextBlock Text="{x:Static p:Language.statusbar_selection_label}" VerticalAlignment="Center" Margin="5,0"/>

--- a/src/TEdit/MainWindow.xaml.cs
+++ b/src/TEdit/MainWindow.xaml.cs
@@ -2,12 +2,14 @@
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
+using System.Collections.Generic;
 using TEdit.Geometry;
 using TEdit.Terraria;
 using TEdit.Editor;
 using TEdit.ViewModel;
 using TEdit.Properties;
 using TEdit.UI.Xaml;
+using TEdit.View.Popups;
 using System.IO;
 
 namespace TEdit;
@@ -27,11 +29,7 @@ public partial class MainWindow : Window
         _vm = (WorldViewModel)DataContext;
         AddHandler(Keyboard.KeyDownEvent, (KeyEventHandler)HandleKeyDownEvent);
         AddHandler(Keyboard.KeyUpEvent, (KeyEventHandler)HandleKeyUpEvent);
-
-        
     }
-
-
 
     void MainWindow_Loaded(object sender, RoutedEventArgs e)
     {
@@ -266,6 +264,37 @@ public partial class MainWindow : Window
             string filelocation = Path.GetFullPath(files[0]);
 
             _vm.LoadWorld(filelocation);
+        }
+    }
+	
+	private void TextBox_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        // Check if the left mouse button was clicked
+        if (e.LeftButton == MouseButtonState.Pressed)
+        {
+            // Prevent the default focus behavior on click
+            e.Handled = true;
+
+            // Ensure the selection area is active.
+            if (!_vm.Selection.IsActive)
+                return;
+
+            // Build the list of tiles per the selection area.
+            List<Tuple<Tile, Vector2Int32>> tileList = new();
+            for (int x = _vm.Selection.SelectionArea.Left; x < _vm.Selection.SelectionArea.Right; x++)
+            {
+                for (int y = _vm.Selection.SelectionArea.Top; y < _vm.Selection.SelectionArea.Bottom; y++)
+                {
+                    tileList.Add(new Tuple<Tile, Vector2Int32>(_vm.CurrentWorld.Tiles[x, y], new Vector2Int32(x, y)));
+                }
+            }
+
+            // Clear the selection for better viewing.
+            _vm.Selection.SetRectangle(new Vector2Int32(0, 0), new Vector2Int32(0, 0));
+
+            // Pass the tile data onto the new controller.
+            UVEditorWindow uvEditorWindow = new(tileList, _vm);
+            uvEditorWindow.ShowDialog();
         }
     }
 }

--- a/src/TEdit/View/Popups/UVEditorWindow.xaml
+++ b/src/TEdit/View/Popups/UVEditorWindow.xaml
@@ -1,0 +1,96 @@
+﻿<Window x:Class="TEdit.View.Popups.UVEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="UV Editor"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="ToolWindow"
+        ResizeMode="NoResize"
+        Background="{StaticResource WindowBackgroundBrush}"
+        Foreground="{DynamicResource TextBrush}"
+        Icon="/TEdit;component/Images/tedit.ico"
+        Height="530"
+        Width="350">
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- Move All Frames Section -->
+        <StackPanel Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,0,0,10">
+            <TextBlock Text="Move All Frames" FontWeight="Bold" Margin="0,0,0,5"/>
+            <Grid HorizontalAlignment="Center">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Arrows -->
+                <Button x:Name="UpButton" Content="^" Width="30" Height="30" Grid.Row="0" Grid.Column="1" Click="Button_Click"/>
+                <Button x:Name="LeftButton" Content="&lt;" Width="30" Height="30" Grid.Row="1" Grid.Column="0" Click="Button_Click"/>
+                <Button x:Name="RightButton" Content="&gt;" Width="30" Height="30" Grid.Row="1" Grid.Column="2" Click="Button_Click"/>
+                <Button x:Name="DownButton" Content="v" Width="30" Height="30" Grid.Row="2" Grid.Column="1" Click="Button_Click"/>
+            </Grid>
+        </StackPanel>
+
+        <!-- Move Amount Section -->
+        <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,10,0,0">
+            <TextBlock Text="Move Amount (Frames):" FontWeight="Bold" VerticalAlignment="Center"/>
+            <StackPanel Orientation="Horizontal" Margin="10,0,0,0">
+                <TextBlock Text="U:" VerticalAlignment="Center"/>
+                <TextBox x:Name="UTextBox" Width="50" Margin="5,0" Text="18"/>
+                <TextBlock Text="V:" VerticalAlignment="Center"/>
+                <TextBox x:Name="VTextBox" Width="50" Margin="5,0" Text="18"/>
+            </StackPanel>
+        </StackPanel>
+
+        <!-- Separator -->
+        <Separator Grid.Row="2" Grid.Column="0" Margin="0,10,0,5"/>
+
+        <!-- Manual Frames -->
+        <StackPanel Grid.Row="3" Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+            <TextBlock Text="Set Manual UV's To All:  " FontWeight="Bold" VerticalAlignment="Center"/>
+            <StackPanel Orientation="Horizontal" Margin="10,0,0,0">
+                <TextBlock Text="U:" VerticalAlignment="Center"/>
+                <TextBox x:Name="UTextBoxManual" Width="50" Margin="5,0" Text="0"/>
+                <TextBlock Text="V:" VerticalAlignment="Center"/>
+                <TextBox x:Name="VTextBoxManual" Width="50" Margin="5,0" Text="0"/>
+            </StackPanel>
+        </StackPanel>
+        <StackPanel Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,5,0,0">
+            <Button Content="Set Values" Width="75" Height="25" IsDefault="True" Click="SetValuesButton_Click"/>
+        </StackPanel>
+
+        <!-- Separator -->
+        <Separator Grid.Row="5" Grid.Column="0" Margin="0,10,0,0"/>
+
+        <!-- Selected Frames Section -->
+        <StackPanel Grid.Row="6" Grid.Column="0" VerticalAlignment="Center">
+            <TextBlock Text="Selected Frames:" FontWeight="Bold" Margin="0,10,0,5"/>
+            <TextBox x:Name="SelectedFramesTextBox" Height="170" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" IsReadOnly="True"/>
+        </StackPanel>
+
+        <!-- Ok/Cancel Buttons -->
+        <StackPanel Grid.Row="7" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,5,0,0">
+            <Button Content="Cancel" Width="75" Height="25" Margin="5" Click="CancelButton_Click"/>
+            <Button Content="Restore" Width="75" Height="25" Margin="5" Click="RestoreButton_Click"/>
+            <Button Content="OK" Width="75" Height="25" Margin="5" IsDefault="True" Click="OkButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/TEdit/View/Popups/UVEditorWindow.xaml.cs
+++ b/src/TEdit/View/Popups/UVEditorWindow.xaml.cs
@@ -1,0 +1,195 @@
+﻿using System.Collections.Generic;
+using System.Windows;
+using System;
+using TEdit.Terraria;
+using TEdit.Geometry;
+using TEdit.ViewModel;
+
+namespace TEdit.View.Popups
+{
+    public partial class UVEditorWindow : Window
+    {
+        private readonly List<Tuple<Tile, Vector2Int32>> UVEditorTileList;
+        private readonly List<Tuple<Tile, Vector2Int32>> UVEditorTileListOriginal;
+        private readonly WorldViewModel _wvm;
+
+        // Constructor to initialize the window with given tiles and ViewModel.
+        public UVEditorWindow(List<Tuple<Tile, Vector2Int32>> tiles, WorldViewModel worldViewModel)
+        {
+            _wvm = worldViewModel;
+            InitializeComponent();
+            UVEditorTileList = tiles;
+
+            // Clone initial tile list for restoration.
+            UVEditorTileListOriginal = CloneTileList(tiles);
+
+            // Save the orignal states.
+            SaveFramesToUndo();
+
+            // Display current UV coordinates.
+            DisplaySelectedFrames();
+        }
+
+        #region Controls
+
+        // Handles Set Values button click to set all values to a manual state.
+        private void SetValuesButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Amount to move in UV directions.
+            int uAmount = int.Parse(UTextBoxManual.Text);
+            int vAmount = int.Parse(VTextBoxManual.Text);
+
+            // Set each tile to the manual values.
+            foreach (var tileTuple in UVEditorTileList)
+            {
+                tileTuple.Item1.U = (short)uAmount;
+                tileTuple.Item1.V = (short)vAmount;
+            }
+
+            // Update display to reflect restored state.
+            DisplaySelectedFrames();
+        }
+
+        // Handles button clicks to move UV coordinates.
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            // Amount to move in UV directions.
+            int uAmount = int.Parse(UTextBox.Text);
+            int vAmount = int.Parse(VTextBox.Text);
+
+            if (sender == UpButton)
+            {
+                MoveV(-vAmount); // Move UV coordinates up (negative V direction).
+            }
+            else if (sender == DownButton)
+            {
+                MoveV(vAmount); // Move UV coordinates down (positive V direction).
+            }
+            else if (sender == LeftButton)
+            {
+                MoveU(-uAmount); // Move UV coordinates left (negative U direction).
+            }
+            else if (sender == RightButton)
+            {
+                MoveU(uAmount); // Move UV coordinates right (positive U direction).
+            }
+        }
+
+        // Handles OK button click to save changes and close the window.
+        private void OkButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Save current state for undo functionality.
+            SaveFramesToUndo();
+
+            // Close the editor window.
+            Close();
+        }
+
+        // Handles Restore button click to revert changes to original state.
+        private void RestoreButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Restore the original tile values.
+            for (int i = 0; i < UVEditorTileList.Count; i++)
+            {
+                UVEditorTileList[i].Item1.U = UVEditorTileListOriginal[i].Item1.U;
+                UVEditorTileList[i].Item1.V = UVEditorTileListOriginal[i].Item1.V;
+            }
+
+            // Update display to reflect restored state.
+            DisplaySelectedFrames();
+        }
+
+        // Handles Cancel button click to discard changes and close the window.
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Restore original tile states.
+            RestoreButton_Click(sender, e);
+
+            // Close the editor window.
+            Close();
+        }
+        #endregion
+
+        #region Data Functions
+
+        // Updates the display with the current UV coordinates of selected tiles.
+        private void DisplaySelectedFrames()
+        {
+            // Clear the current display.
+            SelectedFramesTextBox.Clear();
+
+            // Illiterate through each tile and update the textbox.
+            foreach (var tileTuple in UVEditorTileList)
+            {
+                var tile = tileTuple.Item1;
+
+                // Check if tile is empty. If empty, skip its entree.
+                if (tile.Type <= 0)
+                    continue;
+
+                SelectedFramesTextBox.AppendText($"({tile.U}, {tile.V}){Environment.NewLine}");
+            }
+        }
+
+        // Moves UV coordinates in the U direction by a specified amount.
+        private void MoveU(int amount)
+        {
+            foreach (var tileTuple in UVEditorTileList)
+            {
+                tileTuple.Item1.U += (short)amount;
+            }
+            DisplaySelectedFrames();
+        }
+
+        // Moves UV coordinates in the V direction by a specified amount.
+        private void MoveV(int amount)
+        {
+            foreach (var tileTuple in UVEditorTileList)
+            {
+                tileTuple.Item1.V += (short)amount;
+            }
+            DisplaySelectedFrames();
+        }
+        #endregion
+
+        #region Clone Function
+
+        // Creates a deep copy of the tile list for undo functionality.
+        private List<Tuple<Tile, Vector2Int32>> CloneTileList(List<Tuple<Tile, Vector2Int32>> tiles)
+        {
+            var clonedList = new List<Tuple<Tile, Vector2Int32>>();
+            foreach (var tileTuple in tiles)
+            {
+                // Create a new Tile object with the same properties.
+                var clonedTile = new Tile
+                {
+                    U = tileTuple.Item1.U,
+                    V = tileTuple.Item1.V,
+                    IsActive = tileTuple.Item1.IsActive
+                };
+
+                // Add the cloned Tile and its corresponding Vector2Int32 to the list.
+                clonedList.Add(new Tuple<Tile, Vector2Int32>(clonedTile, tileTuple.Item2));
+            }
+            return clonedList;
+        }
+        #endregion
+
+        #region Undo Manager
+
+        // Saves the current state of tile UV coordinates for undo functionality.
+        private void SaveFramesToUndo()
+        {
+            // Illiterate through each tile and save its new location.
+            foreach (var tileTuple in UVEditorTileList)
+            {
+                var location = tileTuple.Item2;
+                _wvm.UndoManager.SaveTile(location.X, location.Y);
+            }
+
+            // Save undo operation.
+            _wvm.UndoManager.SaveUndo();
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
# Added a Live Frame Editor
This tool will allow you to change a tiles UV and watch it move live within the editor.
- Frame Editor includes full UNDO / REDO support.

![TEdit-Frame-Editor](https://github.com/user-attachments/assets/f9893f9c-8857-4048-a8b3-1756b10c2749)


## How It Works
The frame editor pop is opened by selecting at least one tile on the map and by clicking the `Frame` textbox.

**Controls:**
- "^" button subtracts each of the current tiles "V" by the value in the "V" textbox.
- "v" button adds each of the current tiles "V" by the value in the "V" textbox.
- ">" button adds each of the current tiles "U" by the value in the "U" textbox.
- "<" button subtracts each of the current tiles "U" by the value in the "U" textbox.
- "Set Values" button sets all the tiles UV manually to any value in the the "U" or "V" textbox's.
- "Selected Frames" textbox shows a visual of all the UVs being shifted around.
- "Cancel" button simply cancels all operations.
- "Restore" button will change the UVs to the original loaded values.
- "OK" button will accept the current changes.

![FrameEditor](https://github.com/user-attachments/assets/330c50e6-3583-4ee6-993d-3c4649506aa9)