### PR TITLE
Fixed a missing check for pasting only sprites.

### DIFF
--- a/src/TEdit/Editor/Clipboard/ClipboardManager.cs
+++ b/src/TEdit/Editor/Clipboard/ClipboardManager.cs
@@ -120,7 +120,7 @@ public class ClipboardManager : ObservableObject
     public void PasteBufferIntoWorld(World world, Vector2Int32 anchor)
     {
         if (Buffer == null) return;
-        if (!PasteTiles && !PasteLiquids && !PasteWalls && !PasteWires) return;
+        if (!PasteTiles && !PasteLiquids && !PasteWalls && !PasteWires && !PasteSprites) return;
 
         _selection.IsActive = false; // clear selection when pasting to prevent "unable to use pencil" issue
 


### PR DESCRIPTION
**The fixed desired function:**

![TE-WorkingSpritePasting](https://github.com/user-attachments/assets/0dee5ae7-5a19-425f-a1f6-a4f7d68b946d)