### PR TITLE
Added an Advanced Filter Feature. Added Frame Editor Language Support.

### DIFF
--- a/src/TEdit/Editor/Clipboard/ClipboardManager.cs
+++ b/src/TEdit/Editor/Clipboard/ClipboardManager.cs
@@ -111,7 +111,17 @@ public class ClipboardManager : ObservableObject
 
     public void CopySelection(World world, RectangleInt32 selection)
     {
-        var bufferData = ClipboardBuffer.GetSelectionBuffer(world, selection);
+        bool onlyCopyFiltered = FilterManager.FilerClipboard;
+        var bufferData = ClipboardBuffer.GetSelectionBuffer(
+            world, selection,
+            onlyCopyFiltered,
+            tileFilter:   onlyCopyFiltered ? FilterManager.TileIsNotAllowed : null,
+            wallFilter:   onlyCopyFiltered ? FilterManager.WallIsNotAllowed : null,
+            liquidFilter: onlyCopyFiltered ? (id => FilterManager.LiquidIsNotAllowed((LiquidType)id)) : null,
+            wireFilter:   onlyCopyFiltered ? (id => FilterManager.WireIsNotAllowed((FilterManager.WireType)id)) : null
+        );
+
+
         LoadedBuffers.Add(new ClipboardBufferPreview(bufferData));
 		
         Buffer = new ClipboardBufferPreview(bufferData); // Set the last added buffer as the active one

--- a/src/TEdit/Editor/Clipboard/ClipboardManager.cs
+++ b/src/TEdit/Editor/Clipboard/ClipboardManager.cs
@@ -121,9 +121,7 @@ public class ClipboardManager : ObservableObject
             wireFilter:   onlyCopyFiltered ? (id => FilterManager.WireIsNotAllowed((FilterManager.WireType)id)) : null
         );
 
-
         LoadedBuffers.Add(new ClipboardBufferPreview(bufferData));
-		
         Buffer = new ClipboardBufferPreview(bufferData); // Set the last added buffer as the active one
     }
 

--- a/src/TEdit/Editor/Plugins/HouseGenPlugin.cs
+++ b/src/TEdit/Editor/Plugins/HouseGenPlugin.cs
@@ -85,7 +85,7 @@ public class HouseGenPlugin : BasePlugin
         /// https://docs.microsoft.com/en-us/dotnet/desktop/wpf/data/how-to-implement-property-change-notification?view=netframeworkdesktop-4.8
         /// </summary>
 
-        public WriteableBitmap Preview => GeneratredSchematic.Preview;
+        public WriteableBitmap Preview => GeneratredSchematic?.Preview;
 
         public event PropertyChangedEventHandler PropertyChanged;
         // Create the OnPropertyChanged method to raise the event

--- a/src/TEdit/Editor/Plugins/ImageToPixelartEditorView.xaml.cs
+++ b/src/TEdit/Editor/Plugins/ImageToPixelartEditorView.xaml.cs
@@ -737,6 +737,7 @@ namespace TEdit.Editor.Plugins
                 var bufferRendered = new ClipboardBufferPreview(GeneratedSchematic);
                 _worldViewModel.Clipboard.LoadedBuffers.Add(bufferRendered);
                 _worldViewModel.ClipboardSetActiveCommand.Execute(bufferRendered);
+                _worldViewModel.SelectedTabIndex = 3; // Open the clipboard tab.
 
                 // Display completion message.
                 MessageBox.Show("Schematic copied to clipboard.");

--- a/src/TEdit/Editor/Undo/UndoManager.cs
+++ b/src/TEdit/Editor/Undo/UndoManager.cs
@@ -412,7 +412,7 @@ public class UndoManager : ObservableObject, IDisposable
 
     public void Redo()
     {
-        if (_currentIndex > _maxIndex || _currentIndex < 0)
+        if (_currentIndex > _maxIndex || _currentIndex <= 0)
             return;
 
         ErrorLogging.TelemetryClient?.TrackEvent(nameof(Redo));

--- a/src/TEdit/MainWindow.xaml
+++ b/src/TEdit/MainWindow.xaml
@@ -130,8 +130,9 @@
                             </ControlTemplate>
                         </MenuItem.Template>
                     </MenuItem>
-                </MenuItem>
-                <MenuItem Header="{x:Static p:Language.menu_plugins}" ItemsSource="{Binding Plugins}" ItemContainerStyle="{StaticResource SubmenuItemStyle}">
+        </MenuItem>
+        <MenuItem Header="{x:Static p:Language.menu_filter}" Click="FilterMenuItem_Click" />
+        <MenuItem Header="{x:Static p:Language.menu_plugins}" ItemsSource="{Binding Plugins}" ItemContainerStyle="{StaticResource SubmenuItemStyle}">
 
                 </MenuItem>
                 <MenuItem Header="{x:Static p:Language.menu_help}">

--- a/src/TEdit/MainWindow.xaml.cs
+++ b/src/TEdit/MainWindow.xaml.cs
@@ -77,24 +77,30 @@ public partial class MainWindow : Window
             switch (command)
             {
                 case "copy":
-                    if (_vm.CopyCommand.CanExecute(null))
+                    if (_vm.CurrentWorld != null && _vm.CopyCommand.CanExecute(null))
                     {
                         _vm.CopyCommand.Execute(null);
                         _vm.SelectedTabIndex = 3;
                     }
                     break;
                 case "paste":
-                    if (_vm.PasteCommand.CanExecute(null))
+                    if (_vm.CurrentWorld != null && _vm.PasteCommand.CanExecute(null))
                     {
                         _vm.PasteCommand.Execute(null);
                         _vm.SelectedTabIndex = 3;
                     }
                     break;
                 case "undo":
-                    _vm.UndoCommand.Execute(null);
+                    if (_vm.CurrentWorld != null)
+                    {
+                        _vm.UndoCommand.Execute(null);
+                    }
                     break;
                 case "redo":
-                    _vm.RedoCommand.Execute(null);
+                    if (_vm.CurrentWorld != null)
+                    {
+                        _vm.RedoCommand.Execute(null);
+                    }
                     break;
                 case "selectall":
                     if (_vm.CurrentWorld != null)

--- a/src/TEdit/MainWindow.xaml.cs
+++ b/src/TEdit/MainWindow.xaml.cs
@@ -11,6 +11,8 @@ using TEdit.Properties;
 using TEdit.UI.Xaml;
 using TEdit.View.Popups;
 using System.IO;
+using System.Windows.Controls;
+using TEdit.View;
 
 namespace TEdit;
 
@@ -296,5 +298,19 @@ public partial class MainWindow : Window
             UVEditorWindow uvEditorWindow = new(tileList, _vm);
             uvEditorWindow.ShowDialog();
         }
+    }
+
+    private void FilterMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        // Prevent the default focus behavior on clickAdd commentMore actions
+        // e.Handled = true;
+
+        // Ensure a world is loaded.
+        if (_vm.CurrentWorld == null)
+            return;
+
+        // Launch the advanced filter popup.
+        FilterWindow filterWindow = new(_vm);
+        filterWindow.ShowDialog();
     }
 }

--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -755,6 +755,15 @@ namespace TEdit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filter Clipboard.
+        /// </summary>
+        public static string menu_filter_filterclipboard {
+            get {
+                return ResourceManager.GetString("menu_filter_filterclipboard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to FilterMode.
         /// </summary>
         public static string menu_filter_filtermode {

--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -566,20 +566,20 @@ namespace TEdit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Expand World.
-        /// </summary>
-        public static string menu_edit_expand {
-            get {
-                return ResourceManager.GetString("menu_edit_expand", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Delete Selection.
         /// </summary>
         public static string menu_edit_delete {
             get {
                 return ResourceManager.GetString("menu_edit_delete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expand World.
+        /// </summary>
+        public static string menu_edit_expand {
+            get {
+                return ResourceManager.GetString("menu_edit_expand", resourceCulture);
             }
         }
         
@@ -697,6 +697,177 @@ namespace TEdit.Properties {
         public static string menu_file_update {
             get {
                 return ResourceManager.GetString("menu_file_update", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter.
+        /// </summary>
+        public static string menu_filter {
+            get {
+                return ResourceManager.GetString("menu_filter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Apply.
+        /// </summary>
+        public static string menu_filter_apply {
+            get {
+                return ResourceManager.GetString("menu_filter_apply", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to BackgroundMode.
+        /// </summary>
+        public static string menu_filter_backgroundmode {
+            get {
+                return ResourceManager.GetString("menu_filter_backgroundmode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string menu_filter_cancel {
+            get {
+                return ResourceManager.GetString("menu_filter_cancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom.
+        /// </summary>
+        public static string menu_filter_custom {
+            get {
+                return ResourceManager.GetString("menu_filter_custom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disable.
+        /// </summary>
+        public static string menu_filter_disable {
+            get {
+                return ResourceManager.GetString("menu_filter_disable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FilterMode.
+        /// </summary>
+        public static string menu_filter_filtermode {
+            get {
+                return ResourceManager.GetString("menu_filter_filtermode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grayscale.
+        /// </summary>
+        public static string menu_filter_grayscale {
+            get {
+                return ResourceManager.GetString("menu_filter_grayscale", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Liquids.
+        /// </summary>
+        public static string menu_filter_header_liquids {
+            get {
+                return ResourceManager.GetString("menu_filter_header_liquids", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tiles.
+        /// </summary>
+        public static string menu_filter_header_tiles {
+            get {
+                return ResourceManager.GetString("menu_filter_header_tiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Walls.
+        /// </summary>
+        public static string menu_filter_header_walls {
+            get {
+                return ResourceManager.GetString("menu_filter_header_walls", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wires.
+        /// </summary>
+        public static string menu_filter_header_wires {
+            get {
+                return ResourceManager.GetString("menu_filter_header_wires", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hide.
+        /// </summary>
+        public static string menu_filter_hide {
+            get {
+                return ResourceManager.GetString("menu_filter_hide", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Normal.
+        /// </summary>
+        public static string menu_filter_normal {
+            get {
+                return ResourceManager.GetString("menu_filter_normal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check All.
+        /// </summary>
+        public static string menu_filter_tab_check_all {
+            get {
+                return ResourceManager.GetString("menu_filter_tab_check_all", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        public static string menu_filter_tab_searchname {
+            get {
+                return ResourceManager.GetString("menu_filter_tab_searchname", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uncheck All.
+        /// </summary>
+        public static string menu_filter_tab_uncheck_all {
+            get {
+                return ResourceManager.GetString("menu_filter_tab_uncheck_all", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Advanced Filter.
+        /// </summary>
+        public static string menu_filter_title {
+            get {
+                return ResourceManager.GetString("menu_filter_title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Transparent.
+        /// </summary>
+        public static string menu_filter_transparent {
+            get {
+                return ResourceManager.GetString("menu_filter_transparent", resourceCulture);
             }
         }
         
@@ -1003,6 +1174,87 @@ namespace TEdit.Properties {
         public static string menu_toolbar_zoom_out {
             get {
                 return ResourceManager.GetString("menu_toolbar_zoom_out", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string menu_uveditor_cancel {
+            get {
+                return ResourceManager.GetString("menu_uveditor_cancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move All Frames.
+        /// </summary>
+        public static string menu_uveditor_moveallframes {
+            get {
+                return ResourceManager.GetString("menu_uveditor_moveallframes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move Amount (Frames).
+        /// </summary>
+        public static string menu_uveditor_moveamount {
+            get {
+                return ResourceManager.GetString("menu_uveditor_moveamount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        public static string menu_uveditor_ok {
+            get {
+                return ResourceManager.GetString("menu_uveditor_ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restore.
+        /// </summary>
+        public static string menu_uveditor_restore {
+            get {
+                return ResourceManager.GetString("menu_uveditor_restore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Selected Frames.
+        /// </summary>
+        public static string menu_uveditor_selectedframes {
+            get {
+                return ResourceManager.GetString("menu_uveditor_selectedframes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set Manual UV&apos;s To All.
+        /// </summary>
+        public static string menu_uveditor_setmanualuv {
+            get {
+                return ResourceManager.GetString("menu_uveditor_setmanualuv", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set Values.
+        /// </summary>
+        public static string menu_uveditor_setvalues {
+            get {
+                return ResourceManager.GetString("menu_uveditor_setvalues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UV Editor.
+        /// </summary>
+        public static string menu_uveditor_title {
+            get {
+                return ResourceManager.GetString("menu_uveditor_title", resourceCulture);
             }
         }
         

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -1362,4 +1362,88 @@
   <data name="wp_fixbackground" xml:space="preserve">
     <value>إصلاح فجوة الخلفية</value>
   </data>
+  <data name="menu_filter_header_tiles" xml:space="preserve">
+    <value>البلاط</value>
+  </data>
+  <data name="menu_filter_header_walls" xml:space="preserve">
+    <value>الجدران</value>
+  </data>
+  <data name="menu_filter_header_liquids" xml:space="preserve">
+    <value>السوائل</value>
+  </data>
+  <data name="menu_filter_header_wires" xml:space="preserve">
+    <value>الأسلاك</value>
+  </data>
+  <data name="menu_filter_tab_searchname" xml:space="preserve">
+    <value>اسم</value>
+  </data>
+  <data name="menu_filter_tab_check_all" xml:space="preserve">
+    <value>تحقق من الكل</value>
+  </data>
+  <data name="menu_filter_tab_uncheck_all" xml:space="preserve">
+    <value>قم بإلغاء تحديد الكل</value>
+  </data>
+  <data name="menu_filter_filtermode" xml:space="preserve">
+    <value>وضع التصفية</value>
+  </data>
+  <data name="menu_filter_backgroundmode" xml:space="preserve">
+    <value>وضع الخلفية</value>
+  </data>
+  <data name="menu_filter_hide" xml:space="preserve">
+    <value>يخفي</value>
+  </data>
+  <data name="menu_filter_grayscale" xml:space="preserve">
+    <value>تدرج الرمادي</value>
+  </data>
+  <data name="menu_filter_normal" xml:space="preserve">
+    <value>طبيعي</value>
+  </data>
+  <data name="menu_filter_transparent" xml:space="preserve">
+    <value>شفاف</value>
+  </data>
+  <data name="menu_filter_custom" xml:space="preserve">
+    <value>مخصص</value>
+  </data>
+  <data name="menu_filter_cancel" xml:space="preserve">
+    <value>يلغي</value>
+  </data>
+  <data name="menu_filter_disable" xml:space="preserve">
+    <value>إبطال</value>
+  </data>
+  <data name="menu_filter_apply" xml:space="preserve">
+    <value>يتقدم</value>
+  </data>
+  <data name="menu_uveditor_moveallframes" xml:space="preserve">
+    <value>نقل كافة الإطارات</value>
+  </data>
+  <data name="menu_uveditor_moveamount" xml:space="preserve">
+    <value>كمية النقل (الإطارات)</value>
+  </data>
+  <data name="menu_uveditor_setmanualuv" xml:space="preserve">
+    <value>تعيين الأشعة فوق البنفسجية اليدوية على الكل</value>
+  </data>
+  <data name="menu_uveditor_selectedframes" xml:space="preserve">
+    <value>إطارات مختارة</value>
+  </data>
+  <data name="menu_uveditor_setvalues" xml:space="preserve">
+    <value>تعيين القيم</value>
+  </data>
+  <data name="menu_uveditor_cancel" xml:space="preserve">
+    <value>إلغاء الأمر</value>
+  </data>
+  <data name="menu_uveditor_restore" xml:space="preserve">
+    <value>يعيد</value>
+  </data>
+  <data name="menu_uveditor_ok" xml:space="preserve">
+    <value>نعم</value>
+  </data>
+  <data name="menu_filter" xml:space="preserve">
+    <value>فلتر</value>
+  </data>
+  <data name="menu_filter_title" xml:space="preserve">
+    <value>مرشح متقدم</value>
+  </data>
+  <data name="menu_uveditor_title" xml:space="preserve">
+    <value>محرر الأشعة فوق البنفسجية</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -1446,4 +1446,7 @@
   <data name="menu_uveditor_title" xml:space="preserve">
     <value>محرر الأشعة فوق البنفسجية</value>
   </data>
+  <data name="menu_filter_filterclipboard" xml:space="preserve">
+    <value>تصفية الحافظة</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -1446,4 +1446,7 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="menu_uveditor_title" xml:space="preserve">
     <value>UV-Editor</value>
   </data>
+  <data name="menu_filter_filterclipboard" xml:space="preserve">
+    <value>Zwischenablage filtern</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -1362,4 +1362,88 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="wp_fixbackground" xml:space="preserve">
     <value>Hintergrundlücke schließen</value>
   </data>
+  <data name="menu_filter_header_tiles" xml:space="preserve">
+    <value>Fliesen</value>
+  </data>
+  <data name="menu_filter_header_walls" xml:space="preserve">
+    <value>Wände</value>
+  </data>
+  <data name="menu_filter_header_liquids" xml:space="preserve">
+    <value>Flüssigkeiten</value>
+  </data>
+  <data name="menu_filter_header_wires" xml:space="preserve">
+    <value>Drähte</value>
+  </data>
+  <data name="menu_filter_tab_searchname" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="menu_filter_tab_check_all" xml:space="preserve">
+    <value>Alle markieren</value>
+  </data>
+  <data name="menu_filter_tab_uncheck_all" xml:space="preserve">
+    <value>Deaktivieren Sie „Alle“.</value>
+  </data>
+  <data name="menu_filter_filtermode" xml:space="preserve">
+    <value>Filtermodus</value>
+  </data>
+  <data name="menu_filter_backgroundmode" xml:space="preserve">
+    <value>Hintergrundmodus</value>
+  </data>
+  <data name="menu_filter_hide" xml:space="preserve">
+    <value>Verstecken</value>
+  </data>
+  <data name="menu_filter_grayscale" xml:space="preserve">
+    <value>Graustufen</value>
+  </data>
+  <data name="menu_filter_normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="menu_filter_transparent" xml:space="preserve">
+    <value>Transparent</value>
+  </data>
+  <data name="menu_filter_custom" xml:space="preserve">
+    <value>Brauch</value>
+  </data>
+  <data name="menu_filter_cancel" xml:space="preserve">
+    <value>Stornieren</value>
+  </data>
+  <data name="menu_filter_disable" xml:space="preserve">
+    <value>Deaktivieren</value>
+  </data>
+  <data name="menu_filter_apply" xml:space="preserve">
+    <value>Anwenden</value>
+  </data>
+  <data name="menu_uveditor_moveallframes" xml:space="preserve">
+    <value>Alle Frames verschieben</value>
+  </data>
+  <data name="menu_uveditor_moveamount" xml:space="preserve">
+    <value>Bewegungsbetrag (Frames)</value>
+  </data>
+  <data name="menu_uveditor_setmanualuv" xml:space="preserve">
+    <value>Manuelle UVs auf alle setzen</value>
+  </data>
+  <data name="menu_uveditor_selectedframes" xml:space="preserve">
+    <value>Ausgewählte Frames</value>
+  </data>
+  <data name="menu_uveditor_setvalues" xml:space="preserve">
+    <value>Werte festlegen</value>
+  </data>
+  <data name="menu_uveditor_cancel" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="menu_uveditor_restore" xml:space="preserve">
+    <value>Wiederherstellen</value>
+  </data>
+  <data name="menu_uveditor_ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="menu_filter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="menu_filter_title" xml:space="preserve">
+    <value>Erweiterter Filter</value>
+  </data>
+  <data name="menu_uveditor_title" xml:space="preserve">
+    <value>UV-Editor</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -1362,4 +1362,88 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="wp_fixbackground" xml:space="preserve">
     <value>Fix Background Gap</value>
   </data>
+  <data name="menu_filter_header_tiles" xml:space="preserve">
+    <value>Tiles</value>
+  </data>
+  <data name="menu_filter_header_walls" xml:space="preserve">
+    <value>Walls</value>
+  </data>
+  <data name="menu_filter_header_liquids" xml:space="preserve">
+    <value>Liquids</value>
+  </data>
+  <data name="menu_filter_header_wires" xml:space="preserve">
+    <value>Wires</value>
+  </data>
+  <data name="menu_filter_tab_searchname" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="menu_filter_tab_check_all" xml:space="preserve">
+    <value>Check All</value>
+  </data>
+  <data name="menu_filter_tab_uncheck_all" xml:space="preserve">
+    <value>Uncheck All</value>
+  </data>
+  <data name="menu_filter_filtermode" xml:space="preserve">
+    <value>FilterMode</value>
+  </data>
+  <data name="menu_filter_backgroundmode" xml:space="preserve">
+    <value>BackgroundMode</value>
+  </data>
+  <data name="menu_filter_hide" xml:space="preserve">
+    <value>Hide</value>
+  </data>
+  <data name="menu_filter_grayscale" xml:space="preserve">
+    <value>Grayscale</value>
+  </data>
+  <data name="menu_filter_normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="menu_filter_transparent" xml:space="preserve">
+    <value>Transparent</value>
+  </data>
+  <data name="menu_filter_custom" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="menu_filter_cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="menu_filter_disable" xml:space="preserve">
+    <value>Disable</value>
+  </data>
+  <data name="menu_filter_apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="menu_uveditor_moveallframes" xml:space="preserve">
+    <value>Move All Frames</value>
+  </data>
+  <data name="menu_uveditor_moveamount" xml:space="preserve">
+    <value>Move Amount (Frames)</value>
+  </data>
+  <data name="menu_uveditor_setmanualuv" xml:space="preserve">
+    <value>Set Manual UV's To All</value>
+  </data>
+  <data name="menu_uveditor_selectedframes" xml:space="preserve">
+    <value>Selected Frames</value>
+  </data>
+  <data name="menu_uveditor_setvalues" xml:space="preserve">
+    <value>Set Values</value>
+  </data>
+  <data name="menu_uveditor_cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="menu_uveditor_restore" xml:space="preserve">
+    <value>Restore</value>
+  </data>
+  <data name="menu_uveditor_ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="menu_filter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="menu_filter_title" xml:space="preserve">
+    <value>Advanced Filter</value>
+  </data>
+  <data name="menu_uveditor_title" xml:space="preserve">
+    <value>UV Editor</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -1446,4 +1446,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_uveditor_title" xml:space="preserve">
     <value>UV Editor</value>
   </data>
+  <data name="menu_filter_filterclipboard" xml:space="preserve">
+    <value>Filter Clipboard</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.es-ES.resx
+++ b/src/TEdit/Properties/Language.es-ES.resx
@@ -1362,4 +1362,88 @@ Presione reintentar para elegir una nueva carpeta o cancelar para usar {0} como 
   <data name="wp_fixbackground" xml:space="preserve">
     <value>Arreglar fondo</value>
   </data>
+  <data name="menu_filter_header_tiles" xml:space="preserve">
+    <value>Azulejos</value>
+  </data>
+  <data name="menu_filter_header_walls" xml:space="preserve">
+    <value>Paredes</value>
+  </data>
+  <data name="menu_filter_header_liquids" xml:space="preserve">
+    <value>Líquidos</value>
+  </data>
+  <data name="menu_filter_header_wires" xml:space="preserve">
+    <value>alambres</value>
+  </data>
+  <data name="menu_filter_tab_searchname" xml:space="preserve">
+    <value>Nombre</value>
+  </data>
+  <data name="menu_filter_tab_check_all" xml:space="preserve">
+    <value>Verificar todo</value>
+  </data>
+  <data name="menu_filter_tab_uncheck_all" xml:space="preserve">
+    <value>Desmarcar todo</value>
+  </data>
+  <data name="menu_filter_filtermode" xml:space="preserve">
+    <value>Modo de filtro</value>
+  </data>
+  <data name="menu_filter_backgroundmode" xml:space="preserve">
+    <value>Modo de fondo</value>
+  </data>
+  <data name="menu_filter_hide" xml:space="preserve">
+    <value>Esconder</value>
+  </data>
+  <data name="menu_filter_grayscale" xml:space="preserve">
+    <value>Escala de grises</value>
+  </data>
+  <data name="menu_filter_normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="menu_filter_transparent" xml:space="preserve">
+    <value>Transparente</value>
+  </data>
+  <data name="menu_filter_custom" xml:space="preserve">
+    <value>Costumbre</value>
+  </data>
+  <data name="menu_filter_cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="menu_filter_disable" xml:space="preserve">
+    <value>Desactivar</value>
+  </data>
+  <data name="menu_filter_apply" xml:space="preserve">
+    <value>Aplicar</value>
+  </data>
+  <data name="menu_uveditor_moveallframes" xml:space="preserve">
+    <value>Mover todos los cuadros</value>
+  </data>
+  <data name="menu_uveditor_moveamount" xml:space="preserve">
+    <value>Cantidad de movimiento (fotogramas)</value>
+  </data>
+  <data name="menu_uveditor_setmanualuv" xml:space="preserve">
+    <value>Establecer UV manuales en todos</value>
+  </data>
+  <data name="menu_uveditor_selectedframes" xml:space="preserve">
+    <value>Marcos seleccionados</value>
+  </data>
+  <data name="menu_uveditor_setvalues" xml:space="preserve">
+    <value>Establecer valores</value>
+  </data>
+  <data name="menu_uveditor_cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="menu_uveditor_restore" xml:space="preserve">
+    <value>Restaurar</value>
+  </data>
+  <data name="menu_uveditor_ok" xml:space="preserve">
+    <value>DE ACUERDO</value>
+  </data>
+  <data name="menu_filter" xml:space="preserve">
+    <value>Filtrar</value>
+  </data>
+  <data name="menu_filter_title" xml:space="preserve">
+    <value>Filtro avanzado</value>
+  </data>
+  <data name="menu_uveditor_title" xml:space="preserve">
+    <value>Editor UV</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.es-ES.resx
+++ b/src/TEdit/Properties/Language.es-ES.resx
@@ -1446,4 +1446,7 @@ Presione reintentar para elegir una nueva carpeta o cancelar para usar {0} como 
   <data name="menu_uveditor_title" xml:space="preserve">
     <value>Editor UV</value>
   </data>
+  <data name="menu_filter_filterclipboard" xml:space="preserve">
+    <value>Filtrar portapapeles</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -1362,4 +1362,88 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="wp_fixbackground" xml:space="preserve">
     <value>Napraw lukę w tle</value>
   </data>
+  <data name="menu_filter_header_tiles" xml:space="preserve">
+    <value>Płytki</value>
+  </data>
+  <data name="menu_filter_header_walls" xml:space="preserve">
+    <value>Ściany</value>
+  </data>
+  <data name="menu_filter_header_liquids" xml:space="preserve">
+    <value>Płyny</value>
+  </data>
+  <data name="menu_filter_header_wires" xml:space="preserve">
+    <value>Przewody</value>
+  </data>
+  <data name="menu_filter_tab_searchname" xml:space="preserve">
+    <value>Nazwa</value>
+  </data>
+  <data name="menu_filter_tab_check_all" xml:space="preserve">
+    <value>Zaznacz wszystko</value>
+  </data>
+  <data name="menu_filter_tab_uncheck_all" xml:space="preserve">
+    <value>Odznacz wszystko</value>
+  </data>
+  <data name="menu_filter_filtermode" xml:space="preserve">
+    <value>Tryb filtra</value>
+  </data>
+  <data name="menu_filter_backgroundmode" xml:space="preserve">
+    <value>Tryb tła</value>
+  </data>
+  <data name="menu_filter_hide" xml:space="preserve">
+    <value>Ukrywać</value>
+  </data>
+  <data name="menu_filter_grayscale" xml:space="preserve">
+    <value>Skala szarości</value>
+  </data>
+  <data name="menu_filter_normal" xml:space="preserve">
+    <value>Normalna</value>
+  </data>
+  <data name="menu_filter_transparent" xml:space="preserve">
+    <value>Przezroczysty</value>
+  </data>
+  <data name="menu_filter_custom" xml:space="preserve">
+    <value>Zwyczaj</value>
+  </data>
+  <data name="menu_filter_cancel" xml:space="preserve">
+    <value>Anulować</value>
+  </data>
+  <data name="menu_filter_disable" xml:space="preserve">
+    <value>Wyłączyć</value>
+  </data>
+  <data name="menu_filter_apply" xml:space="preserve">
+    <value>Stosować</value>
+  </data>
+  <data name="menu_uveditor_moveallframes" xml:space="preserve">
+    <value>Przesuń wszystkie klatki</value>
+  </data>
+  <data name="menu_uveditor_moveamount" xml:space="preserve">
+    <value>Ilość ruchu (klatki)</value>
+  </data>
+  <data name="menu_uveditor_setmanualuv" xml:space="preserve">
+    <value>Ustaw ręczne UV dla wszystkich</value>
+  </data>
+  <data name="menu_uveditor_selectedframes" xml:space="preserve">
+    <value>Wybrane ramki</value>
+  </data>
+  <data name="menu_uveditor_setvalues" xml:space="preserve">
+    <value>Ustaw wartości</value>
+  </data>
+  <data name="menu_uveditor_cancel" xml:space="preserve">
+    <value>Anuluj</value>
+  </data>
+  <data name="menu_uveditor_restore" xml:space="preserve">
+    <value>Przywrócić</value>
+  </data>
+  <data name="menu_uveditor_ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="menu_filter" xml:space="preserve">
+    <value>Filtr</value>
+  </data>
+  <data name="menu_filter_title" xml:space="preserve">
+    <value>Zaawansowany filtr</value>
+  </data>
+  <data name="menu_uveditor_title" xml:space="preserve">
+    <value>Edytor UV</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -1446,4 +1446,7 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="menu_uveditor_title" xml:space="preserve">
     <value>Edytor UV</value>
   </data>
+  <data name="menu_filter_filterclipboard" xml:space="preserve">
+    <value>Filtruj schowek</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -1362,4 +1362,88 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="wp_fixbackground" xml:space="preserve">
     <value>Corrigir lacuna de plano de fundo</value>
   </data>
+  <data name="menu_filter_header_tiles" xml:space="preserve">
+    <value>Azulejos</value>
+  </data>
+  <data name="menu_filter_header_walls" xml:space="preserve">
+    <value>Paredes</value>
+  </data>
+  <data name="menu_filter_header_liquids" xml:space="preserve">
+    <value>Líquidos</value>
+  </data>
+  <data name="menu_filter_header_wires" xml:space="preserve">
+    <value>Fios</value>
+  </data>
+  <data name="menu_filter_tab_searchname" xml:space="preserve">
+    <value>Nome</value>
+  </data>
+  <data name="menu_filter_tab_check_all" xml:space="preserve">
+    <value>Verifique tudo</value>
+  </data>
+  <data name="menu_filter_tab_uncheck_all" xml:space="preserve">
+    <value>Desmarque tudo</value>
+  </data>
+  <data name="menu_filter_filtermode" xml:space="preserve">
+    <value>Modo Filtro</value>
+  </data>
+  <data name="menu_filter_backgroundmode" xml:space="preserve">
+    <value>Modo de fundo</value>
+  </data>
+  <data name="menu_filter_hide" xml:space="preserve">
+    <value>Esconder</value>
+  </data>
+  <data name="menu_filter_grayscale" xml:space="preserve">
+    <value>Tons de cinza</value>
+  </data>
+  <data name="menu_filter_normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="menu_filter_transparent" xml:space="preserve">
+    <value>Transparente</value>
+  </data>
+  <data name="menu_filter_custom" xml:space="preserve">
+    <value>Personalizado</value>
+  </data>
+  <data name="menu_filter_cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="menu_filter_disable" xml:space="preserve">
+    <value>Desativar</value>
+  </data>
+  <data name="menu_filter_apply" xml:space="preserve">
+    <value>Aplicar</value>
+  </data>
+  <data name="menu_uveditor_moveallframes" xml:space="preserve">
+    <value>Mover todos os quadros</value>
+  </data>
+  <data name="menu_uveditor_moveamount" xml:space="preserve">
+    <value>Quantidade de Movimento (Quadros)</value>
+  </data>
+  <data name="menu_uveditor_setmanualuv" xml:space="preserve">
+    <value>Definir UVs manuais para todos</value>
+  </data>
+  <data name="menu_uveditor_selectedframes" xml:space="preserve">
+    <value>Quadros selecionados</value>
+  </data>
+  <data name="menu_uveditor_setvalues" xml:space="preserve">
+    <value>Definir valores</value>
+  </data>
+  <data name="menu_uveditor_cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="menu_uveditor_restore" xml:space="preserve">
+    <value>Restaurar</value>
+  </data>
+  <data name="menu_uveditor_ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="menu_filter" xml:space="preserve">
+    <value>Filtro</value>
+  </data>
+  <data name="menu_filter_title" xml:space="preserve">
+    <value>Filtro Avançado</value>
+  </data>
+  <data name="menu_uveditor_title" xml:space="preserve">
+    <value>Editor UV</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -1446,4 +1446,7 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="menu_uveditor_title" xml:space="preserve">
     <value>Editor UV</value>
   </data>
+  <data name="menu_filter_filterclipboard" xml:space="preserve">
+    <value>Filtrar área de transferência</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -1365,4 +1365,88 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="wp_fixbackground" xml:space="preserve">
     <value>Fix Background Gap</value>
   </data>
+  <data name="menu_filter_header_tiles" xml:space="preserve">
+    <value>Tiles</value>
+  </data>
+  <data name="menu_filter_header_walls" xml:space="preserve">
+    <value>Walls</value>
+  </data>
+  <data name="menu_filter_header_liquids" xml:space="preserve">
+    <value>Liquids</value>
+  </data>
+  <data name="menu_filter_header_wires" xml:space="preserve">
+    <value>Wires</value>
+  </data>
+  <data name="menu_filter_tab_searchname" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="menu_filter_tab_check_all" xml:space="preserve">
+    <value>Check All</value>
+  </data>
+  <data name="menu_filter_tab_uncheck_all" xml:space="preserve">
+    <value>Uncheck All</value>
+  </data>
+  <data name="menu_filter_filtermode" xml:space="preserve">
+    <value>FilterMode</value>
+  </data>
+  <data name="menu_filter_backgroundmode" xml:space="preserve">
+    <value>BackgroundMode</value>
+  </data>
+  <data name="menu_filter_hide" xml:space="preserve">
+    <value>Hide</value>
+  </data>
+  <data name="menu_filter_grayscale" xml:space="preserve">
+    <value>Grayscale</value>
+  </data>
+  <data name="menu_filter_normal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="menu_filter_transparent" xml:space="preserve">
+    <value>Transparent</value>
+  </data>
+  <data name="menu_filter_custom" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="menu_filter_cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="menu_filter_disable" xml:space="preserve">
+    <value>Disable</value>
+  </data>
+  <data name="menu_filter_apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="menu_uveditor_moveallframes" xml:space="preserve">
+    <value>Move All Frames</value>
+  </data>
+  <data name="menu_uveditor_moveamount" xml:space="preserve">
+    <value>Move Amount (Frames)</value>
+  </data>
+  <data name="menu_uveditor_setmanualuv" xml:space="preserve">
+    <value>Set Manual UV's To All</value>
+  </data>
+  <data name="menu_uveditor_selectedframes" xml:space="preserve">
+    <value>Selected Frames</value>
+  </data>
+  <data name="menu_uveditor_setvalues" xml:space="preserve">
+    <value>Set Values</value>
+  </data>
+  <data name="menu_uveditor_cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="menu_uveditor_restore" xml:space="preserve">
+    <value>Restore</value>
+  </data>
+  <data name="menu_uveditor_ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="menu_filter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="menu_filter_title" xml:space="preserve">
+    <value>Advanced Filter</value>
+  </data>
+  <data name="menu_uveditor_title" xml:space="preserve">
+    <value>UV Editor</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -1449,4 +1449,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_uveditor_title" xml:space="preserve">
     <value>UV Editor</value>
   </data>
+  <data name="menu_filter_filterclipboard" xml:space="preserve">
+    <value>Filter Clipboard</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -1362,4 +1362,88 @@
   <data name="wp_fixbackground" xml:space="preserve">
     <value>Исправление фонового пробела</value>
   </data>
+  <data name="menu_filter_header_tiles" xml:space="preserve">
+    <value>Плитка</value>
+  </data>
+  <data name="menu_filter_header_walls" xml:space="preserve">
+    <value>Стены</value>
+  </data>
+  <data name="menu_filter_header_liquids" xml:space="preserve">
+    <value>Жидкости</value>
+  </data>
+  <data name="menu_filter_header_wires" xml:space="preserve">
+    <value>Провода</value>
+  </data>
+  <data name="menu_filter_tab_searchname" xml:space="preserve">
+    <value>Имя</value>
+  </data>
+  <data name="menu_filter_tab_check_all" xml:space="preserve">
+    <value>Проверить все</value>
+  </data>
+  <data name="menu_filter_tab_uncheck_all" xml:space="preserve">
+    <value>Снимите все флажки</value>
+  </data>
+  <data name="menu_filter_filtermode" xml:space="preserve">
+    <value>Режим фильтра</value>
+  </data>
+  <data name="menu_filter_backgroundmode" xml:space="preserve">
+    <value>Фоновый режим</value>
+  </data>
+  <data name="menu_filter_hide" xml:space="preserve">
+    <value>Скрывать</value>
+  </data>
+  <data name="menu_filter_grayscale" xml:space="preserve">
+    <value>Оттенки серого</value>
+  </data>
+  <data name="menu_filter_normal" xml:space="preserve">
+    <value>Нормальный</value>
+  </data>
+  <data name="menu_filter_transparent" xml:space="preserve">
+    <value>Прозрачный</value>
+  </data>
+  <data name="menu_filter_custom" xml:space="preserve">
+    <value>Обычай</value>
+  </data>
+  <data name="menu_filter_cancel" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="menu_filter_disable" xml:space="preserve">
+    <value>Запрещать</value>
+  </data>
+  <data name="menu_filter_apply" xml:space="preserve">
+    <value>Применять</value>
+  </data>
+  <data name="menu_uveditor_moveallframes" xml:space="preserve">
+    <value>Переместить все кадры</value>
+  </data>
+  <data name="menu_uveditor_moveamount" xml:space="preserve">
+    <value>Количество перемещений (кадров)</value>
+  </data>
+  <data name="menu_uveditor_setmanualuv" xml:space="preserve">
+    <value>Установить ручные УФ-фильтры для всех</value>
+  </data>
+  <data name="menu_uveditor_selectedframes" xml:space="preserve">
+    <value>Выбранные кадры</value>
+  </data>
+  <data name="menu_uveditor_setvalues" xml:space="preserve">
+    <value>Установить значения</value>
+  </data>
+  <data name="menu_uveditor_cancel" xml:space="preserve">
+    <value>Отменить</value>
+  </data>
+  <data name="menu_uveditor_restore" xml:space="preserve">
+    <value>Восстановить</value>
+  </data>
+  <data name="menu_uveditor_ok" xml:space="preserve">
+    <value>ХОРОШО</value>
+  </data>
+  <data name="menu_filter" xml:space="preserve">
+    <value>Фильтр</value>
+  </data>
+  <data name="menu_filter_title" xml:space="preserve">
+    <value>Расширенный фильтр</value>
+  </data>
+  <data name="menu_uveditor_title" xml:space="preserve">
+    <value>УФ-редактор</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -1446,4 +1446,7 @@
   <data name="menu_uveditor_title" xml:space="preserve">
     <value>УФ-редактор</value>
   </data>
+  <data name="menu_filter_filterclipboard" xml:space="preserve">
+    <value>Фильтровать буфер обмена</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1362,4 +1362,88 @@
   <data name="wp_fixbackground" xml:space="preserve">
     <value>修复背景间隙</value>
   </data>
+  <data name="menu_filter_header_tiles" xml:space="preserve">
+    <value>瓷砖</value>
+  </data>
+  <data name="menu_filter_header_walls" xml:space="preserve">
+    <value>墙壁</value>
+  </data>
+  <data name="menu_filter_header_liquids" xml:space="preserve">
+    <value>液体</value>
+  </data>
+  <data name="menu_filter_header_wires" xml:space="preserve">
+    <value>电线</value>
+  </data>
+  <data name="menu_filter_tab_searchname" xml:space="preserve">
+    <value>姓名</value>
+  </data>
+  <data name="menu_filter_tab_check_all" xml:space="preserve">
+    <value>检查全部</value>
+  </data>
+  <data name="menu_filter_tab_uncheck_all" xml:space="preserve">
+    <value>取消选中全部</value>
+  </data>
+  <data name="menu_filter_filtermode" xml:space="preserve">
+    <value>过滤模式</value>
+  </data>
+  <data name="menu_filter_backgroundmode" xml:space="preserve">
+    <value>背景模式</value>
+  </data>
+  <data name="menu_filter_hide" xml:space="preserve">
+    <value>隐藏</value>
+  </data>
+  <data name="menu_filter_grayscale" xml:space="preserve">
+    <value>灰度</value>
+  </data>
+  <data name="menu_filter_normal" xml:space="preserve">
+    <value>普通的</value>
+  </data>
+  <data name="menu_filter_transparent" xml:space="preserve">
+    <value>透明的</value>
+  </data>
+  <data name="menu_filter_custom" xml:space="preserve">
+    <value>风俗</value>
+  </data>
+  <data name="menu_filter_cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="menu_filter_disable" xml:space="preserve">
+    <value>禁用</value>
+  </data>
+  <data name="menu_filter_apply" xml:space="preserve">
+    <value>申请</value>
+  </data>
+  <data name="menu_uveditor_moveallframes" xml:space="preserve">
+    <value>移动所有帧</value>
+  </data>
+  <data name="menu_uveditor_moveamount" xml:space="preserve">
+    <value>移动量（帧）</value>
+  </data>
+  <data name="menu_uveditor_setmanualuv" xml:space="preserve">
+    <value>将手动 UV 设置为全部</value>
+  </data>
+  <data name="menu_uveditor_selectedframes" xml:space="preserve">
+    <value>选定的帧</value>
+  </data>
+  <data name="menu_uveditor_setvalues" xml:space="preserve">
+    <value>设定值</value>
+  </data>
+  <data name="menu_uveditor_cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="menu_uveditor_restore" xml:space="preserve">
+    <value>恢复</value>
+  </data>
+  <data name="menu_uveditor_ok" xml:space="preserve">
+    <value>好的</value>
+  </data>
+  <data name="menu_filter" xml:space="preserve">
+    <value>筛选</value>
+  </data>
+  <data name="menu_filter_title" xml:space="preserve">
+    <value>高级过滤器</value>
+  </data>
+  <data name="menu_uveditor_title" xml:space="preserve">
+    <value>紫外线编辑器</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1446,4 +1446,7 @@
   <data name="menu_uveditor_title" xml:space="preserve">
     <value>紫外线编辑器</value>
   </data>
+  <data name="menu_filter_filterclipboard" xml:space="preserve">
+    <value>过滤剪贴板</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1402,7 +1402,7 @@
     <value>透明的</value>
   </data>
   <data name="menu_filter_custom" xml:space="preserve">
-    <value>风俗</value>
+    <value>自定义</value>
   </data>
   <data name="menu_filter_cancel" xml:space="preserve">
     <value>取消</value>

--- a/src/TEdit/Render/PixelMap.cs
+++ b/src/TEdit/Render/PixelMap.cs
@@ -1,8 +1,11 @@
 ﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Collections.Generic;
 using TEdit.Common;
 using TEdit.Configuration;
 using TEdit.Terraria;
+using TEdit.ViewModel;
 
 namespace TEdit.Render;
 
@@ -158,9 +161,9 @@ public static class PixelMap
 
     #endregion
 
-
-
-    public static Color GetTileColor(Tile tile, Color background, bool showWall = true, bool showTile = true, bool showLiquid = true, bool showRedWire = true, bool showBlueWire = true, bool showGreenWire = true, bool showYellowWire = true, bool showCoatings = true)
+    public static Color GetTileColor(Tile tile, Color background, bool showWall = true, bool showTile = true, bool showLiquid = true, bool showRedWire = true, bool showBlueWire = true, bool showGreenWire = true, bool showYellowWire = true, bool showCoatings = true,
+        bool wallGrayscale = false, bool tileGrayscale = false, bool liquidGrayscale = false,
+        bool redWireGrayscale = false, bool blueWireGrayscale = false, bool greenWireGrayscale = false, bool yellowWireGrayscale = false)
     {
         var c = new Color(0, 0, 0, 0);
 
@@ -218,6 +221,9 @@ public static class PixelMap
                 c.G = (byte)(c.G * (brightness / 255.0f));
                 c.B = (byte)(c.B * (brightness / 255.0f));
             }
+
+            if (wallGrayscale)
+                c = GrayscaleManager.ToGrayscale(c);
         }
         else
             c = background;
@@ -271,6 +277,9 @@ public static class PixelMap
                 c.G = (byte)(c.G * (brightness / 255.0f));
                 c.B = (byte)(c.B * (brightness / 255.0f));
             }
+
+            if (tileGrayscale)
+                c = GrayscaleManager.ToGrayscale(c);
         }
 
         if (tile.LiquidAmount > 0 && showLiquid)
@@ -279,23 +288,38 @@ public static class PixelMap
             else if (tile.LiquidType == LiquidType.Honey) c = c.AlphaBlend(WorldConfiguration.GlobalColors["Honey"]);
             else if (tile.LiquidType == LiquidType.Shimmer) c = c.AlphaBlend(WorldConfiguration.GlobalColors["Shimmer"]);
             else c = c.AlphaBlend(WorldConfiguration.GlobalColors["Water"]);
+
+            if (liquidGrayscale)
+                c = GrayscaleManager.ToGrayscale(c);
         }
 
         if (tile.WireRed && showRedWire)
         {
             c = c.AlphaBlend(WorldConfiguration.GlobalColors["Wire"]);
-        }
-        if (tile.WireGreen && showGreenWire)
-        {
-            c = c.AlphaBlend(WorldConfiguration.GlobalColors["Wire2"]);
+
+            if (redWireGrayscale)
+                c = GrayscaleManager.ToGrayscale(c);
         }
         if (tile.WireBlue && showBlueWire)
         {
             c = c.AlphaBlend(WorldConfiguration.GlobalColors["Wire1"]);
+
+            if (blueWireGrayscale)
+                c = GrayscaleManager.ToGrayscale(c);
+        }
+        if (tile.WireGreen && showGreenWire)
+        {
+            c = c.AlphaBlend(WorldConfiguration.GlobalColors["Wire2"]);
+
+            if (greenWireGrayscale)
+                c = GrayscaleManager.ToGrayscale(c);
         }
         if (tile.WireYellow && showYellowWire)
         {
             c = c.AlphaBlend(WorldConfiguration.GlobalColors["Wire3"]);
+
+            if (yellowWireGrayscale)
+                c = GrayscaleManager.ToGrayscale(c);
         }
 
         return c;

--- a/src/TEdit/Render/RenderMiniMap.cs
+++ b/src/TEdit/Render/RenderMiniMap.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using TEdit.Terraria;
+using TEdit.ViewModel;
 
 namespace TEdit.Render;
 
@@ -10,7 +11,7 @@ public class RenderMiniMap
 {
     public static int Resolution { get; set; } = 20;
 
-    public static WriteableBitmap Render(World w)
+    public static WriteableBitmap Render(World w, bool useFilter = false)
     {
         // scale the minimap appropriatly
         // UI is 300x100 px
@@ -21,11 +22,16 @@ public class RenderMiniMap
 
         WriteableBitmap bmp = new WriteableBitmap(w.TilesWide / Resolution, w.TilesHigh / Resolution, 96, 96, PixelFormats.Bgra32, null);
 
-        UpdateMinimap(w, ref bmp);
+        // OPTION: This can simply be combined with 'UpdateMinimap'.
+        if (useFilter)
+            UpdateMinimapUsingFilter(w, ref bmp);
+        else
+            UpdateMinimap(w, ref bmp);
 
         return bmp;
     }
 
+    // Normal function.
     public static void UpdateMinimap(World w, ref WriteableBitmap bmp)
     {
         bmp.Lock();
@@ -43,6 +49,96 @@ public class RenderMiniMap
                 int worldY = y * Resolution;
 
                 pixels[i] = XnaColorToWindowsInt(PixelMap.GetTileColor(w.Tiles[worldX, worldY], Microsoft.Xna.Framework.Color.Transparent));
+            }
+        }
+        bmp.AddDirtyRect(new Int32Rect(0, 0, bmp.PixelWidth, bmp.PixelHeight));
+        bmp.Unlock();
+    }
+    public static void UpdateMinimapUsingFilter(World w, ref WriteableBitmap bmp)
+    {
+        bmp.Lock();
+        unsafe
+        {
+            int pixelCount = bmp.PixelHeight * bmp.PixelWidth;
+            var pixels = (int*)bmp.BackBuffer;
+
+            for (int i = 0; i < pixelCount; i++)
+            {
+                int x = i % bmp.PixelWidth;
+                int y = i / bmp.PixelWidth;
+
+                int worldX = x * Resolution;
+                int worldY = y * Resolution;
+
+                // Define defualt bools.
+                Microsoft.Xna.Framework.Color curBgColor = Microsoft.Xna.Framework.Color.Transparent;
+
+                bool showWalls      = true;
+                bool showTiles      = true;
+                bool showLiquids    = true;
+                bool showRedWire    = true;
+                bool showBlueWire   = true;
+                bool showGreenWire  = true;
+                bool showYellowWire = true;
+
+                bool wallGrayscale       = false;
+                bool tileGrayscale       = false;
+                bool liquidGrayscale     = false;
+                bool redWireGrayscale    = false;
+                bool blueWireGrayscale   = false;
+                bool greenWireGrayscale  = false;
+                bool yellowWireGrayscale = false;
+
+                // Test the the filter for walls, tiles, liquids, and wires. 
+                if (FilterManager.WallIsNotAllowed(w.Tiles[worldX, worldY].Wall))                                                       // Check if this wall is not in the list.
+                    if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showWalls = false;                            // Hide walls not in list.
+                    else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) wallGrayscale = true;               // Grayscale walls not in list.
+
+                if (FilterManager.TileIsNotAllowed(w.Tiles[worldX, worldY].Type))                                                       // Check if this block is not in the list.
+                    if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showTiles = false;                            // Hide blocks not in list.
+                    else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) tileGrayscale = true;               // Grayscale blocks not in list.
+
+                if (FilterManager.LiquidIsNotAllowed(w.Tiles[worldX, worldY].LiquidType))                                               // Check if this liquid is not in the list.
+                    if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showLiquids = false;                          // Hide liquids not in list.
+                    else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) liquidGrayscale = true;             // Grayscale liquids not in list.
+
+                // Use the HasWire bool to save on processing speed.
+                if (w.Tiles[worldX, worldY].HasWire)
+                {
+                    if (w.Tiles[worldX, worldY].WireRed)                                                                                // Check if this tile contains a red wire.
+                        if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Red))                                                 // Check if this wire is not in the list.
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showRedWire = false;                  // Hide wires not in list.
+                            else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) redWireGrayscale = true;    // Grayscale wires not in list.
+
+                    if (w.Tiles[worldX, worldY].WireBlue)                                                                               // Check if this tile contains a red wire.
+                        if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Blue))                                                // Check if this wire is not in the list.
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showBlueWire = false;                 // Hide wires not in list.
+                            else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) blueWireGrayscale = true;   // Grayscale wires not in list.
+
+                    if (w.Tiles[worldX, worldY].WireGreen)                                                                              // Check if this tile contains a red wire.
+                        if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Green))                                               // Check if this wire is not in the list.
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showGreenWire = false;                // Hide wires not in list.
+                            else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) greenWireGrayscale = true;  // Grayscale wires not in list.
+
+                    if (w.Tiles[worldX, worldY].WireYellow)                                                                             // Check if this tile contains a red wire.
+                        if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Yellow))                                              // Check if this wire is not in the list.
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showYellowWire = false;               // Hide wires not in list.
+                            else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) yellowWireGrayscale = true; // Grayscale wires not in list.
+                }
+
+                // Test the the filter for custom background (solid color) mode.
+                if (FilterManager.CurrentBackgroundMode == FilterManager.BackgroundMode.Transparent)
+                    curBgColor = Microsoft.Xna.Framework.Color.Transparent;
+                else if (FilterManager.CurrentBackgroundMode == FilterManager.BackgroundMode.Custom)
+                    curBgColor = FilterManager.BackgroundModeCustomColor;
+
+                // Define the color based on the filter results.
+                Microsoft.Xna.Framework.Color color = PixelMap.GetTileColor(w.Tiles[worldX, worldY], curBgColor, showWalls, showTiles, showLiquids, showRedWire, showBlueWire, showGreenWire, showYellowWire,
+                        wallGrayscale: wallGrayscale, tileGrayscale: tileGrayscale, liquidGrayscale: liquidGrayscale,
+                        redWireGrayscale: redWireGrayscale, blueWireGrayscale: blueWireGrayscale, greenWireGrayscale: greenWireGrayscale, yellowWireGrayscale: yellowWireGrayscale);
+
+                // Set the pixel data.
+                pixels[i] = XnaColorToWindowsInt(color);
             }
         }
         bmp.AddDirtyRect(new Int32Rect(0, 0, bmp.PixelWidth, bmp.PixelHeight));

--- a/src/TEdit/View/Popups/FilterWindow.xaml
+++ b/src/TEdit/View/Popups/FilterWindow.xaml
@@ -1,0 +1,194 @@
+<Window x:Class="TEdit.View.Popups.FilterWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:config="clr-namespace:TEdit.Configuration;assembly=TEdit.Configuration"
+        xmlns:filter="clr-namespace:TEdit.ViewModel"
+        xmlns:local="clr-namespace:TEdit.View.Popups"
+        xmlns:p="clr-namespace:TEdit.Properties"
+        Title="{x:Static p:Language.menu_filter_title}"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="ToolWindow"
+        ResizeMode="NoResize"
+        Background="{StaticResource WindowBackgroundBrush}"
+        Foreground="{DynamicResource TextBrush}"
+        Icon="/TEdit;component/Images/tedit.ico"
+        Height="500" Width="600">
+
+    <Window.Resources>
+        <filter:EnumToBooleanConverter x:Key="EnumToBooleanConverter"/>
+    </Window.Resources>
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TabControl Grid.Row="0">
+            <!-- TILES -->
+            <TabItem Header="{x:Static p:Language.menu_filter_header_tiles}">
+                <StackPanel Margin="10,0,10,0" Height="365">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5" VerticalAlignment="Center">
+                        <!-- <TextBlock Text="Name:" Foreground="Snow" VerticalAlignment="Center" Margin="0,0,5,0"/> -->
+                        <TextBlock Foreground="Snow" VerticalAlignment="Center" Margin="0,0,5,0">
+                            <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_filter_tab_searchname)" /></MultiBinding></TextBlock.Text>
+                        </TextBlock>
+                        <TextBox Width="320" Margin="0,0,10,0" VerticalAlignment="Center" Text="{Binding TileSearchText, UpdateSourceTrigger=PropertyChanged}"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_check_all}" Width="80" Margin="0,0,5,0" Click="TileCheckAll_Click"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_uncheck_all}" Width="90" Click="TileUncheckAll_Click"/>
+                    </StackPanel>
+                    <ListBox ItemsSource="{Binding FilteredTileItems}" Height="335">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}" Content="{Binding Name}"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+            </TabItem>
+            <!-- WALLS -->
+            <TabItem Header="{x:Static p:Language.menu_filter_header_walls}">
+                <StackPanel Margin="10,0,10,0" Height="365">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5" VerticalAlignment="Center">
+                        <TextBlock Foreground="Snow" VerticalAlignment="Center" Margin="0,0,5,0">
+                            <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_filter_tab_searchname)" /></MultiBinding></TextBlock.Text>
+                        </TextBlock>
+                        <TextBox Width="320"  Margin="0,0,10,0" VerticalAlignment="Center" Text="{Binding WallSearchText, UpdateSourceTrigger=PropertyChanged}"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_check_all}" Width="80" Margin="0,0,5,0" Click="WallCheckAll_Click"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_uncheck_all}" Width="90" Click="WallUncheckAll_Click"/>
+                    </StackPanel>
+                    <ListBox ItemsSource="{Binding FilteredWallItems}" Height="335">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}" Content="{Binding Name}"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+            </TabItem>
+            <!-- LIQUIDS -->
+            <TabItem Header="{x:Static p:Language.menu_filter_header_liquids}">
+                <StackPanel Margin="10,0,10,0" Height="365">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5" VerticalAlignment="Center">
+                        <TextBlock Foreground="Snow" VerticalAlignment="Center" Margin="0,0,5,0">
+                            <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_filter_tab_searchname)" /></MultiBinding></TextBlock.Text>
+                        </TextBlock>
+                        <TextBox Width="320" Margin="0,0,10,0" VerticalAlignment="Center" Text="{Binding LiquidSearchText, UpdateSourceTrigger=PropertyChanged}"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_check_all}" Width="80" Margin="0,0,5,0" Click="LiquidCheckAll_Click"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_uncheck_all}" Width="90" Click="LiquidUncheckAll_Click"/>
+                    </StackPanel>
+                    <ListBox ItemsSource="{Binding FilteredLiquidItems}" Height="335">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}" Content="{Binding Name}"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+            </TabItem>
+            <!-- WIRES -->
+            <TabItem Header="{x:Static p:Language.menu_filter_header_wires}">
+                <StackPanel Margin="10,0,10,0" Height="365">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5" VerticalAlignment="Center">
+                        <TextBlock Foreground="Snow" VerticalAlignment="Center" Margin="0,0,5,0">
+                            <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_filter_tab_searchname)" /></MultiBinding></TextBlock.Text>
+                        </TextBlock>
+                        <TextBox Width="320" Margin="0,0,10,0" VerticalAlignment="Center" Text="{Binding WireSearchText, UpdateSourceTrigger=PropertyChanged}"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_check_all}" Width="80" Margin="0,0,5,0" Click="WireCheckAll_Click"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_uncheck_all}" Width="90" Click="WireUncheckAll_Click"/>
+                    </StackPanel>
+                    <ListBox ItemsSource="{Binding FilteredWireItems}" Height="335">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}" Content="{Binding Name}"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+            </TabItem>
+        </TabControl>
+      
+        <!-- Bottom Buttons & Modes -->
+        <Grid Grid.Row="1" Margin="0,5,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="2"/>       <!-- Spacer row, 2px high -->
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>  <!-- FilterMode or BackgroundMode label -->
+                <ColumnDefinition Width="Auto"/>  <!-- 1st radio -->
+                <ColumnDefinition Width="10"/>    <!-- Spacer -->
+                <ColumnDefinition Width="Auto"/>  <!-- 2nd radio -->
+                <ColumnDefinition Width="10"/>    <!-- Spacer -->
+                <ColumnDefinition Width="Auto"/>  <!-- 3rd radio -->
+                <ColumnDefinition Width="5"/>     <!-- Spacer -->
+                <ColumnDefinition Width="Auto"/>  <!-- 4th radio -->
+                <ColumnDefinition Width="Auto"/>  <!-- Optional: color picker -->
+                <ColumnDefinition Width="*" />    <!-- Filler -->
+                <ColumnDefinition Width="Auto"/>  <!-- Cancel/Apply -->
+            </Grid.ColumnDefinitions>
+
+            <!-- FIRST ROW: FilterMode -->
+            <TextBlock Foreground="Snow" VerticalAlignment="Center" Margin="0,0,8,0" Grid.Row="0" Grid.Column="0">
+                <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_filter_filtermode)" /></MultiBinding></TextBlock.Text>
+            </TextBlock>
+            <RadioButton x:Name="HideRadio" Content="{x:Static p:Language.menu_filter_hide}" GroupName="FilterMode" Grid.Row="0" Grid.Column="1"
+                         VerticalAlignment="Center"
+                         IsChecked="{Binding Path=PendingFilterMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Hide, Mode=TwoWay}"/>
+            <RadioButton x:Name="GrayscaleRadio" Content="{x:Static p:Language.menu_filter_grayscale}" GroupName="FilterMode" Grid.Row="0" Grid.Column="3"
+                         VerticalAlignment="Center"
+                         IsChecked="{Binding Path=PendingFilterMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Grayscale, Mode=TwoWay}"/>
+
+            <!-- SECOND ROW: This is used for a spacer -->
+            <StackPanel Grid.Row="1"/>
+
+            <!-- THIRD ROW: BackgroundMode, Custom, PickColor, Cancel, Apply -->
+            <TextBlock Foreground="Snow" VerticalAlignment="Center" Margin="0,0,8,0" Grid.Row="2" Grid.Column="0">
+                <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_filter_backgroundmode)" /></MultiBinding></TextBlock.Text>
+            </TextBlock>
+            <RadioButton x:Name="NormalRadio" Content="{x:Static p:Language.menu_filter_normal}" GroupName="BackgroundMode" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center"
+                         IsChecked="{Binding Path=PendingBackgroundMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Normal, Mode=TwoWay}"/>
+            <RadioButton x:Name="TransparentRadio" Content="{x:Static p:Language.menu_filter_transparent}" GroupName="BackgroundMode" Grid.Row="2" Grid.Column="3" VerticalAlignment="Center"
+                         IsChecked="{Binding Path=PendingBackgroundMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Transparent, Mode=TwoWay}"/>
+            <RadioButton x:Name="CustomRadio"
+                         Content="{x:Static p:Language.menu_filter_custom}"
+                         GroupName="BackgroundMode"
+                         Grid.Row="2"
+                         Grid.Column="5"
+                         VerticalAlignment="Center"
+                         IsChecked="{Binding Path=PendingBackgroundMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Custom, Mode=TwoWay}">
+                <RadioButton.Style>
+                    <Style TargetType="RadioButton" BasedOn="{StaticResource {x:Type RadioButton}}">
+                        <Setter Property="Foreground" Value="Snow"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsChecked, ElementName=CustomRadio}" Value="True">
+                                <Setter Property="Foreground">
+                                    <Setter.Value>
+                                        <SolidColorBrush Color="{Binding CustomBackgroundColor}"/>
+                                    </Setter.Value>
+                                </Setter>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </RadioButton.Style>
+            </RadioButton>
+            <Button Content="..."
+                    x:Name="PickColorButton"
+                    Grid.Row="2" Grid.Column="7"
+                    IsEnabled="{Binding IsChecked, ElementName=CustomRadio}"
+                    ToolTip="Pick Color"
+                    Width="28"
+                    Height="20"
+                    VerticalAlignment="Center"
+                    Click="PickCustomColor_Click"/>
+          
+            <!-- Buttons aligned to the right, spanning rows -->
+            <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.RowSpan="3" Grid.Column="10" HorizontalAlignment="Right">
+                <Button Content="{x:Static p:Language.menu_filter_cancel}" Width="55" Margin="0,0,8,0" Click="Cancel_Click"/>
+                <Button Content="{x:Static p:Language.menu_filter_disable}" Width="55" Margin="0,0,8,0" Click="Disable_Click"/>
+                <Button Content="{x:Static p:Language.menu_filter_apply}" Width="55" Margin="0,0,0,0" Click="ApplyFilter_Click"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Window>

--- a/src/TEdit/View/Popups/FilterWindow.xaml
+++ b/src/TEdit/View/Popups/FilterWindow.xaml
@@ -184,6 +184,9 @@
                     Click="PickCustomColor_Click"/>
           
             <!-- Buttons aligned to the right, spanning rows -->
+            <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.RowSpan="1" Grid.Column="10" HorizontalAlignment="Left">
+                <CheckBox x:Name="FilterClipboardCheckBox" Content="{x:Static p:Language.menu_filter_filterclipboard}" VerticalAlignment="Bottom" IsChecked="{Binding IsFilterClipboardEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
             <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.RowSpan="3" Grid.Column="10" HorizontalAlignment="Right">
                 <Button Content="{x:Static p:Language.menu_filter_cancel}" Width="55" Margin="0,0,8,0" Click="Cancel_Click"/>
                 <Button Content="{x:Static p:Language.menu_filter_disable}" Width="55" Margin="0,0,8,0" Click="Disable_Click"/>

--- a/src/TEdit/View/Popups/FilterWindow.xaml.cs
+++ b/src/TEdit/View/Popups/FilterWindow.xaml.cs
@@ -39,6 +39,10 @@ namespace TEdit.View.Popups
         private string _wireSearchText;
         public string WireSearchText { get => _wireSearchText; set { _wireSearchText = value; OnPropertyChanged(nameof(WireSearchText)); FilterWireItems(); } }
 
+        // Checkboxes
+        private bool _isFilterClipboardEnabled;
+        public bool IsFilterClipboardEnabled { get => _isFilterClipboardEnabled; set { _isFilterClipboardEnabled = value; OnPropertyChanged(nameof(IsFilterClipboardEnabled)); } }
+
         // RadioButtons
         private FilterManager.FilterMode _pendingFilterMode;
         private FilterManager.BackgroundMode _pendingBackgroundMode;
@@ -111,6 +115,9 @@ namespace TEdit.View.Popups
             // Synchronize color fields with FilterManager for persistence.
             CustomModeColor = FromXnaColor(FilterManager.FilterModeCustomColor);
             CustomBackgroundColor = FromXnaColor(FilterManager.BackgroundModeCustomColor);
+
+            // Sync and toggle filter clipboard checkbox with the actual value.
+            IsFilterClipboardEnabled = FilterManager.FilerClipboard;
 
             // Sync pending filter / background modes with the actual value.
             PendingFilterMode = FilterManager.CurrentFilterMode;
@@ -233,8 +240,15 @@ namespace TEdit.View.Popups
                 FilterManager.SelectedWireNames.Add(wire.Name);
             }
 
-            #region REMOVED: Toggle UI Wire Layers
+            #region Toggle UI Wire Layers
 
+            // Toggle on each UI wire selection if hidden and choosen.
+            if (!_wvm.ShowRedWires    && FilterManager.WireIsAllowed(FilterManager.WireType.Red)) _wvm.ShowRedWires = true;
+            if (!_wvm.ShowBlueWires   && FilterManager.WireIsAllowed(FilterManager.WireType.Blue)) _wvm.ShowBlueWires = true;
+            if (!_wvm.ShowGreenWires  && FilterManager.WireIsAllowed(FilterManager.WireType.Green)) _wvm.ShowGreenWires = true;
+            if (!_wvm.ShowYellowWires && FilterManager.WireIsAllowed(FilterManager.WireType.Yellow)) _wvm.ShowYellowWires = true;
+
+            #region REMOVED: Toggle UI wire layers based on the wire selections.
             /*
             // Wires.
             FilterManager.ClearWireFilters();
@@ -280,6 +294,7 @@ namespace TEdit.View.Popups
                 }
             }
             */
+            #endregion
 
             #endregion
 
@@ -308,6 +323,9 @@ namespace TEdit.View.Popups
                 }
             }
             FilterManager.BackgroundModeCustomColor = ToXnaColor(CustomBackgroundColor);
+
+            // Update the filter clipboard preferences.
+            FilterManager.FilerClipboard = IsFilterClipboardEnabled;
 
             // Schedule RedrawMap to run after this method (and window) closes.
             // This eliminates the akward wait time for redraw before closing.

--- a/src/TEdit/View/Popups/FilterWindow.xaml.cs
+++ b/src/TEdit/View/Popups/FilterWindow.xaml.cs
@@ -189,7 +189,7 @@ namespace TEdit.View.Popups
             GrayscaleManager.GrayscaleCache.Clear();
 
             // Schedule RedrawMap to run after this method (and window) closes.
-            // This eliminates the akward wait time for redraw before closing.
+            // This eliminates the awkward wait time for redraw before closing.
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 RedrawMap(true);

--- a/src/TEdit/View/Popups/FilterWindow.xaml.cs
+++ b/src/TEdit/View/Popups/FilterWindow.xaml.cs
@@ -1,0 +1,360 @@
+using System.Collections.ObjectModel;
+using System.Windows.Controls;
+using System.ComponentModel;
+using System.Windows.Media;
+using TEdit.Configuration; // For WorldConfiguration.TileBricks, WallProperties, LiquidType.
+using TEdit.ViewModel;     // For FilterItem, FilterManager, etc.
+using System.Windows;
+using System.Linq;
+using System;
+
+namespace TEdit.View.Popups
+{
+    public partial class FilterWindow : Window, INotifyPropertyChanged
+    {
+        // WVM
+        private readonly WorldViewModel _wvm;
+
+        // Tiles
+        public ObservableCollection<FilterCheckItem> TileItems { get; } = [];
+        public ObservableCollection<FilterCheckItem> FilteredTileItems { get; } = [];
+        private string _tileSearchText;
+        public string TileSearchText { get => _tileSearchText; set { _tileSearchText = value; OnPropertyChanged(nameof(TileSearchText)); FilterTileItems(); } }
+
+        // Walls
+        public ObservableCollection<FilterCheckItem> WallItems { get; } = [];
+        public ObservableCollection<FilterCheckItem> FilteredWallItems { get; } = [];
+        private string _wallSearchText;
+        public string WallSearchText { get => _wallSearchText; set { _wallSearchText = value; OnPropertyChanged(nameof(WallSearchText)); FilterWallItems(); } }
+
+        // Liquids
+        public ObservableCollection<FilterCheckItem> LiquidItems { get; } = [];
+        public ObservableCollection<FilterCheckItem> FilteredLiquidItems { get; } = [];
+        private string _liquidSearchText;
+        public string LiquidSearchText { get => _liquidSearchText; set { _liquidSearchText = value; OnPropertyChanged(nameof(LiquidSearchText)); FilterLiquidItems(); } }
+
+        // Wires
+        public ObservableCollection<FilterCheckItem> WireItems { get; } = [];
+        public ObservableCollection<FilterCheckItem> FilteredWireItems { get; } = [];
+        private string _wireSearchText;
+        public string WireSearchText { get => _wireSearchText; set { _wireSearchText = value; OnPropertyChanged(nameof(WireSearchText)); FilterWireItems(); } }
+
+        // RadioButtons
+        private FilterManager.FilterMode _pendingFilterMode;
+        private FilterManager.BackgroundMode _pendingBackgroundMode;
+
+        public FilterManager.FilterMode PendingFilterMode { get => _pendingFilterMode; set { _pendingFilterMode = value; OnPropertyChanged(nameof(PendingFilterMode)); } }
+        public FilterManager.FilterMode CurrentFilterMode { get => FilterManager.CurrentFilterMode; set { if (FilterManager.CurrentFilterMode != value) { FilterManager.CurrentFilterMode = value; OnPropertyChanged(nameof(CurrentFilterMode)); } } }
+        public FilterManager.BackgroundMode PendingBackgroundMode { get => _pendingBackgroundMode; set { _pendingBackgroundMode = value; OnPropertyChanged(nameof(PendingBackgroundMode)); } }
+        public FilterManager.BackgroundMode CurrentBackgroundMode { get => FilterManager.CurrentBackgroundMode; set { if (FilterManager.CurrentBackgroundMode != value) { FilterManager.CurrentBackgroundMode = value; OnPropertyChanged(nameof(CurrentBackgroundMode)); } } }
+
+        // This will hold the selected color for custom modes.
+        private Color _customModeColor       = Colors.Transparent;
+        private Color _customBackgroundColor = Colors.Lime;
+        public Color CustomModeColor { get => _customModeColor; set { if (_customModeColor != value) { _customModeColor = value; OnPropertyChanged(nameof(CustomModeColor)); } } }
+        public Color CustomBackgroundColor { get => _customBackgroundColor; set { if (_customBackgroundColor != value) { _customBackgroundColor = value; OnPropertyChanged(nameof(CustomBackgroundColor)); } } }
+
+        // Helper for quickly converting Windows.Media.Color to Xna.Framework.Color.
+        public static Microsoft.Xna.Framework.Color ToXnaColor(System.Windows.Media.Color c) => new(c.R, c.G, c.B, c.A);
+        public static System.Windows.Media.Color FromXnaColor(Microsoft.Xna.Framework.Color c) => System.Windows.Media.Color.FromArgb(c.A, c.R, c.G, c.B);
+        public static Microsoft.Xna.Framework.Color ToGrayscale(Microsoft.Xna.Framework.Color c)
+        {
+            // Calculate luminance
+            byte gray = (byte)(c.R * 0.299 + c.G * 0.587 + c.B * 0.114);
+            return new Microsoft.Xna.Framework.Color(gray, gray, gray, c.A);
+        }
+
+        public FilterWindow(WorldViewModel worldViewModel)
+        {
+            InitializeComponent();
+            _wvm = worldViewModel;
+            DataContext = this;
+
+            // Populate tile items.
+            TileItems.Clear();
+            foreach (var tile in TEdit.Configuration.WorldConfiguration.TileBricks)
+                TileItems.Add(new FilterCheckItem(tile.Id, tile.Name, false));
+            foreach (var item in TileItems)   // Populate IsChecked with previous saved values.
+                item.IsChecked = FilterManager.SelectedTileIDs.Contains(item.Id);
+            FilterTileItems();
+
+            // Populate wall items.
+            WallItems.Clear();
+            foreach (var wall in TEdit.Configuration.WorldConfiguration.WallProperties)
+                WallItems.Add(new FilterCheckItem(wall.Id, wall.Name, false));
+            foreach (var item in WallItems)   // Populate IsChecked with previous saved values.
+                item.IsChecked = FilterManager.SelectedWallIDs.Contains(item.Id);
+            FilterWallItems();
+
+            // Populate liquid items.
+            LiquidItems.Clear();
+            foreach (var val in Enum.GetValues<LiquidType>())
+            {
+                int v = Convert.ToInt32(val);
+                if (v != 0) // Exclude None
+                    LiquidItems.Add(new FilterCheckItem(v, val.ToString(), false));
+            }
+            foreach (var item in LiquidItems) // Populate IsChecked with previous saved values.
+                item.IsChecked = FilterManager.SelectedLiquidNames.Contains(item.Name); // or use IDs.
+            FilterLiquidItems();
+
+            // Populate wires (red, blue, green, yellow).
+            WireItems.Clear();
+            WireItems.Add(new FilterCheckItem((int)FilterManager.WireType.Red, "Red Wire", false));       // 1. _wvm.ShowXXXWires
+            WireItems.Add(new FilterCheckItem((int)FilterManager.WireType.Blue, "Blue Wire", false));     // 2. 
+            WireItems.Add(new FilterCheckItem((int)FilterManager.WireType.Green, "Green Wire", false));   // 4.
+            WireItems.Add(new FilterCheckItem((int)FilterManager.WireType.Yellow, "Yellow Wire", false)); // 8.
+            foreach (var item in WireItems)   // Populate IsChecked with previous saved values.
+                item.IsChecked = FilterManager.WireIsAllowed((FilterManager.WireType)item.Id);
+            FilterWireItems();
+
+            // Synchronize color fields with FilterManager for persistence.
+            CustomModeColor = FromXnaColor(FilterManager.FilterModeCustomColor);
+            CustomBackgroundColor = FromXnaColor(FilterManager.BackgroundModeCustomColor);
+
+            // Sync pending filter / background modes with the actual value.
+            PendingFilterMode = FilterManager.CurrentFilterMode;
+            PendingBackgroundMode = FilterManager.CurrentBackgroundMode;
+        }
+
+        // Filtering logic for each section.
+        private void FilterTileItems()
+        {
+            FilteredTileItems.Clear();
+            foreach (var item in TileItems.Where(i => string.IsNullOrWhiteSpace(TileSearchText) || i.Name.Contains(TileSearchText, StringComparison.CurrentCultureIgnoreCase)))
+                FilteredTileItems.Add(item);
+        }
+        private void FilterWallItems()
+        {
+            FilteredWallItems.Clear();
+            foreach (var item in WallItems.Where(i => string.IsNullOrWhiteSpace(WallSearchText) || i.Name.Contains(WallSearchText, StringComparison.CurrentCultureIgnoreCase)))
+                FilteredWallItems.Add(item);
+        }
+        private void FilterLiquidItems()
+        {
+            FilteredLiquidItems.Clear();
+            foreach (var item in LiquidItems.Where(i => string.IsNullOrWhiteSpace(LiquidSearchText) || i.Name.Contains(LiquidSearchText, StringComparison.CurrentCultureIgnoreCase)))
+                FilteredLiquidItems.Add(item);
+        }
+        private void FilterWireItems()
+        {
+            FilteredWireItems.Clear();
+            foreach (var item in WireItems.Where(i => string.IsNullOrWhiteSpace(WireSearchText) || i.Name.Contains(WireSearchText, StringComparison.CurrentCultureIgnoreCase)))
+                FilteredWireItems.Add(item);
+        }
+
+        // Check All / Uncheck All.
+        private void TileCheckAll_Click(object sender, RoutedEventArgs e) => FilteredTileItems.ToList().ForEach(i => i.IsChecked = true);
+        private void TileUncheckAll_Click(object sender, RoutedEventArgs e) => FilteredTileItems.ToList().ForEach(i => i.IsChecked = false);
+
+        private void WallCheckAll_Click(object sender, RoutedEventArgs e) => FilteredWallItems.ToList().ForEach(i => i.IsChecked = true);
+        private void WallUncheckAll_Click(object sender, RoutedEventArgs e) => FilteredWallItems.ToList().ForEach(i => i.IsChecked = false);
+
+        private void LiquidCheckAll_Click(object sender, RoutedEventArgs e) => FilteredLiquidItems.ToList().ForEach(i => i.IsChecked = true);
+        private void LiquidUncheckAll_Click(object sender, RoutedEventArgs e) => FilteredLiquidItems.ToList().ForEach(i => i.IsChecked = false);
+
+        private void WireCheckAll_Click(object sender, RoutedEventArgs e) => FilteredWireItems.ToList().ForEach(i => i.IsChecked = true);
+        private void WireUncheckAll_Click(object sender, RoutedEventArgs e) => FilteredWireItems.ToList().ForEach(i => i.IsChecked = false);
+
+        // Final buttons.
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        private void Disable_Click(object sender, RoutedEventArgs e)
+        {
+            // Save the existing filter modes.
+            FilterManager.CurrentFilterMode = PendingFilterMode;
+            FilterManager.CurrentBackgroundMode = PendingBackgroundMode;
+
+            // Uncheck all checkboxes.
+            foreach (var item in TileItems) item.IsChecked = false;
+            foreach (var item in WallItems) item.IsChecked = false;
+            foreach (var item in LiquidItems) item.IsChecked = false;
+            foreach (var item in WireItems) item.IsChecked = false;
+
+            // Clear all filters.
+            FilterManager.ClearAll();
+
+            // Clear the grayscale cache.
+            GrayscaleManager.GrayscaleCache.Clear();
+
+            // Schedule RedrawMap to run after this method (and window) closes.
+            // This eliminates the akward wait time for redraw before closing.
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                RedrawMap(true);
+            }), System.Windows.Threading.DispatcherPriority.ApplicationIdle);
+
+            DialogResult = true;
+            Close();
+        }
+
+        private void ApplyFilter_Click(object sender, RoutedEventArgs e)
+        {
+            // Clear the grayscale cache.
+            GrayscaleManager.GrayscaleCache.Clear();
+
+            // Tiles.
+            FilterManager.ClearTileFilters();
+            FilterManager.SelectedTileNames.Clear();
+            foreach (var tile in TileItems.Where(x => x.IsChecked))
+            {
+                FilterManager.AddTileFilter(tile.Id);
+                FilterManager.SelectedTileNames.Add(tile.Name);
+            }
+
+            // Walls.
+            FilterManager.ClearWallFilters();
+            FilterManager.SelectedWallNames.Clear();
+            foreach (var wall in WallItems.Where(x => x.IsChecked))
+            {
+                FilterManager.AddWallFilter(wall.Id);
+                FilterManager.SelectedWallNames.Add(wall.Name);
+            }
+
+            // Liquids.
+            FilterManager.ClearLiquidFilters();
+            FilterManager.SelectedLiquidNames.Clear();
+            foreach (var liquid in LiquidItems.Where(x => x.IsChecked))
+            {
+                FilterManager.AddLiquidFilter((LiquidType)liquid.Id);
+                FilterManager.SelectedLiquidNames.Add(liquid.Name);
+            }
+
+            // Wires.
+            FilterManager.ClearWireFilters();
+            FilterManager.SelectedWireNames.Clear();
+            foreach (var wire in WireItems.Where(x => x.IsChecked))
+            {
+                FilterManager.AddWireFilter((FilterManager.WireType)wire.Id);
+                FilterManager.SelectedWireNames.Add(wire.Name);
+            }
+
+            #region REMOVED: Toggle UI Wire Layers
+
+            /*
+            // Wires.
+            FilterManager.ClearWireFilters();
+            FilterManager.SelectedWireNames.Clear();
+            foreach (var wire in WireItems.Where(x => x.IsChecked))
+            {
+                switch (wire.Name)
+                {
+                    case "Red Wire":
+                        _wvm.ShowRedWires = true;
+                        break;
+                    case "Blue Wire":
+                        _wvm.ShowBlueWires = true;
+                        break;
+                    case "Green Wire":
+                        _wvm.ShowGreenWires = true;
+                        break;
+                    case "Yellow Wire":
+                        _wvm.ShowYellowWires = true;
+                        break;
+                }
+                FilterManager.AddWireFilter((FilterManager.WireType)wire.Id);
+                FilterManager.SelectedWireNames.Add(wire.Name);
+            }
+
+            // For *unchecked* wires, set _wvm.ShowXXXWires to false.
+            foreach (var wire in WireItems.Where(x => !x.IsChecked))
+            {
+                switch (wire.Name)
+                {
+                    case "Red Wire":
+                        _wvm.ShowRedWires = false;
+                        break;
+                    case "Blue Wire":
+                        _wvm.ShowBlueWires = false;
+                        break;
+                    case "Green Wire":
+                        _wvm.ShowGreenWires = false;
+                        break;
+                    case "Yellow Wire":
+                        _wvm.ShowYellowWires = false;
+                        break;
+                }
+            }
+            */
+
+            #endregion
+
+            // Filter mode.
+            FilterManager.CurrentFilterMode = PendingFilterMode;
+            RadioButton[] filterModeRadios = [HideRadio, GrayscaleRadio];
+            foreach (var rb in filterModeRadios)
+            {
+                if (rb.IsChecked == true && Enum.TryParse(typeof(FilterManager.FilterMode), rb.Tag?.ToString(), out var mode))
+                {
+                    FilterManager.CurrentFilterMode = (FilterManager.FilterMode)mode;
+                    break;
+                }
+            }
+            FilterManager.FilterModeCustomColor = ToXnaColor(CustomModeColor);
+
+            // Background mode.
+            FilterManager.CurrentBackgroundMode = PendingBackgroundMode;
+            RadioButton[] backgroundModeRadios = [NormalRadio, CustomRadio];
+            foreach (var rb in backgroundModeRadios)
+            {
+                if (rb.IsChecked == true && Enum.TryParse(typeof(FilterManager.BackgroundMode), rb.Tag?.ToString(), out var mode))
+                {
+                    FilterManager.CurrentBackgroundMode = (FilterManager.BackgroundMode)mode;
+                    break;
+                }
+            }
+            FilterManager.BackgroundModeCustomColor = ToXnaColor(CustomBackgroundColor);
+
+            // Schedule RedrawMap to run after this method (and window) closes.
+            // This eliminates the akward wait time for redraw before closing.
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                RedrawMap();
+            }), System.Windows.Threading.DispatcherPriority.ApplicationIdle);
+
+            DialogResult = true;
+            Close();
+        }
+
+        /// <summary>
+        /// Forces a complete re-render of the map display in TEdit to reflect current filters or edits.
+        /// </summary>
+        private void RedrawMap(bool loadDefualt = false)
+        {
+            var main = (MainWindow)Application.Current.MainWindow;
+            main.MapView.DrawTileWalls();
+            main.MapView.DrawTileTextures();
+
+            // Reload the map without any filtration applied.
+            if (loadDefualt)
+            {
+                _wvm.UpdateRenderWorld();                                             // Re-render map.
+                _wvm.MinimapImage = Render.RenderMiniMap.Render(_wvm.CurrentWorld);   // Update Minimap.
+                return;
+            }
+
+            _wvm.UpdateRenderWorldUsingFilter();                                      // Re-render map.
+            _wvm.MinimapImage = Render.RenderMiniMap.Render(_wvm.CurrentWorld, true); // Update Minimap.
+        }
+
+        // Custom color picker logic for the map backdrop.
+        private void PickCustomColor_Click(object sender, RoutedEventArgs e)
+        {
+            var dlg = new System.Windows.Forms.ColorDialog();
+            if (dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                CustomBackgroundColor = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+                FilterManager.BackgroundModeCustomColor = ToXnaColor(CustomBackgroundColor);
+            }
+        }
+
+        // INotifyPropertyChanged.
+        public event PropertyChangedEventHandler PropertyChanged;
+        protected void OnPropertyChanged(string prop) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+    }
+}

--- a/src/TEdit/View/Popups/FilterWindow.xaml.cs
+++ b/src/TEdit/View/Popups/FilterWindow.xaml.cs
@@ -344,16 +344,20 @@ namespace TEdit.View.Popups
         private void RedrawMap(bool loadDefualt = false)
         {
             var main = (MainWindow)Application.Current.MainWindow;
-            main.MapView.DrawTileWalls();
-            main.MapView.DrawTileTextures();
-
+            
             // Reload the map without any filtration applied.
             if (loadDefualt)
             {
+                main.MapView.DrawTileWalls();
+                main.MapView.DrawTileTextures();
+
                 _wvm.UpdateRenderWorld();                                             // Re-render map.
                 _wvm.MinimapImage = Render.RenderMiniMap.Render(_wvm.CurrentWorld);   // Update Minimap.
                 return;
             }
+
+            main.MapView.DrawTileWallsFiltered();
+            main.MapView.DrawTileTexturesFiltered();
 
             _wvm.UpdateRenderWorldUsingFilter();                                      // Re-render map.
             _wvm.MinimapImage = Render.RenderMiniMap.Render(_wvm.CurrentWorld, true); // Update Minimap.

--- a/src/TEdit/View/Popups/UVEditorWindow.xaml
+++ b/src/TEdit/View/Popups/UVEditorWindow.xaml
@@ -1,7 +1,8 @@
 ﻿<Window x:Class="TEdit.View.Popups.UVEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="UV Editor"
+        xmlns:p="clr-namespace:TEdit.Properties"
+        Title="{x:Static p:Language.menu_uveditor_title}"
         WindowStartupLocation="CenterOwner"
         WindowStyle="ToolWindow"
         ResizeMode="NoResize"
@@ -28,7 +29,7 @@
 
         <!-- Move All Frames Section -->
         <StackPanel Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,0,0,10">
-            <TextBlock Text="Move All Frames" FontWeight="Bold" Margin="0,0,0,5"/>
+            <TextBlock Text="{x:Static p:Language.menu_uveditor_moveallframes}" FontWeight="Bold" Margin="0,0,0,5"/>
             <Grid HorizontalAlignment="Center">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -50,31 +51,52 @@
         </StackPanel>
 
         <!-- Move Amount Section -->
-        <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,10,0,0">
-            <TextBlock Text="Move Amount (Frames):" FontWeight="Bold" VerticalAlignment="Center"/>
-            <StackPanel Orientation="Horizontal" Margin="10,0,0,0">
-                <TextBlock Text="U:" VerticalAlignment="Center"/>
-                <TextBox x:Name="UTextBox" Width="50" Margin="5,0" Text="18"/>
-                <TextBlock Text="V:" VerticalAlignment="Center"/>
-                <TextBox x:Name="VTextBox" Width="50" Margin="5,0" Text="18"/>
-            </StackPanel>
-        </StackPanel>
+        <Grid Grid.Row="1" Grid.Column="0" Margin="0,10,0,0" VerticalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="10"/>   <!-- Spacer -->
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="60"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="60"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" FontWeight="Bold" VerticalAlignment="Center">
+                <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_uveditor_moveamount)" /></MultiBinding></TextBlock.Text>
+            </TextBlock>
+            <!-- Spacer -->
+            <TextBlock Grid.Column="1"/>
+            <TextBlock Grid.Column="2" Text="U:" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="3" x:Name="UTextBox" Width="50" Margin="5,0" Text="18"/>
+            <TextBlock Grid.Column="4" Text="V:" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="5" x:Name="VTextBox" Width="50" Margin="5,0" Text="18"/>
+        </Grid>
 
         <!-- Separator -->
         <Separator Grid.Row="2" Grid.Column="0" Margin="0,10,0,5"/>
 
         <!-- Manual Frames -->
-        <StackPanel Grid.Row="3" Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
-            <TextBlock Text="Set Manual UV's To All:  " FontWeight="Bold" VerticalAlignment="Center"/>
-            <StackPanel Orientation="Horizontal" Margin="10,0,0,0">
-                <TextBlock Text="U:" VerticalAlignment="Center"/>
-                <TextBox x:Name="UTextBoxManual" Width="50" Margin="5,0" Text="0"/>
-                <TextBlock Text="V:" VerticalAlignment="Center"/>
-                <TextBox x:Name="VTextBoxManual" Width="50" Margin="5,0" Text="0"/>
-            </StackPanel>
-        </StackPanel>
+        <Grid Grid.Row="3" Grid.Column="0" Margin="0,0,0,0" VerticalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="16.5"/>   <!-- Spacer -->
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="60"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="60"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" FontWeight="Bold" VerticalAlignment="Center">
+                <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_uveditor_setmanualuv)" /></MultiBinding></TextBlock.Text>
+            </TextBlock>
+            <!-- Spacer -->
+            <TextBlock Grid.Column="1"/>
+            <TextBlock Grid.Column="2" Text="U:" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="3" x:Name="UTextBoxManual" Width="50" Margin="5,0" Text="0"/>
+            <TextBlock Grid.Column="4" Text="V:" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="5" x:Name="VTextBoxManual" Width="50" Margin="5,0" Text="0"/>
+        </Grid>
+
         <StackPanel Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,5,0,0">
-            <Button Content="Set Values" Width="75" Height="25" IsDefault="True" Click="SetValuesButton_Click"/>
+            <Button Content="{x:Static p:Language.menu_uveditor_setvalues}" Width="75" Height="25" IsDefault="True" Click="SetValuesButton_Click"/>
         </StackPanel>
 
         <!-- Separator -->
@@ -82,15 +104,17 @@
 
         <!-- Selected Frames Section -->
         <StackPanel Grid.Row="6" Grid.Column="0" VerticalAlignment="Center">
-            <TextBlock Text="Selected Frames:" FontWeight="Bold" Margin="0,10,0,5"/>
+            <TextBlock FontWeight="Bold" Margin="0,10,0,5">
+                <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_uveditor_selectedframes)" /></MultiBinding></TextBlock.Text>
+            </TextBlock>
             <TextBox x:Name="SelectedFramesTextBox" Height="170" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" IsReadOnly="True"/>
         </StackPanel>
 
         <!-- Ok/Cancel Buttons -->
         <StackPanel Grid.Row="7" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,5,0,0">
-            <Button Content="Cancel" Width="75" Height="25" Margin="5" Click="CancelButton_Click"/>
-            <Button Content="Restore" Width="75" Height="25" Margin="5" Click="RestoreButton_Click"/>
-            <Button Content="OK" Width="75" Height="25" Margin="5" IsDefault="True" Click="OkButton_Click"/>
+            <Button Content="{x:Static p:Language.menu_uveditor_cancel}" Width="75" Height="25" Margin="5" Click="CancelButton_Click"/>
+            <Button Content="{x:Static p:Language.menu_uveditor_restore}" Width="75" Height="25" Margin="5" Click="RestoreButton_Click"/>
+            <Button Content="{x:Static p:Language.menu_uveditor_ok}" Width="75" Height="25" Margin="5" IsDefault="True" Click="OkButton_Click"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/TEdit/View/WorldRenderXna.xaml.cs
+++ b/src/TEdit/View/WorldRenderXna.xaml.cs
@@ -2636,25 +2636,29 @@ public partial class WorldRenderXna : UserControl
                     if (curtile.Type >= WorldConfiguration.TileProperties.Count) { continue; }
 
                     // Hide all wires not within a filter when enabled.
+                    bool allowRed          = true;
                     bool forceRedGrayscale = false;
                     if (curtile.WireRed)
                         if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Red))
-                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) continue;
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           allowRed = false;
                             else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceRedGrayscale = true;
+                    bool allowBlue          = true;
                     bool forceBlueGrayscale = false;
                     if (curtile.WireBlue)
                         if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Blue))
-                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) continue;
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           allowBlue = false;
                             else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceBlueGrayscale = true;
+                    bool allowGreen          = true;
                     bool forceGreenGrayscale = false;
                     if (curtile.WireGreen)
                         if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Green))
-                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) continue;
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           allowGreen = false;
                             else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceGreenGrayscale = true;
+                    bool allowYellow          = true;
                     bool forceYellowGrayscale = false;
                     if (curtile.WireYellow)
                         if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Yellow))
-                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) continue;
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           allowYellow = false;
                             else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceYellowGrayscale = true;
 
                     //Neighbor tiles are often used when dynamically determining which UV position to render
@@ -2677,7 +2681,7 @@ public partial class WorldRenderXna : UserControl
                                 voffset = (curtile.U / 18 + 1) * 72;
                             if (curtile.Type == 445)
                                 voffset = 72;
-                            if (curtile.WireRed && _wvm.ShowRedWires)
+                            if (curtile.WireRed && _wvm.ShowRedWires && allowRed)
                             {
                                 var source = new Rectangle(0, 0, 16, 16);
                                 var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
@@ -2702,7 +2706,7 @@ public partial class WorldRenderXna : UserControl
                                 else
                                     _spriteBatch.Draw(tileTex, dest, source, Color.White, 0f, default, SpriteEffects.None, LayerRedWires);
                             }
-                            if (curtile.WireBlue && _wvm.ShowBlueWires)
+                            if (curtile.WireBlue && _wvm.ShowBlueWires && allowBlue)
                             {
                                 var source = new Rectangle(0, 0, 16, 16);
                                 var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
@@ -2727,7 +2731,7 @@ public partial class WorldRenderXna : UserControl
                                 else
                                     _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerBlueWires);
                             }
-                            if (curtile.WireGreen && _wvm.ShowGreenWires)
+                            if (curtile.WireGreen && _wvm.ShowGreenWires && allowGreen)
                             {
                                 var source = new Rectangle(0, 0, 16, 16);
                                 var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
@@ -2752,7 +2756,7 @@ public partial class WorldRenderXna : UserControl
                                 else
                                     _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerGreenWires);
                             }
-                            if (curtile.WireYellow && _wvm.ShowYellowWires)
+                            if (curtile.WireYellow && _wvm.ShowYellowWires && allowYellow)
                             {
                                 var source = new Rectangle(0, 0, 16, 16);
                                 var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);

--- a/src/TEdit/View/WorldRenderXna.xaml.cs
+++ b/src/TEdit/View/WorldRenderXna.xaml.cs
@@ -1194,27 +1194,27 @@ public partial class WorldRenderXna : UserControl
 
                     /// <summary>
                     /// Returns the tile at (nx, ny) unless it's out of bounds or filtered out (when filter mode is Hide).
-                    /// If filtered, returns Tile.Empty (treated as air/inactive).
+                    /// If filtered, returns null (treated as air/inactive).
                     /// </summary>
-                    Tile GetNeighbor(int nx, int ny)
+                    Tile GetTileNeighbor(int nx, int ny)
                     {
                         if (nx < 0 || ny < 0 || nx >= width || ny >= height) return null;
                         var t = _wvm.CurrentWorld.Tiles[nx, ny];
                         if (FilterManager.TileIsNotAllowed(t.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)
-                            return Tile.Empty;
+                            return null;
                         return t;
                     }
 
                     //Neighbor tiles are often used when dynamically determining which UV position to render
                     //Tile[] neighborTile = new Tile[8];
-                    neighborTile[e] = GetNeighbor(x + 1, y);
-                    neighborTile[n] = GetNeighbor(x, y - 1);
-                    neighborTile[w] = GetNeighbor(x - 1, y);
-                    neighborTile[s] = GetNeighbor(x, y + 1);
-                    neighborTile[ne] = GetNeighbor(x + 1, y - 1);
-                    neighborTile[nw] = GetNeighbor(x - 1, y - 1);
-                    neighborTile[sw] = GetNeighbor(x - 1, y + 1);
-                    neighborTile[se] = GetNeighbor(x + 1, y + 1);
+                    neighborTile[e] = GetTileNeighbor(x + 1, y);
+                    neighborTile[n] = GetTileNeighbor(x, y - 1);
+                    neighborTile[w] = GetTileNeighbor(x - 1, y);
+                    neighborTile[s] = GetTileNeighbor(x, y + 1);
+                    neighborTile[ne] = GetTileNeighbor(x + 1, y - 1);
+                    neighborTile[nw] = GetTileNeighbor(x - 1, y - 1);
+                    neighborTile[sw] = GetTileNeighbor(x - 1, y + 1);
+                    neighborTile[se] = GetTileNeighbor(x + 1, y + 1);
 
                     if (_wvm.ShowTiles)
                     {

--- a/src/TEdit/View/WorldRenderXna.xaml.cs
+++ b/src/TEdit/View/WorldRenderXna.xaml.cs
@@ -691,30 +691,57 @@ public partial class WorldRenderXna : UserControl
 
         _spriteBatch.End();
 
-
         // Draw sprite overlays
         if (_wvm.ShowTextures && _textureDictionary.Valid && AreTexturesVisible())
         {
             if (_wvm.ShowWalls)
             {
-                _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
-                DrawTileWalls();
-                _spriteBatch.End();
+                // Check if the advanced filter has active wall filters.
+                if (!FilterManager.AnyFilterActive)
+                {
+                    _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+                    DrawTileWalls();
+                    _spriteBatch.End();
 
-                _spriteBatch.Begin(SpriteSortMode.Immediate, _negativePaint, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
-                DrawTileWalls(true);
-                _spriteBatch.End();
+                    _spriteBatch.Begin(SpriteSortMode.Immediate, _negativePaint, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+                    DrawTileWalls(true);
+                    _spriteBatch.End();
+                }
+                else
+                {
+                    _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+                    DrawTileWallsFiltered();
+                    _spriteBatch.End();
+
+                    _spriteBatch.Begin(SpriteSortMode.Immediate, _negativePaint, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+                    DrawTileWallsFiltered(true);
+                    _spriteBatch.End();
+                }
             }
 
             if (_wvm.ShowTiles)
             {
-                _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
-                DrawTileTextures();
-                _spriteBatch.End();
+                // Check if the advanced filter has active tile filters.
+                if (!FilterManager.AnyFilterActive)
+                {
+                    _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+                    DrawTileTextures();
+                    _spriteBatch.End();
 
-                _spriteBatch.Begin(SpriteSortMode.Immediate, _negativePaint, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
-                DrawTileTextures(true);
-                _spriteBatch.End();
+                    _spriteBatch.Begin(SpriteSortMode.Immediate, _negativePaint, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+                    DrawTileTextures(true);
+                    _spriteBatch.End();
+                }
+                else
+                {
+                    _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+                    DrawTileTexturesFiltered();
+                    _spriteBatch.End();
+
+                    _spriteBatch.Begin(SpriteSortMode.Immediate, _negativePaint, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+                    DrawTileTexturesFiltered(true);
+                    _spriteBatch.End();
+                }
             }
 
             if ((_wvm.ShowTiles) ||
@@ -726,12 +753,20 @@ public partial class WorldRenderXna : UserControl
 
                 if (_wvm.ShowBlueWires || _wvm.ShowRedWires || _wvm.ShowGreenWires || _wvm.ShowYellowWires)
                 {
-                    DrawTileWires();
+                    // Check if the advanced filter has active wire filters.
+                    if (!FilterManager.AnyFilterActive)
+                        DrawTileWires();
+                    else
+                        DrawTileWiresFiltered();
                 }
 
                 if (_wvm.ShowLiquid)
                 {
-                    DrawTileLiquid();
+                    // Check if the advanced filter has active wire filters.
+                    if (!FilterManager.AnyFilterActive)
+                        DrawTileLiquid();
+                    else
+                        DrawTileLiquidFiltered();
                 }
                 // Draw Tile Entities
 
@@ -759,7 +794,6 @@ public partial class WorldRenderXna : UserControl
         // End SpriteBatch
         _spriteBatch.End();
     }
-
 
     private void DrawTileEntities()
     {
@@ -925,6 +959,103 @@ public partial class WorldRenderXna : UserControl
         {
             for (int x = visibleBounds.Left - 1; x < visibleBounds.Right + 2; x++)
             {
+                if (x < 0 ||
+                    y < 0 ||
+                    x >= _wvm.CurrentWorld.TilesWide ||
+                    y >= _wvm.CurrentWorld.TilesHigh)
+                {
+                    continue;
+                }
+
+                //draw background textures
+                if (y >= 80)
+                {
+
+                    int hellback = _wvm.CurrentWorld.HellBackStyle;
+                    int backX = 0;
+                    if (x <= _wvm.CurrentWorld.CaveBackX0)
+                        backX = _wvm.CurrentWorld.CaveBackStyle0;
+                    else if (x > _wvm.CurrentWorld.CaveBackX0 && x <= _wvm.CurrentWorld.CaveBackX1)
+                        backX = _wvm.CurrentWorld.CaveBackStyle1;
+                    else if (x > _wvm.CurrentWorld.CaveBackX1 && x <= _wvm.CurrentWorld.CaveBackX2)
+                        backX = _wvm.CurrentWorld.CaveBackStyle2;
+                    else if (x > _wvm.CurrentWorld.CaveBackX2)
+                        backX = _wvm.CurrentWorld.CaveBackStyle3;
+                    var source = new Rectangle(0, 0, 16, 16);
+                    var backTex = _textureDictionary.GetBackground(0);
+
+                    if (y < _wvm.CurrentWorld.GroundLevel)
+                    {
+                        backTex = _textureDictionary.GetBackground(0);
+                        source.Y += (y - 80) * 16;
+                    }
+                    else if (y == _wvm.CurrentWorld.GroundLevel)
+                    {
+                        backTex = _textureDictionary.GetBackground(backstyle[backX, 0]);
+                        source.X += (x % 8) * 16;
+                    }
+                    else if (y > _wvm.CurrentWorld.GroundLevel && y < _wvm.CurrentWorld.RockLevel)
+                    {
+                        backTex = _textureDictionary.GetBackground(backstyle[backX, 1]);
+                        source.X += (x % 8) * 16;
+                        source.Y += ((y - 1 - (int)_wvm.CurrentWorld.GroundLevel) % 6) * 16;
+                    }
+                    else if (y == _wvm.CurrentWorld.RockLevel)
+                    {
+                        backTex = _textureDictionary.GetBackground(backstyle[backX, 2]);
+                        source.X += (x % 8) * 16;
+                    }
+                    else if (y > _wvm.CurrentWorld.RockLevel && y < (_wvm.CurrentWorld.TilesHigh - 327))
+                    {
+                        backTex = _textureDictionary.GetBackground(backstyle[backX, 3]);
+                        source.X += (x % 8) * 16;
+                        source.Y += ((y - 1 - (int)_wvm.CurrentWorld.RockLevel) % 6) * 16;
+                    }
+                    else if (y == (_wvm.CurrentWorld.TilesHigh - 327))
+                    {
+                        backTex = _textureDictionary.GetBackground(backstyle[backX, 4] + hellback);
+                        source.X += (x % 8) * 16;
+                    }
+                    else if (y > (_wvm.CurrentWorld.TilesHigh - 327) && y < (_wvm.CurrentWorld.TilesHigh - 200))
+                    {
+                        backTex = _textureDictionary.GetBackground(backstyle[backX, 5] + hellback);
+                        source.X += (x % 8) * 16;
+                        source.Y += ((y - 1 - (int)_wvm.CurrentWorld.TilesHigh + 327) % 18) * 16;
+                    }
+                    else if (y == (_wvm.CurrentWorld.TilesHigh - 200))
+                    {
+                        backTex = _textureDictionary.GetBackground(backstyle[backX, 6] + hellback);
+                        source.X += (x % 8) * 16;
+                    }
+                    else
+                    {
+                        backTex = _textureDictionary.GetUnderworld(4);
+                        source.Y += (y - (int)_wvm.CurrentWorld.TilesHigh + 200) * 16;
+                    }
+
+                    var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                    _spriteBatch.Draw(backTex, dest, source, Color.White, 0f, default, SpriteEffects.None, LayerTileBackgroundTextures);
+                }
+            }
+        }
+    }
+
+    private Tile[] neighborTile = new Tile[8];
+    const int e = 0, n = 1, w = 2, s = 3, ne = 4, nw = 5, sw = 6, se = 7;
+
+    Texture2D wallTex;
+    public void DrawTileWalls(bool drawInverted = false)
+    {
+        Rectangle visibleBounds = GetViewingArea();
+        BlendRules blendRules = BlendRules.Instance;
+        var width = _wvm.CurrentWorld.TilesWide;
+        var height = _wvm.CurrentWorld.TilesHigh;
+
+        //Extended the viewing space to give tiles time to cache their UV's
+        for (int y = visibleBounds.Top - 1; y < visibleBounds.Bottom + 2; y++)
+        {
+            for (int x = visibleBounds.Left - 1; x < visibleBounds.Right + 2; x++)
+            {
                 try
                 {
                     if (x < 0 ||
@@ -935,74 +1066,88 @@ public partial class WorldRenderXna : UserControl
                         continue;
                     }
 
-                    //draw background textures
-                    if (y >= 80)
+                    var curtile = _wvm.CurrentWorld.Tiles[x, y];
+                    if ((curtile.WallColor == 30) != drawInverted) continue;
+
+                    //Neighbor tiles are often used when dynamically determining which UV position to render
+                    neighborTile[e]  = (x + 1) < width                     ? _wvm.CurrentWorld.Tiles[x + 1, y]     : null;
+                    neighborTile[n]  = (y - 1) > 0                         ? _wvm.CurrentWorld.Tiles[x, y - 1]     : null;
+                    neighborTile[w]  = (x - 1) > 0                         ? _wvm.CurrentWorld.Tiles[x - 1, y]     : null;
+                    neighborTile[s]  = (y + 1) < height                    ? _wvm.CurrentWorld.Tiles[x, y + 1]     : null;
+                    neighborTile[ne] = (x + 1) < width && (y - 1) > 0      ? _wvm.CurrentWorld.Tiles[x + 1, y - 1] : null;
+                    neighborTile[nw] = (x - 1) > 0 && (y - 1) > 0          ? _wvm.CurrentWorld.Tiles[x - 1, y - 1] : null;
+                    neighborTile[sw] = (x - 1) > 0 && (y + 1) < height     ? _wvm.CurrentWorld.Tiles[x - 1, y + 1] : null;
+                    neighborTile[se] = (x + 1) < width && (y + 1) < height ? _wvm.CurrentWorld.Tiles[x + 1, y + 1] : null;
+
+                    if (_wvm.ShowWalls)
                     {
+                        // white for inverted
+                        var wallPaintColor = Color.White;
 
-                        int hellback = _wvm.CurrentWorld.HellBackStyle;
-                        int backX = 0;
-                        if (x <= _wvm.CurrentWorld.CaveBackX0)
-                            backX = _wvm.CurrentWorld.CaveBackStyle0;
-                        else if (x > _wvm.CurrentWorld.CaveBackX0 && x <= _wvm.CurrentWorld.CaveBackX1)
-                            backX = _wvm.CurrentWorld.CaveBackStyle1;
-                        else if (x > _wvm.CurrentWorld.CaveBackX1 && x <= _wvm.CurrentWorld.CaveBackX2)
-                            backX = _wvm.CurrentWorld.CaveBackStyle2;
-                        else if (x > _wvm.CurrentWorld.CaveBackX2)
-                            backX = _wvm.CurrentWorld.CaveBackStyle3;
-                        var source = new Rectangle(0, 0, 16, 16);
-                        var backTex = _textureDictionary.GetBackground(0);
+                        if (_wvm.ShowCoatings)
+                        {
+                            wallPaintColor = Color.LightGray;
 
-                        if (y < _wvm.CurrentWorld.GroundLevel)
-                        {
-                            backTex = _textureDictionary.GetBackground(0);
-                            source.Y += (y - 80) * 16;
-                        }
-                        else if (y == _wvm.CurrentWorld.GroundLevel)
-                        {
-                            backTex = _textureDictionary.GetBackground(backstyle[backX, 0]);
-                            source.X += (x % 8) * 16;
-                        }
-                        else if (y > _wvm.CurrentWorld.GroundLevel && y < _wvm.CurrentWorld.RockLevel)
-                        {
-                            backTex = _textureDictionary.GetBackground(backstyle[backX, 1]);
-                            source.X += (x % 8) * 16;
-                            source.Y += ((y - 1 - (int)_wvm.CurrentWorld.GroundLevel) % 6) * 16;
-                        }
-                        else if (y == _wvm.CurrentWorld.RockLevel)
-                        {
-                            backTex = _textureDictionary.GetBackground(backstyle[backX, 2]);
-                            source.X += (x % 8) * 16;
-                        }
-                        else if (y > _wvm.CurrentWorld.RockLevel && y < (_wvm.CurrentWorld.TilesHigh - 327))
-                        {
-                            backTex = _textureDictionary.GetBackground(backstyle[backX, 3]);
-                            source.X += (x % 8) * 16;
-                            source.Y += ((y - 1 - (int)_wvm.CurrentWorld.RockLevel) % 6) * 16;
-                        }
-                        else if (y == (_wvm.CurrentWorld.TilesHigh - 327))
-                        {
-                            backTex = _textureDictionary.GetBackground(backstyle[backX, 4] + hellback);
-                            source.X += (x % 8) * 16;
-                        }
-                        else if (y > (_wvm.CurrentWorld.TilesHigh - 327) && y < (_wvm.CurrentWorld.TilesHigh - 200))
-                        {
-                            backTex = _textureDictionary.GetBackground(backstyle[backX, 5] + hellback);
-                            source.X += (x % 8) * 16;
-                            source.Y += ((y - 1 - (int)_wvm.CurrentWorld.TilesHigh + 327) % 18) * 16;
-                        }
-                        else if (y == (_wvm.CurrentWorld.TilesHigh - 200))
-                        {
-                            backTex = _textureDictionary.GetBackground(backstyle[backX, 6] + hellback);
-                            source.X += (x % 8) * 16;
-                        }
-                        else
-                        {
-                            backTex = _textureDictionary.GetUnderworld(4);
-                            source.Y += (y - (int)_wvm.CurrentWorld.TilesHigh + 200) * 16;
+                            if (curtile.InvisibleWall)
+                            {
+                                wallPaintColor = Color.DarkGray;
+                            }
+
+                            if (curtile.FullBrightWall || curtile.WallColor == 30)
+                            {
+                                wallPaintColor = Color.White;
+                            }
                         }
 
-                        var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
-                        _spriteBatch.Draw(backTex, dest, source, Color.White, 0f, default, SpriteEffects.None, LayerTileBackgroundTextures);
+                        if (curtile.WallColor > 0 && curtile.WallColor != 30)
+                        {
+                            var paint = WorldConfiguration.PaintProperties[curtile.WallColor].Color;
+                            switch (curtile.WallColor)
+                            {
+                                case 29:
+                                    float light = wallPaintColor.B * 0.3f;
+                                    wallPaintColor.R = (byte)(wallPaintColor.R * light);
+                                    wallPaintColor.G = (byte)(wallPaintColor.G * light);
+                                    wallPaintColor.B = (byte)(wallPaintColor.B * light);
+                                    break;
+                                case 30:
+                                    wallPaintColor.R = (byte)((byte.MaxValue - wallPaintColor.R) * 0.5);
+                                    wallPaintColor.G = (byte)((byte.MaxValue - wallPaintColor.G) * 0.5);
+                                    wallPaintColor.B = (byte)((byte.MaxValue - wallPaintColor.B) * 0.5);
+                                    break;
+                                default:
+                                    paint.A = (byte)wallPaintColor.R;
+                                    wallPaintColor = wallPaintColor.AlphaBlend(paint);
+                                    break;
+                            }
+                        }
+
+                        if (curtile.Wall > 0)
+                        {
+                            wallTex = _textureDictionary.GetWall(curtile.Wall);
+
+                            if (wallTex != null)
+                            {
+                                if (curtile.uvWallCache == 0xFFFF)
+                                {
+                                    int sameStyle = 0x00000000;
+                                    sameStyle |= (neighborTile[e] != null && neighborTile[e].Wall > 0) ? 0x0001 : 0x0000;
+                                    sameStyle |= (neighborTile[n] != null && neighborTile[n].Wall > 0) ? 0x0010 : 0x0000;
+                                    sameStyle |= (neighborTile[w] != null && neighborTile[w].Wall > 0) ? 0x0100 : 0x0000;
+                                    sameStyle |= (neighborTile[s] != null && neighborTile[s].Wall > 0) ? 0x1000 : 0x0000;
+
+                                    Vector2Int32 uvBlend = blendRules.GetUVForMasks((uint)sameStyle, 0x00000000, 0);
+                                    curtile.uvWallCache = (ushort)((uvBlend.Y << 8) + uvBlend.X);
+                                }
+
+                                var texsize = new Vector2Int32(32, 32);
+                                var source = new Rectangle((curtile.uvWallCache & 0x00FF) * (texsize.X + 4), (curtile.uvWallCache >> 8) * (texsize.Y + 4), texsize.X, texsize.Y);
+                                var dest = new Rectangle(1 + (int)((_scrollPosition.X + x - 0.5) * _zoom), 1 + (int)((_scrollPosition.Y + y - 0.5) * _zoom), (int)_zoom * 2, (int)_zoom * 2);
+
+                                _spriteBatch.Draw(wallTex, dest, source, wallPaintColor, 0f, default, SpriteEffects.None, LayerTileWallTextures);
+
+                            }
+                        }
                     }
                 }
                 catch (Exception)
@@ -1012,13 +1157,7 @@ public partial class WorldRenderXna : UserControl
             }
         }
     }
-
-    private Tile[] neighborTile = new Tile[8];
-    const int e = 0, n = 1, w = 2, s = 3, ne = 4, nw = 5, sw = 6, se = 7;
-
-    Texture2D wallTex;
-
-    public void DrawTileWalls(bool drawInverted = false)
+    public void DrawTileWallsFiltered(bool drawInverted = false)
     {
         Rectangle visibleBounds = GetViewingArea();
         BlendRules blendRules = BlendRules.Instance;
@@ -1049,25 +1188,15 @@ public partial class WorldRenderXna : UserControl
                         if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) continue;
                         else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceGrayscale = true;
 
-                    /// <summary>
-                    /// Returns the tile at (nx, ny) if within bounds; otherwise returns null.
-                    /// Use this for wall neighbor lookups (no filter checks).
-                    /// </summary>
-                    Tile GetWallNeighbor(int nx, int ny)
-                    {
-                        if (nx < 0 || ny < 0 || nx >= width || ny >= height) return null;
-                        return _wvm.CurrentWorld.Tiles[nx, ny];
-                    }
-
                     //Neighbor tiles are often used when dynamically determining which UV position to render
-                    neighborTile[e] = GetWallNeighbor(x + 1, y);
-                    neighborTile[n] = GetWallNeighbor(x, y - 1);
-                    neighborTile[w] = GetWallNeighbor(x - 1, y);
-                    neighborTile[s] = GetWallNeighbor(x, y + 1);
-                    neighborTile[ne] = GetWallNeighbor(x + 1, y - 1);
-                    neighborTile[nw] = GetWallNeighbor(x - 1, y - 1);
-                    neighborTile[sw] = GetWallNeighbor(x - 1, y + 1);
-                    neighborTile[se] = GetWallNeighbor(x + 1, y + 1);
+                    neighborTile[e]  = (x + 1 < width)                   ? _wvm.CurrentWorld.Tiles[x + 1, y]     : null;
+                    neighborTile[n]  = (y - 1 >= 0)                      ? _wvm.CurrentWorld.Tiles[x, y - 1]     : null;
+                    neighborTile[w]  = (x - 1 >= 0)                      ? _wvm.CurrentWorld.Tiles[x - 1, y]     : null;
+                    neighborTile[s]  = (y + 1 < height)                  ? _wvm.CurrentWorld.Tiles[x, y + 1]     : null;
+                    neighborTile[ne] = (x + 1 < width && y - 1 >= 0)     ? _wvm.CurrentWorld.Tiles[x + 1, y - 1] : null;
+                    neighborTile[nw] = (x - 1 >= 0 && y - 1 >= 0)        ? _wvm.CurrentWorld.Tiles[x - 1, y - 1] : null;
+                    neighborTile[sw] = (x - 1 >= 0 && y + 1 < height)    ? _wvm.CurrentWorld.Tiles[x - 1, y + 1] : null;
+                    neighborTile[se] = (x + 1 < width && y + 1 < height) ? _wvm.CurrentWorld.Tiles[x + 1, y + 1] : null;
 
                     if (_wvm.ShowWalls)
                     {
@@ -1186,35 +1315,1243 @@ public partial class WorldRenderXna : UserControl
                     if (curtile.Type >= WorldConfiguration.TileProperties.Count) { continue; }
                     var tileprop = WorldConfiguration.GetTileProperties(curtile.Type);
 
+                    //Neighbor tiles are often used when dynamically determining which UV position to render
+                    //Tile[] neighborTile = new Tile[8];
+                    neighborTile[e] = (x + 1) < width ? _wvm.CurrentWorld.Tiles[x + 1, y] : null;
+                    neighborTile[n] = (y - 1) > 0 ? _wvm.CurrentWorld.Tiles[x, y - 1] : null;
+                    neighborTile[w] = (x - 1) > 0 ? _wvm.CurrentWorld.Tiles[x - 1, y] : null;
+                    neighborTile[s] = (y + 1) < height ? _wvm.CurrentWorld.Tiles[x, y + 1] : null;
+                    neighborTile[ne] = (x + 1) < width && (y - 1) > 0 ? _wvm.CurrentWorld.Tiles[x + 1, y - 1] : null;
+                    neighborTile[nw] = (x - 1) > 0 && (y - 1) > 0 ? _wvm.CurrentWorld.Tiles[x - 1, y - 1] : null;
+                    neighborTile[sw] = (x - 1) > 0 && (y + 1) < height ? _wvm.CurrentWorld.Tiles[x - 1, y + 1] : null;
+                    neighborTile[se] = (x + 1) < width && (y + 1) < height ? _wvm.CurrentWorld.Tiles[x + 1, y + 1] : null;
+
+
+
+                    if (_wvm.ShowTiles)
+                    {
+                        if (curtile.IsActive)
+                        {
+                            // white for inverted
+                            var tilePaintColor = Color.White;
+
+                            if (_wvm.ShowCoatings)
+                            {
+                                tilePaintColor = Color.LightGray;
+
+                                if (curtile.InvisibleBlock)
+                                {
+                                    tilePaintColor = Color.DarkGray;
+                                }
+
+                                if (curtile.FullBrightBlock || curtile.TileColor == 30)
+                                {
+                                    tilePaintColor = Color.White;
+                                }
+                            }
+
+                            if (curtile.TileColor > 0 && curtile.TileColor != 30)
+                            {
+                                var paint = WorldConfiguration.PaintProperties[curtile.TileColor].Color;
+                                switch (curtile.TileColor)
+                                {
+                                    case 29:
+                                        float light = tilePaintColor.B * 0.3f;
+                                        tilePaintColor.R = (byte)(tilePaintColor.R * light);
+                                        tilePaintColor.G = (byte)(tilePaintColor.G * light);
+                                        tilePaintColor.B = (byte)(tilePaintColor.B * light);
+                                        break;
+                                    case 30:
+                                        tilePaintColor.R = (byte)((byte.MaxValue - tilePaintColor.R) * 0.5);
+                                        tilePaintColor.G = (byte)((byte.MaxValue - tilePaintColor.G) * 0.5);
+                                        tilePaintColor.B = (byte)((byte.MaxValue - tilePaintColor.B) * 0.5);
+                                        break;
+                                    default:
+                                        paint.A = (byte)tilePaintColor.R;
+                                        tilePaintColor = tilePaintColor.AlphaBlend(paint);
+                                        break;
+                                }
+                            }
+
+                            if (tileprop.IsFramed)
+                            {
+                                Rectangle source = new Rectangle(), dest = new Rectangle();
+                                tileTex = _textureDictionary.GetTile(curtile.Type);
+
+                                bool isTreeSpecial = false, isMushroom = false;
+                                bool isLeft = false, isBase = false, isRight = false;
+                                if (curtile.Type == (int)TileType.Tree)
+                                {
+                                    int baseX = 0;
+                                    if (curtile.U == 66 && curtile.V <= 45)
+                                        ++baseX;
+                                    if (curtile.U == 88 && curtile.V >= 66 && curtile.V <= 110)
+                                        --baseX;
+                                    if (curtile.U == 22 && curtile.V >= 132 && curtile.V < 198)
+                                        --baseX;
+                                    if (curtile.U == 44 && curtile.V >= 132 && curtile.V < 198)
+                                        ++baseX;
+                                    if (curtile.U >= 22 && curtile.V >= 198)
+                                    {
+                                        isTreeSpecial = true;
+                                        switch (curtile.U)
+                                        {
+                                            case 22:
+                                                isBase = true;
+                                                break;
+                                            case 44:
+                                                isLeft = true;
+                                                ++baseX;
+                                                break;
+                                            case 66:
+                                                isRight = true;
+                                                --baseX;
+                                                break;
+                                        }
+                                    }
+
+                                    //Check tree type
+                                    int treeType = -1; //Default to normal in case no grass grows beneath the tree
+                                    for (int i = 0; i < 100; i++)
+                                    {
+                                        Tile checkTile = (y + i) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x + baseX, y + i] : null;
+                                        if (checkTile != null && checkTile.IsActive)
+                                        {
+                                            bool found = true;
+                                            switch (checkTile.Type)
+                                            {
+                                                case 2:
+                                                    treeType = -1;
+                                                    break; //Normal
+                                                case 23:
+                                                    treeType = 0;
+                                                    break; //Corruption
+                                                case 60:
+                                                    if (y <= _wvm.CurrentWorld.GroundLevel)
+                                                    {
+                                                        treeType = 1;
+                                                        break; // Jungle
+                                                    }
+                                                    treeType = 5;
+                                                    break; // Underground Jungle
+                                                case 70:
+                                                    treeType = 6;
+                                                    break; // Surface Mushroom
+                                                case 109:
+                                                    treeType = 2;
+                                                    break; // Hallow
+                                                case 147:
+                                                    treeType = 3;
+                                                    break; // Snow
+                                                case 199:
+                                                    treeType = 4;
+                                                    break; // Crimson
+                                                default:
+                                                    found = false;
+                                                    break;
+                                            }
+                                            if (found)
+                                                break;
+                                        }
+                                    }
+                                    if (isTreeSpecial)
+                                    {
+                                        int treeStyle = 0; // default branches and tops
+                                        switch (treeType)
+                                        {
+                                            case -1:
+                                                if (x <= _wvm.CurrentWorld.TreeX0)
+                                                    treeStyle = _wvm.CurrentWorld.TreeStyle0;
+                                                else if (x <= _wvm.CurrentWorld.TreeX1)
+                                                    treeStyle = _wvm.CurrentWorld.TreeStyle1;
+                                                else if (x <= _wvm.CurrentWorld.TreeX2)
+                                                    treeStyle = _wvm.CurrentWorld.TreeStyle2;
+                                                else
+                                                    treeStyle = _wvm.CurrentWorld.TreeStyle3;
+                                                if (treeStyle == 0)
+                                                {
+                                                    break;
+                                                }
+                                                if (treeStyle == 5)
+                                                {
+                                                    treeStyle = 10;
+                                                    break;
+                                                }
+                                                treeStyle = 5 + treeStyle;
+                                                break;
+                                            case 0:
+                                                treeStyle = 1;
+                                                break;
+                                            case 1:
+                                                treeStyle = 2;
+                                                if (_wvm.CurrentWorld.BgJungle == 1)
+                                                    treeStyle = 11;
+                                                break;
+                                            case 2:
+                                                treeStyle = 3;
+                                                break;
+                                            case 3:
+                                                treeStyle = 4;
+                                                if (_wvm.CurrentWorld.BgSnow == 0)
+                                                {
+                                                    treeStyle = 12;
+                                                    if (x % 10 == 0)
+                                                        treeStyle = 18;
+                                                }
+                                                if (_wvm.CurrentWorld.BgSnow != 2 && _wvm.CurrentWorld.BgSnow != 3 && _wvm.CurrentWorld.BgSnow != 32 && _wvm.CurrentWorld.BgSnow != 4 && _wvm.CurrentWorld.BgSnow != 42)
+                                                {
+                                                    break;
+                                                }
+                                                if (_wvm.CurrentWorld.BgSnow % 2 == 0)
+                                                {
+                                                    if (x < _wvm.CurrentWorld.TilesWide / 2)
+                                                    {
+                                                        treeStyle = 16;
+                                                        break;
+                                                    }
+                                                    treeStyle = 17;
+                                                    break;
+                                                }
+                                                else
+                                                {
+                                                    if (x > _wvm.CurrentWorld.TilesWide / 2)
+                                                    {
+                                                        treeStyle = 16;
+                                                        break;
+                                                    }
+                                                    treeStyle = 17;
+                                                    break;
+                                                }
+                                            case 4:
+                                                treeStyle = 5;
+                                                break;
+                                            case 5:
+                                                treeStyle = 13;
+                                                break;
+                                            case 6:
+                                                treeStyle = 14;
+                                                break;
+                                        }
+                                        //Abuse uvTileCache to remember what type of tree it is, since potentially scanning a hundred of blocks PER tree tile sounds slow
+                                        curtile.uvTileCache = (ushort)((0x00 << 8) + 0x01 * treeStyle);
+                                        if (isBase)
+                                        {
+                                            tileTex = (Texture2D)_textureDictionary.GetTreeTops(treeStyle);
+                                        }
+                                        else
+                                        {
+                                            tileTex = (Texture2D)_textureDictionary.GetTreeBranches(treeStyle);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        tileTex = _textureDictionary.GetTree(treeType);
+                                    }
+                                }
+                                if (curtile.Type == (int)TileType.MushroomTree && curtile.U >= 36)
+                                {
+                                    isMushroom = true;
+                                    tileTex = (Texture2D)_textureDictionary.GetShroomTop(0);
+                                }
+                                if (curtile.Type == 323)
+                                {
+                                    if (curtile.U >= 88 && curtile.U <= 132)
+                                    {
+                                        isTreeSpecial = true;
+                                        isBase = true;
+                                        tileTex = (Texture2D)_textureDictionary.GetTreeTops(15);
+                                    }
+                                    int treeType = 0;
+                                    for (int i = 0; i < 100; i++)
+                                    {
+                                        Tile checkTile = (y + i) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x, y + i] : null;
+                                        if (checkTile != null && checkTile.IsActive)
+                                        {
+                                            bool found = true;
+                                            switch (checkTile.Type)
+                                            {
+                                                case 53:
+                                                    treeType = 0;
+                                                    break; //Palm
+                                                case 112:
+                                                    treeType = 3;
+                                                    break; //Ebonsand Palm
+                                                case 116:
+                                                    treeType = 2;
+                                                    break; //Pearlsand Palm
+                                                case 234:
+                                                    treeType = 1;
+                                                    break; //Crimsand Palm
+                                                default:
+                                                    found = false;
+                                                    break;
+                                            }
+                                            if (found)
+                                                break;
+                                        }
+                                    }
+                                    curtile.uvTileCache = (ushort)((0x00 << 8) + 0x01 * treeType);
+                                }
+
+                                if (tileTex != null)
+                                {
+                                    if ((curtile.Type == (int)TileType.MannequinLegacy || curtile.Type == (int)TileType.WomannequinLegacy) && curtile.U >= 100)
+                                    {
+                                        int armor = curtile.U / 100;
+                                        dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                        switch (curtile.V / 18)
+                                        {
+                                            case 0:
+                                                tileTex = (Texture2D)_textureDictionary.GetArmorHead(armor);
+                                                source = new Rectangle(2, 0, 36, 36);
+                                                dest.Width = (int)(_zoom * source.Width / 16f);
+                                                dest.Height = (int)(_zoom * source.Height / 16f);
+                                                dest.Y += (int)(((16 - source.Height - 4) / 2F) * _zoom / 16);
+                                                dest.X -= (int)((2 * _zoom / 16));
+                                                break;
+                                            case 1:
+                                                if (curtile.Type == (int)TileType.MannequinLegacy)
+                                                    tileTex = (Texture2D)_textureDictionary.GetArmorBody(armor);
+                                                else
+                                                    tileTex = (Texture2D)_textureDictionary.GetArmorFemale(armor);
+                                                source = new Rectangle(2, 0, 36, 54);
+                                                dest.Width = (int)(_zoom * source.Width / 16f);
+                                                dest.Height = (int)(_zoom * source.Height / 16f);
+                                                dest.Y += (int)(((16 - source.Height - 18) / 2F) * _zoom / 16);
+                                                dest.X -= (int)((2 * _zoom / 16));
+                                                break;
+                                            case 2:
+                                                tileTex = (Texture2D)_textureDictionary.GetArmorLegs(armor);
+                                                source = new Rectangle(2, 42, 36, 12);
+                                                dest.Width = (int)(_zoom * source.Width / 16f);
+                                                dest.Height = (int)(_zoom * source.Height / 16f);
+                                                dest.Y -= (int)((2 * _zoom / 16));
+                                                dest.X -= (int)((2 * _zoom / 16));
+                                                break;
+                                        }
+                                        if (curtile.U % 100 < 36)
+                                            _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.FlipHorizontally, LayerTileTrack);
+                                        else
+                                            _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTrack);
+                                        tileTex = _textureDictionary.GetTile(curtile.Type);
+                                        source = new Rectangle((curtile.U % 100), curtile.V, tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                        dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                    }
+                                    else if ((curtile.Type == (int)TileType.WeaponRackLegacy) && curtile.U >= 5000)
+                                    {
+                                        if (_wvm.CurrentWorld.Tiles[x + 1, y].U >= 5000)
+                                        {
+                                            int weapon = (curtile.U % 5000) - 100;
+                                            tileTex = (Texture2D)_textureDictionary.GetItem(weapon);
+                                            int flip = curtile.U / 5000;
+                                            float scale = 1f;
+                                            if (tileTex.Width > 40 || tileTex.Height > 40)
+                                            {
+                                                if (tileTex.Width > tileTex.Height)
+                                                    scale = 40f / (float)tileTex.Width;
+                                                else
+                                                    scale = 40f / (float)tileTex.Height;
+                                            }
+                                            if (WorldConfiguration.ItemLookupTable.TryGetValue(weapon, out var itemProps))
+                                            {
+                                                scale *= itemProps?.Scale ?? 1.0f;
+                                            }
+                                            source = new Rectangle(0, 0, tileTex.Width, tileTex.Height);
+                                            SpriteEffects effect = SpriteEffects.None;
+                                            if (flip >= 3)
+                                            {
+                                                effect = SpriteEffects.FlipHorizontally;
+                                            }
+                                            _spriteBatch.Draw(tileTex, new Vector2(1 + (int)((_scrollPosition.X + x + 1.5) * _zoom), 1 + (int)((_scrollPosition.Y + y + .5) * _zoom)), source, tilePaintColor, 0f, new Vector2((float)(tileTex.Width / 2), (float)(tileTex.Height / 2)), scale * _zoom / 16f, effect, LayerTileTrack);
+                                        }
+                                        source = new Rectangle(((curtile.U / 5000) - 1) * 18, curtile.V, tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                        tileTex = _textureDictionary.GetTile(curtile.Type);
+                                        dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                    }
+                                    else if (curtile.Type == (int)TileType.ItemFrame && curtile.V == 0 && curtile.U % 36 == 0)
+                                    {
+                                        TileEntity entity = _wvm.CurrentWorld.GetTileEntityAtTile(x, y);
+                                        if (entity != null)
+                                        {
+                                            int item = entity.NetId;
+                                            if (item > 0)
+                                            {
+                                                tileTex = (Texture2D)_textureDictionary.GetItem(item);
+                                                float scale = 1f;
+                                                if (tileTex.Width > 20 || tileTex.Height > 20)
+                                                {
+                                                    if (tileTex.Width > tileTex.Height)
+                                                        scale = 20f / (float)tileTex.Width;
+                                                    else
+                                                        scale = 20f / (float)tileTex.Height;
+                                                }
+                                                if (WorldConfiguration.ItemLookupTable.TryGetValue(item, out var itemProps))
+                                                {
+                                                    scale *= itemProps?.Scale ?? 1.0f;
+                                                }
+                                                source = new Rectangle(0, 0, tileTex.Width, tileTex.Height);
+                                                _spriteBatch.Draw(
+                                                    tileTex,
+                                                    new Vector2(
+                                                        1 + (int)((_scrollPosition.X + x + 1) * _zoom),
+                                                        1 + (int)((_scrollPosition.Y + y + 1) * _zoom)),
+                                                    source,
+                                                    Color.White,
+                                                    0f,
+                                                    new Vector2((float)(tileTex.Width / 2),
+                                                    (float)(tileTex.Height / 2)),
+                                                    scale * _zoom / 16f,
+                                                    SpriteEffects.None,
+                                                    LayerTileTrack);
+                                            }
+                                        }
+                                        source = new Rectangle(curtile.U, curtile.V, tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                        tileTex = _textureDictionary.GetTile(curtile.Type);
+                                        dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                    }
+                                    else if (curtile.Type == (int)TileType.FoodPlatter)
+                                    {
+                                        SpriteEffects effect = SpriteEffects.None;
+                                        if (curtile.U == 0)
+                                        {
+                                            effect = SpriteEffects.FlipHorizontally;
+                                        }
+
+
+                                        TileEntity entity = _wvm.CurrentWorld.GetTileEntityAtTile(x, y);
+                                        if (entity != null)
+                                        {
+                                            int item = entity.NetId;
+                                            if (item > 0)
+                                            {
+                                                tileTex = (Texture2D)_textureDictionary.GetItem(item);
+                                                bool isFood = false;
+                                                if (WorldConfiguration.ItemLookupTable.TryGetValue(item, out var itemData))
+                                                {
+                                                    isFood = itemData?.IsFood ?? false;
+
+                                                }
+                                                source = !isFood ? tileTex.Frame(1, 1, 0, 0, 0, 0) : tileTex.Frame(1, 3, 0, 2, 0, 0);
+
+                                                float scale = 1f;
+
+                                                _spriteBatch.Draw(tileTex,
+                                                    new Vector2(
+                                                        1 + (int)((_scrollPosition.X + x + 0.5) * _zoom),
+                                                        1 + (int)((_scrollPosition.Y + y + 1) * _zoom)),
+                                                    source,
+                                                    tilePaintColor,
+                                                    0f,
+                                                    new Vector2((float)(source.Width / 2),
+                                                    (float)(source.Height)),
+                                                    scale * _zoom / 16f,
+                                                    effect,
+                                                    LayerTileTrack);
+                                            }
+                                            //else
+                                            {
+                                                tileTex = _textureDictionary.GetTile(curtile.Type);
+                                                source = (curtile.U == 0) ? tileTex.Frame(2, 1, 0, 0, 0, 0) : tileTex.Frame(2, 1, 1, 0, 0, 0);
+                                                _spriteBatch.Draw(tileTex,
+                                                     new Vector2(
+                                                         1 + (int)((_scrollPosition.X + x + 1) * _zoom),
+                                                         1 + (int)((_scrollPosition.Y + y + 0.5) * _zoom)),
+                                                     source,
+                                                     tilePaintColor,
+                                                     0f,
+                                                     new Vector2((float)(tileTex.Width / 2),
+                                                     (float)(tileTex.Height / 2)),
+                                                     1f * _zoom / 16f,
+                                                     effect,
+                                                     LayerTileTextures);
+                                            }
+                                        }
+                                    }
+                                    else if (curtile.Type == (int)TileType.ChristmasTree) // Christmas Tree
+                                    {
+                                        if (curtile.U >= 10)
+                                        {
+                                            int star = curtile.V & 7;
+                                            int garland = (curtile.V >> 3) & 7;
+                                            int bulb = (curtile.V >> 6) & 0xf;
+                                            int light = (curtile.V >> 10) & 0xf;
+                                            source = new Rectangle(0, 0, 64, 128);
+                                            dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom * 4, (int)_zoom * 8);
+                                            if (star > 0)
+                                            {
+                                                tileTex = (Texture2D)_textureDictionary.GetMisc("Xmas_3");
+                                                source.X = 66 * (star - 1);
+                                                _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTrack);
+                                            }
+                                            if (garland > 0)
+                                            {
+                                                tileTex = (Texture2D)_textureDictionary.GetMisc("Xmas_1");
+                                                source.X = 66 * (garland - 1);
+                                                _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTrack);
+                                            }
+                                            if (bulb > 0)
+                                            {
+                                                tileTex = (Texture2D)_textureDictionary.GetMisc("Xmas_2");
+                                                source.X = 66 * (bulb - 1);
+                                                _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTrack);
+                                            }
+                                            if (light > 0)
+                                            {
+                                                tileTex = (Texture2D)_textureDictionary.GetMisc("Xmas_4");
+                                                source.X = 66 * (light - 1);
+                                                _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTrack);
+                                            }
+                                            source.X = 0;
+                                            tileTex = (Texture2D)_textureDictionary.GetMisc("Xmas_0");
+                                        }
+                                    }
+                                    else if (curtile.Type == (int)TileType.MinecartTrack)
+                                    {
+                                        source = new Rectangle(0, 0, 16, 16);
+                                        dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                        if (curtile.V >= 0) // Switch Track, Y is back tile if not -1
+                                        {
+                                            Vector2Int32 uvback = TrackUV(curtile.V);
+                                            source.X = uvback.X * (source.Width + 2);
+                                            source.Y = uvback.Y * (source.Height + 2);
+                                            _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTrackBack);
+                                        }
+                                        if ((curtile.U >= 2 && curtile.U <= 3) || (curtile.U >= 10 && curtile.U <= 13))
+                                        { // Adding regular endcap
+                                            dest.Y = 1 + (int)((_scrollPosition.Y + y - 1) * _zoom);
+                                            source.X = 0;
+                                            source.Y = 126;
+                                            _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTrack);
+                                        }
+                                        if (curtile.U >= 24 && curtile.U <= 29)
+                                        { // Adding bumper endcap
+                                            dest.Y = 1 + (int)((_scrollPosition.Y + y - 1) * _zoom);
+                                            source.X = 18;
+                                            source.Y = 126;
+                                            _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTrack);
+                                        }
+                                        if (curtile.U == 4 || curtile.U == 9 || curtile.U == 10 || curtile.U == 16 || curtile.U == 26 || curtile.U == 33 || curtile.U == 35 || curtile.V == 4)
+                                        { // Adding angle track bottom right
+                                            dest.Y = 1 + (int)((_scrollPosition.Y + y + 1) * _zoom);
+                                            source.X = 0;
+                                            source.Y = 108;
+                                            for (int slice = 0; slice < 6; slice++)
+                                            {
+                                                Rectangle? sourceSlice = new Rectangle(source.X + slice * 2, source.Y, 2, 12 - slice * 2);
+                                                Vector2 destSlice = new Vector2((int)(dest.X + slice * _zoom / 8.0f), dest.Y);
+
+                                                _spriteBatch.Draw(tileTex, destSlice, sourceSlice, tilePaintColor, 0f, default, _zoom / 16, SpriteEffects.None, LayerTileTrack);
+                                            }
+                                        }
+                                        if (curtile.U == 5 || curtile.U == 8 || curtile.U == 11 || curtile.U == 17 || curtile.U == 27 || curtile.U == 32 || curtile.U == 34 || curtile.V == 5)
+                                        { // Adding angle track bottom left
+                                            dest.Y = 1 + (int)((_scrollPosition.Y + y + 1) * _zoom);
+                                            source.X = 18;
+                                            source.Y = 108;
+                                            for (int slice = 2; slice < 8; slice++)
+                                            {
+                                                Rectangle? sourceSlice = new Rectangle(source.X + slice * 2, source.Y, 2, slice * 2 - 2);
+                                                Vector2 destSlice = new Vector2((int)(dest.X + slice * _zoom / 8.0f), dest.Y);
+
+                                                _spriteBatch.Draw(tileTex, destSlice, sourceSlice, tilePaintColor, 0f, default, _zoom / 16, SpriteEffects.None, LayerTileTrack);
+                                            }
+                                        }
+                                        dest.Y = 1 + (int)((_scrollPosition.Y + y) * _zoom);
+                                        Vector2Int32 uv = TrackUV(curtile.U);
+                                        source.X = uv.X * (source.Width + 2);
+                                        source.Y = uv.Y * (source.Height + 2);
+
+                                    }
+                                    else if (isTreeSpecial)
+                                    {
+                                        source = new Rectangle(0, 0, 40, 40);
+                                        dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                        FrameAnchor frameAnchor = FrameAnchor.None;
+
+                                        int treeStyle = (curtile.uvTileCache & 0x000F);
+                                        if (isBase)
+                                        {
+                                            source.Width = 80;
+                                            source.Height = 80;
+                                            if (curtile.Type == 323)
+                                            {
+                                                source.Y = treeStyle * (source.Height + 2);
+                                                source.X = ((curtile.U - 88) / 22) * (source.Width + 2);
+                                                dest.X += (int)(curtile.V * _zoom / 16);
+                                            }
+                                            else
+                                            {
+                                                switch (treeStyle)
+                                                {
+                                                    case 2:
+                                                    case 11:
+                                                    case 13:
+                                                        source.Width = 114;
+                                                        source.Height = 96;
+                                                        break;
+                                                    case 3:
+                                                        source.X = (x % 3) * (82 * 3);
+                                                        source.Height = 140;
+                                                        break;
+                                                }
+                                                source.X += ((curtile.V - 198) / 22) * (source.Width + 2);
+                                            }
+                                            frameAnchor = FrameAnchor.Bottom;
+                                        }
+                                        else if (isLeft)
+                                        {
+                                            source.X = 0;
+                                            switch (treeStyle)
+                                            {
+                                                case 3:
+                                                    source.Y = (x % 3) * (42 * 3);
+                                                    break;
+                                            }
+                                            frameAnchor = FrameAnchor.Right;
+                                            source.Y += ((curtile.V - 198) / 22) * (source.Height + 2);
+                                        }
+                                        else if (isRight)
+                                        {
+                                            source.X = 42;
+                                            switch (treeStyle)
+                                            {
+                                                case 3:
+                                                    source.Y = (x % 3) * (42 * 3);
+                                                    break;
+                                            }
+                                            frameAnchor = FrameAnchor.Left;
+                                            source.Y += ((curtile.V - 198) / 22) * (source.Height + 2);
+                                        }
+                                        dest.Width = (int)(_zoom * source.Width / 16f);
+                                        dest.Height = (int)(_zoom * source.Height / 16f);
+                                        switch (frameAnchor)
+                                        {
+                                            case FrameAnchor.None:
+                                                dest.X += (int)(((16 - source.Width) / 2F) * _zoom / 16);
+                                                dest.Y += (int)(((16 - source.Height) / 2F) * _zoom / 16);
+                                                break;
+                                            case FrameAnchor.Left:
+                                                dest.Y += (int)(((16 - source.Height) / 2F) * _zoom / 16);
+                                                break;
+                                            case FrameAnchor.Right:
+                                                dest.X += (int)((16 - source.Width) * _zoom / 16);
+                                                dest.Y += (int)(((16 - source.Height) / 2F) * _zoom / 16);
+                                                break;
+                                            case FrameAnchor.Top:
+                                                dest.X += (int)(((16 - source.Width) / 2F) * _zoom / 16);
+                                                break;
+                                            case FrameAnchor.Bottom:
+                                                dest.X += (int)(((16 - source.Width) / 2F) * _zoom / 16);
+                                                dest.Y += (int)((16 - source.Height) * _zoom / 16);
+                                                break;
+                                        }
+                                    }
+                                    else if (isMushroom)
+                                    {
+                                        source = new Rectangle(0, 0, 60, 42);
+                                        dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                        source.X = (curtile.V / 18) * 62;
+
+                                        dest.Width = (int)(_zoom * source.Width / 16f);
+                                        dest.Height = (int)(_zoom * source.Height / 16f);
+                                        dest.X += (int)(((16 - source.Width) / 2F) * _zoom / 16);
+                                        dest.Y += (int)((16 - source.Height) * _zoom / 16);
+                                    }
+                                    else if ((curtile.Type >= 373 && curtile.Type <= 375) || curtile.Type == 461)
+                                    {
+                                        //skip rendering drips
+                                    }
+                                    else
+                                    {
+                                        var type = curtile.Type;
+                                        var renderUV = TileProperty.GetRenderUV(curtile.Type, curtile.U, curtile.V);
+
+                                        source = new Rectangle(renderUV.X, renderUV.Y, tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                        if (source.Width <= 0)
+                                            source.Width = 16;
+                                        if (source.Height <= 0)
+                                            source.Height = 16;
+
+                                        if (source.Bottom > tileTex.Height)
+                                            source.Height -= (source.Bottom - tileTex.Height);
+                                        if (source.Right > tileTex.Width)
+                                            source.Width -= (source.Right - tileTex.Width);
+
+                                        if (source.Width <= 0 || source.Height <= 0)
+                                            continue;
+
+                                        dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                        if (curtile.Type == 323)
+                                        {
+                                            dest.X += (int)(curtile.V * _zoom / 16);
+                                            int treeType = (curtile.uvTileCache & 0x000F);
+                                            source.Y = 22 * treeType;
+                                        }
+                                        var texsize = tileprop.TextureGrid;
+                                        if (texsize.X != 16 || texsize.Y != 16)
+                                        {
+                                            dest.Width = (int)(texsize.X * (_zoom / 16));
+                                            dest.Height = (int)(texsize.Y * (_zoom / 16));
+
+                                            var frame = (tileprop.Frames.FirstOrDefault(f => f.UV == new Vector2Short(curtile.U, curtile.V)));
+                                            var frameAnchor = FrameAnchor.None;
+                                            if (frame != null)
+                                                frameAnchor = frame.Anchor;
+                                            switch (frameAnchor)
+                                            {
+                                                case FrameAnchor.None:
+                                                    dest.X += (int)(((16 - texsize.X) / 2F) * _zoom / 16);
+                                                    dest.Y += (int)(((16 - texsize.Y) / 2F) * _zoom / 16);
+                                                    break;
+                                                case FrameAnchor.Left:
+                                                    //position.X += (16 - texsize.X) / 2;
+                                                    dest.Y += (int)(((16 - texsize.Y) / 2F) * _zoom / 16);
+                                                    break;
+                                                case FrameAnchor.Right:
+                                                    dest.X += (int)((16 - texsize.X) * _zoom / 16);
+                                                    dest.Y += (int)(((16 - texsize.Y) / 2F) * _zoom / 16);
+                                                    break;
+                                                case FrameAnchor.Top:
+                                                    dest.X += (int)(((16 - texsize.X) / 2F) * _zoom / 16);
+                                                    //position.Y += (16 - texsize.Y);
+                                                    break;
+                                                case FrameAnchor.Bottom:
+                                                    dest.X += (int)(((16 - texsize.X) / 2F) * _zoom / 16);
+                                                    dest.Y += (int)((16 - texsize.Y) * _zoom / 16);
+                                                    break;
+                                            }
+                                        }
+                                    }
+
+                                    _spriteBatch.Draw(tileTex, dest, source, curtile.InActive ? Color.Gray : tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTextures);
+                                    // Actuator Overlay
+                                    if (curtile.Actuator && _wvm.ShowActuators)
+                                        _spriteBatch.Draw(_textureDictionary.Actuator, dest, _textureDictionary.ZeroSixteenRectangle, Color.White, 0f, default, SpriteEffects.None, LayerTileActuator);
+
+                                }
+                            }
+                            else if (tileprop.IsPlatform)
+                            {
+                                var tileTex = _textureDictionary.GetTile(curtile.Type);
+
+                                if (tileTex != null)
+                                {
+                                    Vector2Int32 uv;
+                                    if (curtile.uvTileCache == 0xFFFF)
+                                    {
+                                        uv = new Vector2Int32(0, 0);
+                                        byte state = 0x00;
+                                        state |= (byte)((neighborTile[w] != null && neighborTile[w].IsActive && neighborTile[w].Type == curtile.Type) ? 0x01 : 0x00);
+                                        state |= (byte)((neighborTile[w] != null && neighborTile[w].IsActive && WorldConfiguration.GetTileProperties(neighborTile[w].Type).HasSlopes && neighborTile[w].Type != curtile.Type) ? 0x02 : 0x00);
+                                        state |= (byte)((neighborTile[e] != null && neighborTile[e].IsActive && neighborTile[e].Type == curtile.Type) ? 0x04 : 0x00);
+                                        state |= (byte)((neighborTile[e] != null && neighborTile[e].IsActive && WorldConfiguration.GetTileProperties(neighborTile[e].Type).HasSlopes && neighborTile[e].Type != curtile.Type) ? 0x08 : 0x00);
+                                        switch (state)
+                                        {
+                                            case 0x00:
+                                            case 0x0A:
+                                                uv.X = 5;
+                                                break;
+                                            case 0x01:
+                                                uv.X = 1;
+                                                break;
+                                            case 0x02:
+                                                uv.X = 6;
+                                                break;
+                                            case 0x04:
+                                                uv.X = 2;
+                                                break;
+                                            case 0x05:
+                                                uv.X = 0;
+                                                break;
+                                            case 0x06:
+                                                uv.X = 3;
+                                                break;
+                                            case 0x08:
+                                                uv.X = 7;
+                                                break;
+                                            case 0x09:
+                                                uv.X = 4;
+                                                break;
+                                        }
+                                        uv.Y = blendRules.randomVariation.Next(3);
+                                        curtile.uvTileCache = (ushort)((uv.Y << 8) + uv.X);
+                                    }
+
+                                    var texsize = new Vector2Int32(tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                    if (texsize.X == 0 || texsize.Y == 0)
+                                    {
+                                        texsize = new Vector2Int32(16, 16);
+                                    }
+                                    var source = new Rectangle((curtile.uvTileCache & 0x00FF) * (texsize.X + 2), (curtile.uvTileCache >> 8) * (texsize.Y + 2), texsize.X, texsize.Y);
+                                    var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                    _spriteBatch.Draw(tileTex, dest, source, curtile.InActive ? Color.Gray : tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTextures);
+                                    // Actuator Overlay
+                                    if (curtile.Actuator && _wvm.ShowActuators)
+                                        _spriteBatch.Draw(_textureDictionary.Actuator, dest, _textureDictionary.ZeroSixteenRectangle, Color.White, 0f, default, SpriteEffects.None, LayerTileActuator);
+
+                                }
+                            }
+                            else if (tileprop.IsCactus)
+                            {
+
+                                var tileTex = _textureDictionary.GetTile(curtile.Type);
+
+                                if ((curtile.uvTileCache & 0x00FF) >= 24)
+                                {
+                                    tileTex = (Texture2D)_textureDictionary.GetMisc("Crimson_Cactus");
+                                }
+                                else if ((curtile.uvTileCache & 0x00FF) >= 16)
+                                {
+                                    tileTex = (Texture2D)_textureDictionary.GetMisc("Evil_Cactus");
+                                }
+                                else if ((curtile.uvTileCache & 0x00FF) >= 8)
+                                {
+                                    tileTex = (Texture2D)_textureDictionary.GetMisc("Good_Cactus");
+                                }
+
+                                if (tileTex != null)
+                                {
+                                    Vector2Int32 uv;
+                                    if (curtile.uvTileCache == 0xFFFF || curtile.hasLazyChecked == false)
+                                    {
+                                        bool isLeft = false, isRight = false, isBase = false;
+
+                                        //Has this cactus been base-evaluated yet?
+                                        int neighborX = (neighborTile[w].uvTileCache & 0x00FF) % 8; //Why % 8? If X >= 8, use hallow, If X >= 16, use corruption
+                                        if (neighborX == 0 || neighborX == 1 || neighborX == 4 || neighborX == 5)
+                                        {
+                                            isRight = true;
+                                        }
+                                        neighborX = neighborTile[e].uvTileCache & 0x00FF;
+                                        if (neighborX == 0 || neighborX == 1 || neighborX == 4 || neighborX == 5)
+                                        {
+                                            isLeft = true;
+                                        }
+                                        neighborX = curtile.uvTileCache & 0x00FF;
+                                        if (neighborX == 0 || neighborX == 1 || neighborX == 4 || neighborX == 5)
+                                        {
+                                            isBase = true;
+                                        }
+
+                                        //Evaluate Base
+                                        if (isLeft == false && isRight == false && isBase == false)
+                                        {
+                                            int length1 = 0;
+                                            int length2 = 0;
+                                            while (true)
+                                            {
+                                                Tile checkTile = (y + length1) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x, y + length1] : null;
+                                                if (checkTile == null || checkTile.IsActive == false || checkTile.Type != curtile.Type)
+                                                {
+                                                    break;
+                                                }
+                                                length1++;
+                                            }
+                                            if (x + 1 < _wvm.CurrentWorld.TilesWide)
+                                            {
+                                                while (true)
+                                                {
+                                                    Tile checkTile = (y + length2) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x + 1, y + length2] : null;
+                                                    if (checkTile == null || checkTile.IsActive == false || checkTile.Type != curtile.Type)
+                                                    {
+                                                        break;
+                                                    }
+                                                    length2++;
+                                                }
+                                            }
+                                            int baseX = 0;
+                                            int baseY = length1;
+                                            isBase = true;
+                                            if (length2 >= length1)
+                                            {
+                                                baseX = 1;
+                                                baseY = length2;
+                                                isBase = false;
+                                                isLeft = true;
+                                            }
+                                            for (int cy = y; cy < y + baseY; cy++)
+                                            {
+                                                if (_wvm.CurrentWorld.Tiles[x + baseX, cy].uvTileCache == 0xFFFF)
+                                                {
+                                                    if (cy == y)
+                                                    {
+                                                        _wvm.CurrentWorld.Tiles[x + baseX, cy].uvTileCache = 0x00 << 8 + 0x00;
+                                                    }
+                                                    else
+                                                    {
+                                                        _wvm.CurrentWorld.Tiles[x + baseX, cy].uvTileCache = 0x01 << 8 + 0x00;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        uv = new Vector2Int32(0, 0);
+                                        byte state = 0x00;
+                                        state |= (byte)((neighborTile[e] != null && neighborTile[e].IsActive && neighborTile[e].Type == curtile.Type) ? 0x01 : 0x00);
+                                        state |= (byte)((neighborTile[n] != null && neighborTile[n].IsActive && neighborTile[n].Type == curtile.Type) ? 0x02 : 0x00);
+                                        state |= (byte)((neighborTile[w] != null && neighborTile[w].IsActive && neighborTile[w].Type == curtile.Type) ? 0x04 : 0x00);
+                                        state |= (byte)((neighborTile[s] != null && neighborTile[s].IsActive && neighborTile[s].Type == curtile.Type) ? 0x08 : 0x00);
+                                        //state |= (byte)((neighborTile[ne] != null && neighborTile[ne].IsActive && neighborTile[ne].Type == curtile.Type) ? 0x10 : 0x00);
+                                        //state |= (byte)((neighborTile[nw] != null && neighborTile[nw].IsActive && neighborTile[nw].Type == curtile.Type) ? 0x20 : 0x00);
+                                        state |= (byte)((neighborTile[sw] != null && neighborTile[sw].IsActive && neighborTile[sw].Type == curtile.Type) ? 0x40 : 0x00);
+                                        state |= (byte)((neighborTile[se] != null && neighborTile[se].IsActive && neighborTile[se].Type == curtile.Type) ? 0x80 : 0x00);
+
+                                        if (isLeft)
+                                        {
+                                            uv.X = 3;
+                                            if ((state & 0x08) != 0x00) //s
+                                            {
+                                                if ((state & 0x02) != 0x00) //n
+                                                {
+                                                    uv.Y = 1;
+                                                }
+                                                else //!n
+                                                {
+                                                    uv.Y = 0;
+                                                }
+                                            }
+                                            else //!s
+                                            {
+                                                if ((state & 0x02) != 0x00) //n
+                                                {
+                                                    uv.Y = 2;
+                                                }
+                                                else //!n
+                                                {
+                                                    uv.X = 6;
+                                                    uv.Y = 2;
+                                                }
+                                            }
+                                        }
+                                        if (isRight)
+                                        {
+                                            uv.X = 2;
+                                            if ((state & 0x08) != 0x00) //s
+                                            {
+                                                if ((state & 0x02) != 0x00) //n
+                                                {
+                                                    uv.Y = 1;
+                                                }
+                                                else //!n
+                                                {
+                                                    uv.Y = 0;
+                                                }
+                                            }
+                                            else //!s
+                                            {
+                                                if ((state & 0x02) != 0x00) //n
+                                                {
+                                                    uv.Y = 2;
+                                                }
+                                                else //!n
+                                                {
+                                                    uv.X = 6;
+                                                    uv.Y = 1;
+                                                }
+                                            }
+                                        }
+                                        if (isBase)
+                                        {
+                                            if ((state & 0x02) != 0x00) //n
+                                            {
+                                                uv.Y = 2;
+                                                if ((state & 0x04) != 0x00 && (state & 0x40) == 0x00 && ((state & 0x01) == 0x00 || (state & 0x80) != 0x00)) //w !sw (!e or se)
+                                                {
+                                                    uv.X = 4;
+                                                }
+                                                else if ((state & 0x01) != 0x00 && (state & 0x80) == 0x00 && ((state & 0x04) == 0x00 || (state & 0x40) != 0x00)) //e !se (!w or sw)
+                                                {
+                                                    uv.X = 1;
+                                                }
+                                                else if ((state & 0x04) != 0x00 && (state & 0x40) == 0x00 && (state & 0x01) != 0x00 && (state & 0x80) == 0x00) //w !sw e !se
+                                                {
+                                                    uv.X = 5;
+                                                }
+                                                else
+                                                {
+                                                    uv.X = 0;
+                                                    uv.Y = 1;
+                                                }
+                                            }
+                                            else //!n
+                                            {
+                                                uv.Y = 0;
+                                                if ((state & 0x04) != 0x00 && (state & 0x40) == 0x00 && ((state & 0x01) == 0x00 || (state & 0x80) != 0x00)) //w !sw (!e or se)
+                                                {
+                                                    uv.X = 4;
+                                                }
+                                                else if ((state & 0x01) != 0x00 && (state & 0x80) == 0x00 && ((state & 0x04) == 0x00 || (state & 0x40) != 0x00)) //e !se (!w or sw)
+                                                {
+                                                    uv.X = 1;
+                                                }
+                                                else if ((state & 0x04) != 0x00 && (state & 0x40) == 0x00 && (state & 0x01) != 0x00 && (state & 0x80) == 0x00) //w !sw e !se
+                                                {
+                                                    uv.X = 5;
+                                                }
+                                                else
+                                                {
+                                                    uv.X = 0;
+                                                    uv.Y = 0;
+                                                }
+                                            }
+                                        }
+
+                                        //Check if cactus is good or evil
+                                        for (int i = 0; i < 100; i++)
+                                        {
+                                            int baseX = (isLeft) ? 1 : (isRight) ? -1 : 0;
+                                            Tile checkTile = (y + i) < _wvm.CurrentWorld.TilesHigh ? _wvm.CurrentWorld.Tiles[x + baseX, y + i] : null;
+                                            if (checkTile != null && checkTile.IsActive && checkTile.Type == (int)TileType.CrimsandBlock) //Crimson
+                                            {
+                                                uv.X += 24;
+                                                break;
+                                            }
+                                            if (checkTile != null && checkTile.IsActive && checkTile.Type == (int)TileType.EbonsandBlock) //Corruption
+                                            {
+                                                uv.X += 16;
+                                                break;
+                                            }
+                                            else if (checkTile != null && checkTile.IsActive && checkTile.Type == (int)TileType.PearlsandBlock) //Hallow
+                                            {
+                                                uv.X += 8;
+                                                break;
+                                            }
+                                        }
+                                        curtile.hasLazyChecked = true;
+
+                                        curtile.uvTileCache = (ushort)((uv.Y << 8) + uv.X);
+                                    }
+
+                                    var texsize = new Vector2Int32(tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                    if (texsize.X == 0 || texsize.Y == 0)
+                                    {
+                                        texsize = new Vector2Int32(16, 16);
+                                    }
+                                    var source = new Rectangle(((curtile.uvTileCache & 0x00FF) % 8) * (texsize.X + 2), (curtile.uvTileCache >> 8) * (texsize.Y + 2), texsize.X, texsize.Y);
+                                    var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                    _spriteBatch.Draw(tileTex, dest, source, tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTextures);
+                                }
+                            }
+                            else if (tileprop.CanBlend || !(tileprop.IsFramed || tileprop.IsAnimated))
+                            {
+                                var tileTex = _textureDictionary.GetTile(curtile.Type);
+
+                                if (tileTex != null)
+                                {
+                                    if (curtile.uvTileCache == 0xFFFF || curtile.hasLazyChecked == false)
+                                    {
+                                        int sameStyle = 0x00000000;
+                                        int mergeMask = 0x00000000;
+                                        int strictness = 0;
+                                        if (tileprop.MergeWith.HasValue && tileprop.MergeWith.Value == -1) //Basically for cobweb
+                                        {
+                                            sameStyle |= (neighborTile[e] != null && neighborTile[e].IsActive) ? 0x0001 : 0x0000;
+                                            sameStyle |= (neighborTile[n] != null && neighborTile[n].IsActive) ? 0x0010 : 0x0000;
+                                            sameStyle |= (neighborTile[w] != null && neighborTile[w].IsActive) ? 0x0100 : 0x0000;
+                                            sameStyle |= (neighborTile[s] != null && neighborTile[s].IsActive) ? 0x1000 : 0x0000;
+                                        }
+                                        else if (tileprop.IsStone) //Stone & Gems
+                                        {
+                                            sameStyle |= (neighborTile[e] != null && neighborTile[e].IsActive && WorldConfiguration.GetTileProperties(neighborTile[e].Type).IsStone) ? 0x0001 : 0x0000;
+                                            sameStyle |= (neighborTile[n] != null && neighborTile[n].IsActive && WorldConfiguration.GetTileProperties(neighborTile[n].Type).IsStone) ? 0x0010 : 0x0000;
+                                            sameStyle |= (neighborTile[w] != null && neighborTile[w].IsActive && WorldConfiguration.GetTileProperties(neighborTile[w].Type).IsStone) ? 0x0100 : 0x0000;
+                                            sameStyle |= (neighborTile[s] != null && neighborTile[s].IsActive && WorldConfiguration.GetTileProperties(neighborTile[s].Type).IsStone) ? 0x1000 : 0x0000;
+                                            sameStyle |= (neighborTile[ne] != null && neighborTile[ne].IsActive && WorldConfiguration.GetTileProperties(neighborTile[ne].Type).IsStone) ? 0x00010000 : 0x00000000;
+                                            sameStyle |= (neighborTile[nw] != null && neighborTile[nw].IsActive && WorldConfiguration.GetTileProperties(neighborTile[nw].Type).IsStone) ? 0x00100000 : 0x00000000;
+                                            sameStyle |= (neighborTile[sw] != null && neighborTile[sw].IsActive && WorldConfiguration.GetTileProperties(neighborTile[sw].Type).IsStone) ? 0x01000000 : 0x00000000;
+                                            sameStyle |= (neighborTile[se] != null && neighborTile[se].IsActive && WorldConfiguration.GetTileProperties(neighborTile[se].Type).IsStone) ? 0x10000000 : 0x00000000;
+                                        }
+                                        else //Everything else
+                                        {
+                                            //Join to nearby tiles if their merge type is this tile's type
+                                            sameStyle |= (neighborTile[e] != null && neighborTile[e].IsActive && tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[e].Type))) ? 0x0001 : 0x0000;
+                                            sameStyle |= (neighborTile[n] != null && neighborTile[n].IsActive && tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[n].Type))) ? 0x0010 : 0x0000;
+                                            sameStyle |= (neighborTile[w] != null && neighborTile[w].IsActive && tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[w].Type))) ? 0x0100 : 0x0000;
+                                            sameStyle |= (neighborTile[s] != null && neighborTile[s].IsActive && tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[s].Type))) ? 0x1000 : 0x0000;
+                                            sameStyle |= (neighborTile[ne] != null && neighborTile[ne].IsActive && tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[ne].Type))) ? 0x00010000 : 0x00000000;
+                                            sameStyle |= (neighborTile[nw] != null && neighborTile[nw].IsActive && tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[nw].Type))) ? 0x00100000 : 0x00000000;
+                                            sameStyle |= (neighborTile[sw] != null && neighborTile[sw].IsActive && tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[sw].Type))) ? 0x01000000 : 0x00000000;
+                                            sameStyle |= (neighborTile[se] != null && neighborTile[se].IsActive && tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[se].Type))) ? 0x10000000 : 0x00000000;
+                                            //Join if nearby tiles have the same type as this tile's type
+                                            sameStyle |= (neighborTile[e] != null && neighborTile[e].IsActive && curtile.Type == neighborTile[e].Type) ? 0x0001 : 0x0000;
+                                            sameStyle |= (neighborTile[n] != null && neighborTile[n].IsActive && curtile.Type == neighborTile[n].Type) ? 0x0010 : 0x0000;
+                                            sameStyle |= (neighborTile[w] != null && neighborTile[w].IsActive && curtile.Type == neighborTile[w].Type) ? 0x0100 : 0x0000;
+                                            sameStyle |= (neighborTile[s] != null && neighborTile[s].IsActive && curtile.Type == neighborTile[s].Type) ? 0x1000 : 0x0000;
+                                            sameStyle |= (neighborTile[ne] != null && neighborTile[ne].IsActive && curtile.Type == neighborTile[ne].Type) ? 0x00010000 : 0x00000000;
+                                            sameStyle |= (neighborTile[nw] != null && neighborTile[nw].IsActive && curtile.Type == neighborTile[nw].Type) ? 0x00100000 : 0x00000000;
+                                            sameStyle |= (neighborTile[sw] != null && neighborTile[sw].IsActive && curtile.Type == neighborTile[sw].Type) ? 0x01000000 : 0x00000000;
+                                            sameStyle |= (neighborTile[se] != null && neighborTile[se].IsActive && curtile.Type == neighborTile[se].Type) ? 0x10000000 : 0x00000000;
+                                        }
+                                        if (curtile.hasLazyChecked == false)
+                                        {
+                                            bool lazyCheckReady = true;
+                                            lazyCheckReady &= (neighborTile[e] == null || neighborTile[e].IsActive == false || !tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[e].Type))) ? true : (neighborTile[e].lazyMergeId != 0xFF);
+                                            lazyCheckReady &= (neighborTile[n] == null || neighborTile[n].IsActive == false || !tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[n].Type))) ? true : (neighborTile[n].lazyMergeId != 0xFF);
+                                            lazyCheckReady &= (neighborTile[w] == null || neighborTile[w].IsActive == false || !tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[w].Type))) ? true : (neighborTile[w].lazyMergeId != 0xFF);
+                                            lazyCheckReady &= (neighborTile[s] == null || neighborTile[s].IsActive == false || !tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[s].Type))) ? true : (neighborTile[s].lazyMergeId != 0xFF);
+                                            if (lazyCheckReady)
+                                            {
+                                                sameStyle &= 0x11111110 | ((neighborTile[e] == null || neighborTile[e].IsActive == false || !tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[e].Type))) ? 0x00000001 : ((neighborTile[e].lazyMergeId & 0x04) >> 2));
+                                                sameStyle &= 0x11111101 | ((neighborTile[n] == null || neighborTile[n].IsActive == false || !tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[n].Type))) ? 0x00000010 : ((neighborTile[n].lazyMergeId & 0x08) << 1));
+                                                sameStyle &= 0x11111011 | ((neighborTile[w] == null || neighborTile[w].IsActive == false || !tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[w].Type))) ? 0x00000100 : ((neighborTile[w].lazyMergeId & 0x01) << 8));
+                                                sameStyle &= 0x11110111 | ((neighborTile[s] == null || neighborTile[s].IsActive == false || !tileprop.Merges(WorldConfiguration.GetTileProperties(neighborTile[s].Type))) ? 0x00001000 : ((neighborTile[s].lazyMergeId & 0x02) << 11));
+                                                curtile.hasLazyChecked = true;
+                                            }
+                                        }
+                                        if (tileprop.MergeWith.HasValue && tileprop.MergeWith.Value > -1) //Merges with a specific type
+                                        {
+                                            mergeMask |= (neighborTile[e] != null && neighborTile[e].IsActive && neighborTile[e].Type == tileprop.MergeWith.Value) ? 0x0001 : 0x0000;
+                                            mergeMask |= (neighborTile[n] != null && neighborTile[n].IsActive && neighborTile[n].Type == tileprop.MergeWith.Value) ? 0x0010 : 0x0000;
+                                            mergeMask |= (neighborTile[w] != null && neighborTile[w].IsActive && neighborTile[w].Type == tileprop.MergeWith.Value) ? 0x0100 : 0x0000;
+                                            mergeMask |= (neighborTile[s] != null && neighborTile[s].IsActive && neighborTile[s].Type == tileprop.MergeWith.Value) ? 0x1000 : 0x0000;
+                                            mergeMask |= (neighborTile[ne] != null && neighborTile[ne].IsActive && neighborTile[ne].Type == tileprop.MergeWith.Value) ? 0x00010000 : 0x00000000;
+                                            mergeMask |= (neighborTile[nw] != null && neighborTile[nw].IsActive && neighborTile[nw].Type == tileprop.MergeWith.Value) ? 0x00100000 : 0x00000000;
+                                            mergeMask |= (neighborTile[sw] != null && neighborTile[sw].IsActive && neighborTile[sw].Type == tileprop.MergeWith.Value) ? 0x01000000 : 0x00000000;
+                                            mergeMask |= (neighborTile[se] != null && neighborTile[se].IsActive && neighborTile[se].Type == tileprop.MergeWith.Value) ? 0x10000000 : 0x00000000;
+                                            strictness = 1;
+                                        }
+                                        if (tileprop.IsGrass)
+                                        {
+                                            strictness = 2;
+                                        }
+
+                                        Vector2Int32 uvBlend = blendRules.GetUVForMasks((uint)sameStyle, (uint)mergeMask, strictness);
+                                        curtile.uvTileCache = (ushort)((uvBlend.Y << 8) + uvBlend.X);
+                                        curtile.lazyMergeId = blendRules.lazyMergeValidation[uvBlend.Y, uvBlend.X];
+                                    }
+
+                                    var texsize = new Vector2Int32(tileprop.TextureGrid.X, tileprop.TextureGrid.Y);
+                                    if (texsize.X == 0 || texsize.Y == 0)
+                                    {
+                                        texsize = new Vector2Int32(16, 16);
+                                    }
+                                    var source = new Rectangle((curtile.uvTileCache & 0x00FF) * (texsize.X + 2), (curtile.uvTileCache >> 8) * (texsize.Y + 2), texsize.X, texsize.Y);
+                                    var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+
+                                    // hack for some slopes
+                                    switch (curtile.BrickStyle)
+                                    {
+
+                                        case BrickStyle.HalfBrick:
+                                            source.Height /= 2;
+                                            dest.Y += (int)(_zoom * 0.5);
+                                            dest.Height = (int)(_zoom / 2.0f);
+                                            _spriteBatch.Draw(tileTex, dest, source, curtile.InActive ? Color.Gray : tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTextures);
+                                            break;
+                                        case BrickStyle.SlopeTopRight:
+
+                                            for (int slice = 0; slice < 8; slice++)
+                                            {
+                                                Rectangle? sourceSlice = new Rectangle(source.X + slice * 2, source.Y, 2, 16 - slice * 2);
+                                                Vector2 destSlice = new Vector2((int)(dest.X + slice * _zoom / 8.0f), (int)(dest.Y + slice * _zoom / 8.0f));
+
+                                                _spriteBatch.Draw(tileTex, destSlice, sourceSlice, curtile.InActive ? Color.Gray : tilePaintColor, 0f, default, _zoom / 16, SpriteEffects.None, LayerTileTextures);
+                                            }
+
+                                            break;
+                                        case BrickStyle.SlopeTopLeft:
+                                            for (int slice = 0; slice < 8; slice++)
+                                            {
+                                                Rectangle? sourceSlice = new Rectangle(source.X + slice * 2, source.Y, 2, slice * 2 + 2);
+                                                Vector2 destSlice = new Vector2((int)(dest.X + slice * _zoom / 8.0f), (int)(dest.Y + (7 - slice) * _zoom / 8.0f));
+
+                                                _spriteBatch.Draw(tileTex, destSlice, sourceSlice, curtile.InActive ? Color.Gray : tilePaintColor, 0f, default, _zoom / 16, SpriteEffects.None, LayerTileTextures);
+                                            }
+
+                                            break;
+                                        case BrickStyle.SlopeBottomRight:
+                                            for (int slice = 0; slice < 8; slice++)
+                                            {
+                                                Rectangle? sourceSlice = new Rectangle(source.X + slice * 2, source.Y + slice * 2, 2, 16 - slice * 2);
+                                                Vector2 destSlice = new Vector2((int)(dest.X + slice * _zoom / 8.0f), dest.Y);
+
+                                                _spriteBatch.Draw(tileTex, destSlice, sourceSlice, curtile.InActive ? Color.Gray : tilePaintColor, 0f, default, _zoom / 16, SpriteEffects.None, LayerTileTextures);
+                                            }
+
+                                            break;
+                                        case BrickStyle.SlopeBottomLeft:
+                                            for (int slice = 0; slice < 8; slice++)
+                                            {
+                                                Rectangle? sourceSlice = new Rectangle(source.X + slice * 2, source.Y, 2, slice * 2 + 2);
+                                                Vector2 destSlice = new Vector2((int)(dest.X + slice * _zoom / 8.0f), dest.Y);
+
+                                                _spriteBatch.Draw(tileTex, destSlice, sourceSlice, curtile.InActive ? Color.Gray : tilePaintColor, 0f, default, _zoom / 16, SpriteEffects.None, LayerTileTextures);
+                                            }
+
+                                            break;
+                                        case BrickStyle.Full:
+                                        default:
+                                            _spriteBatch.Draw(tileTex, dest, source, curtile.InActive ? Color.Gray : tilePaintColor, 0f, default, SpriteEffects.None, LayerTileTextures);
+                                            break;
+                                    }
+
+
+                                    // Actuator Overlay
+                                    if (curtile.Actuator && _wvm.ShowActuators)
+                                        _spriteBatch.Draw(_textureDictionary.Actuator, dest, _textureDictionary.ZeroSixteenRectangle, Color.White, 0f, default, SpriteEffects.None, LayerTileActuator);
+
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception)
+                {
+                    // failed to render tile? log?
+                }
+            }
+        }
+    }
+    public void DrawTileTexturesFiltered(bool drawInverted = false)
+    {
+        Rectangle visibleBounds = GetViewingArea();
+        BlendRules blendRules = BlendRules.Instance;
+        var width = _wvm.CurrentWorld.TilesWide;
+        var height = _wvm.CurrentWorld.TilesHigh;
+
+        //Extended the viewing space to give tiles time to cache their UV's
+        for (int y = visibleBounds.Top - 1; y < visibleBounds.Bottom + 2; y++)
+        {
+            for (int x = visibleBounds.Left - 1; x < visibleBounds.Right + 2; x++)
+            {
+                try
+                {
+                    if (x < 0 ||
+                        y < 0 ||
+                        x >= _wvm.CurrentWorld.TilesWide ||
+                        y >= _wvm.CurrentWorld.TilesHigh)
+                    {
+                        continue;
+                    }
+
+
+                    var curtile = _wvm.CurrentWorld.Tiles[x, y];
+
+                    if ((curtile.TileColor == 30) != drawInverted) continue;
+
+                    if (curtile.Type >= WorldConfiguration.TileProperties.Count) { continue; }
+                    var tileprop = WorldConfiguration.GetTileProperties(curtile.Type);
+
                     // Hide all tiles not within a filter when enabled.
                     bool forceGrayscale = false;
                     if (FilterManager.TileIsNotAllowed(curtile.Type))
                         if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) continue;
                         else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceGrayscale = true;
 
-                    /// <summary>
-                    /// Returns the tile at (nx, ny) unless it's out of bounds or filtered out (when filter mode is Hide).
-                    /// If filtered, returns null (treated as air/inactive).
-                    /// </summary>
-                    Tile GetTileNeighbor(int nx, int ny)
-                    {
-                        if (nx < 0 || ny < 0 || nx >= width || ny >= height) return null;
-                        var t = _wvm.CurrentWorld.Tiles[nx, ny];
-                        if (FilterManager.TileIsNotAllowed(t.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)
-                            return null;
-                        return t;
-                    }
-
                     //Neighbor tiles are often used when dynamically determining which UV position to render
                     //Tile[] neighborTile = new Tile[8];
-                    neighborTile[e] = GetTileNeighbor(x + 1, y);
-                    neighborTile[n] = GetTileNeighbor(x, y - 1);
-                    neighborTile[w] = GetTileNeighbor(x - 1, y);
-                    neighborTile[s] = GetTileNeighbor(x, y + 1);
-                    neighborTile[ne] = GetTileNeighbor(x + 1, y - 1);
-                    neighborTile[nw] = GetTileNeighbor(x - 1, y - 1);
-                    neighborTile[sw] = GetTileNeighbor(x - 1, y + 1);
-                    neighborTile[se] = GetTileNeighbor(x + 1, y + 1);
+                    neighborTile[e]  = (x + 1 < width)                   ? ((_wvm.CurrentWorld.Tiles[x + 1, y]     is var t0 && !(FilterManager.TileIsNotAllowed(t0.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)) ? t0 : null) : null;
+                    neighborTile[n]  = (y - 1 >= 0)                      ? ((_wvm.CurrentWorld.Tiles[x, y - 1]     is var t1 && !(FilterManager.TileIsNotAllowed(t1.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)) ? t1 : null) : null;
+                    neighborTile[w]  = (x - 1 >= 0)                      ? ((_wvm.CurrentWorld.Tiles[x - 1, y]     is var t2 && !(FilterManager.TileIsNotAllowed(t2.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)) ? t2 : null) : null;
+                    neighborTile[s]  = (y + 1 < height)                  ? ((_wvm.CurrentWorld.Tiles[x, y + 1]     is var t3 && !(FilterManager.TileIsNotAllowed(t3.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)) ? t3 : null) : null;
+                    neighborTile[ne] = (x + 1 < width && y - 1 >= 0)     ? ((_wvm.CurrentWorld.Tiles[x + 1, y - 1] is var t4 && !(FilterManager.TileIsNotAllowed(t4.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)) ? t4 : null) : null;
+                    neighborTile[nw] = (x - 1 >= 0 && y - 1 >= 0)        ? ((_wvm.CurrentWorld.Tiles[x - 1, y - 1] is var t5 && !(FilterManager.TileIsNotAllowed(t5.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)) ? t5 : null) : null;
+                    neighborTile[sw] = (x - 1 >= 0 && y + 1 < height)    ? ((_wvm.CurrentWorld.Tiles[x - 1, y + 1] is var t6 && !(FilterManager.TileIsNotAllowed(t6.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)) ? t6 : null) : null;
+                    neighborTile[se] = (x + 1 < width && y + 1 < height) ? ((_wvm.CurrentWorld.Tiles[x + 1, y + 1] is var t7 && !(FilterManager.TileIsNotAllowed(t7.Type) && FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)) ? t7 : null) : null;
 
                     if (_wvm.ShowTiles)
                     {
@@ -2571,7 +3908,7 @@ public partial class WorldRenderXna : UserControl
                                         case BrickStyle.Full:
                                         default:
                                             {
-                                                
+
                                                 if (forceGrayscale) // Check if to force grayscale via the filter manager.
                                                 {
                                                     // Get or create grayscale version of this subtexture. // Paint color should also be gray.
@@ -2635,30 +3972,150 @@ public partial class WorldRenderXna : UserControl
                     var curtile = _wvm.CurrentWorld.Tiles[x, y];
                     if (curtile.Type >= WorldConfiguration.TileProperties.Count) { continue; }
 
+                    //Neighbor tiles are often used when dynamically determining which UV position to render
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
+                    int e = 0, n = 1, w = 2, s = 3, ne = 4, nw = 5, sw = 6, se = 7;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
+                    //Tile[] neighborTile = new Tile[8];
+                    neighborTile[e] = (x + 1) < width ? _wvm.CurrentWorld.Tiles[x + 1, y] : null;
+                    neighborTile[n] = (y - 1) > 0 ? _wvm.CurrentWorld.Tiles[x, y - 1] : null;
+                    neighborTile[w] = (x - 1) > 0 ? _wvm.CurrentWorld.Tiles[x - 1, y] : null;
+                    neighborTile[s] = (y + 1) < height ? _wvm.CurrentWorld.Tiles[x, y + 1] : null;
+
+                    if (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowGreenWires || _wvm.ShowYellowWires)
+                    {
+                        var tileTex = (Texture2D)_textureDictionary.GetMisc("WiresNew");
+                        if (tileTex != null)
+                        {
+                            int voffset = 0;
+                            if (curtile.Type == 424)
+                                voffset = (curtile.U / 18 + 1) * 72;
+                            if (curtile.Type == 445)
+                                voffset = 72;
+                            if (curtile.WireRed && _wvm.ShowRedWires)
+                            {
+                                var source = new Rectangle(0, 0, 16, 16);
+                                var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                byte state = 0x00;
+                                state |= (byte)((neighborTile[n] != null && neighborTile[n].WireRed == true) ? 0x01 : 0x00);
+                                state |= (byte)((neighborTile[e] != null && neighborTile[e].WireRed == true) ? 0x02 : 0x00);
+                                state |= (byte)((neighborTile[s] != null && neighborTile[s].WireRed == true) ? 0x04 : 0x00);
+                                state |= (byte)((neighborTile[w] != null && neighborTile[w].WireRed == true) ? 0x08 : 0x00);
+                                source.X = state * 18;
+                                source.Y = voffset;
+
+                                var color = (!_wvm.ShowWireTransparency) ? Color.White : (curtile.WireRed && (_wvm.ShowBlueWires || _wvm.ShowGreenWires || _wvm.ShowYellowWires)) ? Translucent : Color.White;
+
+                                _spriteBatch.Draw(tileTex, dest, source, Color.White, 0f, default, SpriteEffects.None, LayerRedWires);
+                            }
+                            if (curtile.WireBlue && _wvm.ShowBlueWires)
+                            {
+                                var source = new Rectangle(0, 0, 16, 16);
+                                var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                byte state = 0x00;
+                                state |= (byte)((neighborTile[n] != null && neighborTile[n].WireBlue == true) ? 0x01 : 0x00);
+                                state |= (byte)((neighborTile[e] != null && neighborTile[e].WireBlue == true) ? 0x02 : 0x00);
+                                state |= (byte)((neighborTile[s] != null && neighborTile[s].WireBlue == true) ? 0x04 : 0x00);
+                                state |= (byte)((neighborTile[w] != null && neighborTile[w].WireBlue == true) ? 0x08 : 0x00);
+                                source.X = state * 18;
+                                source.Y = 18 + voffset;
+
+                                var color = (!_wvm.ShowWireTransparency) ? Color.White : (curtile.WireRed && (_wvm.ShowRedWires || _wvm.ShowGreenWires || _wvm.ShowYellowWires)) ? Translucent : Color.White;
+                                _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerBlueWires);
+                            }
+                            if (curtile.WireGreen && _wvm.ShowGreenWires)
+                            {
+                                var source = new Rectangle(0, 0, 16, 16);
+                                var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                byte state = 0x00;
+                                state |= (byte)((neighborTile[n] != null && neighborTile[n].WireGreen == true) ? 0x01 : 0x00);
+                                state |= (byte)((neighborTile[e] != null && neighborTile[e].WireGreen == true) ? 0x02 : 0x00);
+                                state |= (byte)((neighborTile[s] != null && neighborTile[s].WireGreen == true) ? 0x04 : 0x00);
+                                state |= (byte)((neighborTile[w] != null && neighborTile[w].WireGreen == true) ? 0x08 : 0x00);
+                                source.X = state * 18;
+                                source.Y = 36 + voffset;
+
+                                var color = (!_wvm.ShowWireTransparency) ? Color.White : ((curtile.WireRed || curtile.WireBlue) && (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowYellowWires)) ? Translucent : Color.White;
+                                _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerGreenWires);
+                            }
+                            if (curtile.WireYellow && _wvm.ShowYellowWires)
+                            {
+                                var source = new Rectangle(0, 0, 16, 16);
+                                var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+
+                                byte state = 0x00;
+                                state |= (byte)((neighborTile[n] != null && neighborTile[n].WireYellow == true) ? 0x01 : 0x00);
+                                state |= (byte)((neighborTile[e] != null && neighborTile[e].WireYellow == true) ? 0x02 : 0x00);
+                                state |= (byte)((neighborTile[s] != null && neighborTile[s].WireYellow == true) ? 0x04 : 0x00);
+                                state |= (byte)((neighborTile[w] != null && neighborTile[w].WireYellow == true) ? 0x08 : 0x00);
+                                source.X = state * 18;
+                                source.Y = 54 + voffset;
+
+                                var color = (!_wvm.ShowWireTransparency) ? Color.White : ((curtile.WireRed || curtile.WireBlue || curtile.WireGreen) && (_wvm.ShowRedWires || _wvm.ShowBlueWires || _wvm.ShowGreenWires)) ? Translucent : Color.White;
+                                _spriteBatch.Draw(tileTex, dest, source, color, 0f, default, SpriteEffects.None, LayerYellowWires);
+                            }
+                        }
+                    }
+                }
+                catch (Exception)
+                {
+                    // failed to render tile? log?
+                }
+            }
+        }
+    }
+    private void DrawTileWiresFiltered()
+    {
+        Rectangle visibleBounds = GetViewingArea();
+        BlendRules blendRules = BlendRules.Instance;
+        var width = _wvm.CurrentWorld.TilesWide;
+        var height = _wvm.CurrentWorld.TilesHigh;
+
+        //Extended the viewing space to give tiles time to cache their UV's
+        for (int y = visibleBounds.Top - 1; y < visibleBounds.Bottom + 2; y++)
+        {
+            for (int x = visibleBounds.Left - 1; x < visibleBounds.Right + 2; x++)
+            {
+                try
+                {
+                    if (x < 0 ||
+                        y < 0 ||
+                        x >= _wvm.CurrentWorld.TilesWide ||
+                        y >= _wvm.CurrentWorld.TilesHigh)
+                    {
+                        continue;
+                    }
+
+                    var curtile = _wvm.CurrentWorld.Tiles[x, y];
+                    if (curtile.Type >= WorldConfiguration.TileProperties.Count) { continue; }
+
                     // Hide all wires not within a filter when enabled.
-                    bool allowRed          = true;
+                    bool allowRed = true;
                     bool forceRedGrayscale = false;
                     if (curtile.WireRed)
                         if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Red))
-                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           allowRed = false;
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) allowRed = false;
                             else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceRedGrayscale = true;
-                    bool allowBlue          = true;
+                    bool allowBlue = true;
                     bool forceBlueGrayscale = false;
                     if (curtile.WireBlue)
                         if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Blue))
-                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           allowBlue = false;
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) allowBlue = false;
                             else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceBlueGrayscale = true;
-                    bool allowGreen          = true;
+                    bool allowGreen = true;
                     bool forceGreenGrayscale = false;
                     if (curtile.WireGreen)
                         if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Green))
-                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           allowGreen = false;
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) allowGreen = false;
                             else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceGreenGrayscale = true;
-                    bool allowYellow          = true;
+                    bool allowYellow = true;
                     bool forceYellowGrayscale = false;
                     if (curtile.WireYellow)
                         if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Yellow))
-                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           allowYellow = false;
+                            if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) allowYellow = false;
                             else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceYellowGrayscale = true;
 
                     //Neighbor tiles are often used when dynamically determining which UV position to render
@@ -2793,6 +4250,99 @@ public partial class WorldRenderXna : UserControl
     }
 
     private void DrawTileLiquid()
+    {
+        Rectangle visibleBounds = GetViewingArea();
+
+        //Extended the viewing space to give tiles time to cache their UV's
+        for (int y = visibleBounds.Top - 1; y < visibleBounds.Bottom + 2; y++)
+        {
+            for (int x = visibleBounds.Left - 1; x < visibleBounds.Right + 2; x++)
+            {
+                try
+                {
+                    if (x < 0 ||
+                        y < 0 ||
+                        x >= _wvm.CurrentWorld.TilesWide ||
+                        y >= _wvm.CurrentWorld.TilesHigh)
+                    {
+                        continue;
+                    }
+
+                    var curtile = _wvm.CurrentWorld.Tiles[x, y];
+                    if (curtile.Type >= WorldConfiguration.TileProperties.Count) { continue; }
+
+                    //Neighbor tiles are often used when dynamically determining which UV position to render
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
+                    int e = 0, n = 1, w = 2, s = 3, ne = 4, nw = 5, sw = 6, se = 7;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
+                    //Tile[] neighborTile = new Tile[8];
+
+                    neighborTile[n] = (y - 1) > 0 ? _wvm.CurrentWorld.Tiles[x, y - 1] : null;
+
+                    if (_wvm.ShowLiquid)
+                    {
+                        if (curtile.LiquidAmount > 0)
+                        {
+                            var liquidColor = Color.White;
+                            Texture2D tileTex = null;
+                            if (curtile.LiquidType == LiquidType.Lava)
+                            {
+                                tileTex = (Texture2D)_textureDictionary.GetLiquid(1);
+                            }
+                            else if (curtile.LiquidType == LiquidType.Honey)
+                            {
+                                tileTex = (Texture2D)_textureDictionary.GetLiquid(11); // Not sure if yellow Desert water, or Honey, but looks fine.
+                            }
+                            else if (curtile.LiquidType == LiquidType.Shimmer)
+                            {
+                                tileTex = (Texture2D)_textureDictionary.GetLiquid(14);
+                                liquidColor = new Color(WorldConfiguration.GlobalColors["Shimmer"].PackedValue);
+                            }
+                            else
+                            {
+                                tileTex = (Texture2D)_textureDictionary.GetLiquid(0);
+                            }
+
+                            if (tileTex != null)
+                            {
+                                var source = new Rectangle(0, 0, 16, 16);
+                                var dest = new Rectangle(1 + (int)((_scrollPosition.X + x) * _zoom), 1 + (int)((_scrollPosition.Y + y) * _zoom), (int)_zoom, (int)_zoom);
+                                float alpha = 1f;
+
+                                if (curtile.LiquidType != LiquidType.Lava)
+                                {
+                                    alpha = 0.5f;
+                                }
+                                else
+                                {
+                                    alpha = 0.85f;
+                                }
+
+                                if (neighborTile[n] != null && neighborTile[n].LiquidAmount > 0)
+                                {
+                                    source.Y = 8;
+                                    source.Height = 8;
+                                }
+                                else
+                                {
+                                    source.Height = 4 + ((int)Math.Round(curtile.LiquidAmount * 6f / 255f)) * 2;
+                                    dest.Height = (int)(source.Height * _zoom / 16f);
+                                    dest.Y = 1 + (int)((_scrollPosition.Y + y) * _zoom + ((16 - source.Height) * _zoom / 16f));
+                                }
+
+                                _spriteBatch.Draw(tileTex, dest, source, liquidColor * alpha, 0f, default, SpriteEffects.None, LayerLiquid);
+                            }
+                        }
+                    }
+                }
+                catch (Exception)
+                {
+                    // failed to render tile? log?
+                }
+            }
+        }
+    }
+    private void DrawTileLiquidFiltered()
     {
         Rectangle visibleBounds = GetViewingArea();
 

--- a/src/TEdit/ViewModel/FilterManager.cs
+++ b/src/TEdit/ViewModel/FilterManager.cs
@@ -37,6 +37,8 @@ namespace TEdit.ViewModel
         public static BackgroundMode CurrentBackgroundMode { get; set; } = BackgroundMode.Normal;
         public static Color BackgroundModeCustomColor { get; set; }      = Color.Lime;
 
+        public static bool FilerClipboard { get; set; } = false;
+
         /// <summary>
         /// Returns true if any tile‐filter is active.
         /// </summary>
@@ -92,6 +94,9 @@ namespace TEdit.ViewModel
             // Reset the filter modes.
             CurrentFilterMode = FilterManager.FilterMode.Hide;
             CurrentBackgroundMode = FilterManager.BackgroundMode.Normal;
+
+            // Reset the clipboard settings.
+            FilerClipboard = false;
         }
 
         #region Tile Filter Methods
@@ -174,10 +179,10 @@ namespace TEdit.ViewModel
         [Flags]
         public enum WireType : byte
         {
-            Red = 1 << 0,
-            Blue = 1 << 1,
-            Green = 1 << 2,
-            Yellow = 1 << 3,
+            Red = 1 << 0,    // 1.
+            Blue = 1 << 1,   // 2.
+            Green = 1 << 2,  // 4.
+            Yellow = 1 << 3, // 8.
         }
         public static void AddWireFilter(WireType wire) { _selectedWires.Add(wire); }
         public static void RemoveWireFilter(WireType wire) { _selectedWires.Remove(wire); }

--- a/src/TEdit/ViewModel/FilterManager.cs
+++ b/src/TEdit/ViewModel/FilterManager.cs
@@ -1,0 +1,241 @@
+﻿using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using System.ComponentModel;
+using System.Globalization;
+using System.Windows.Data;
+using TEdit.Configuration;
+using System;
+
+namespace TEdit.ViewModel
+{
+    /// <summary>
+    /// Provides static logic for managing all filter settings in TEdit's advanced filter popup,
+    /// including filtered tiles, walls, liquids, and wires. 
+    /// Maintains filter selection sets, filter modes (Hide, Grayscale), and background display modes.
+    /// Used for both UI data binding and core filtering logic throughout TEdit.
+    /// </summary>
+    public static class FilterManager
+    {
+        public enum FilterMode { Hide, Grayscale }
+        public enum BackgroundMode { Normal, Transparent, Custom }
+
+        // When these sets are empty, it means "no filter" -> show every tile/wall/liquid
+        private static readonly HashSet<int> _selectedTileIDs = [];
+        private static readonly HashSet<int> _selectedWallIDs = [];
+        private static readonly HashSet<LiquidType> _selectedLiquids = [];
+        private static readonly HashSet<WireType> _selectedWires = [];
+        public static ObservableCollection<string> SelectedTileNames { get; } = [];
+        public static ObservableCollection<string> SelectedWallNames { get; } = [];
+        public static ObservableCollection<string> SelectedLiquidNames { get; } = [];
+        public static ObservableCollection<string> SelectedWireNames { get; } = [];
+        public static IReadOnlyCollection<int> SelectedTileIDs => _selectedTileIDs;
+        public static IReadOnlyCollection<int> SelectedWallIDs => _selectedWallIDs;
+
+        public static FilterMode CurrentFilterMode { get; set; }         = FilterMode.Hide;
+        public static Color FilterModeCustomColor { get; set; }          = Color.Transparent;
+        public static BackgroundMode CurrentBackgroundMode { get; set; } = BackgroundMode.Normal;
+        public static Color BackgroundModeCustomColor { get; set; }      = Color.Lime;
+
+        /// <summary>
+        /// Returns true if any tile‐filter is active.
+        /// </summary>
+        public static bool AnyFilterActive => SelectedTileIDs.Count > 0 || SelectedWallIDs.Count > 0 || SelectedLiquidNames.Count > 0 || _selectedWires.Count > 0;
+
+        /// <summary>
+        /// Returns true if tile‐filter is active and the tileId is not in the set.
+        /// </summary>
+        public static bool TileIsNotAllowed(int tileId) => (_selectedTileIDs.Count > 0 || AnyFilterActive) && !_selectedTileIDs.Contains(tileId);
+
+        /// <summary>
+        /// Returns true if wall‐filter is active and the wallId is not in the set.
+        /// </summary>
+        public static bool WallIsNotAllowed(int wallId) => (_selectedWallIDs.Count > 0 || AnyFilterActive) && !_selectedWallIDs.Contains(wallId);
+
+        /// <summary>
+        /// Returns true if no liquid‐filter is active and the liquidId is not in the set.
+        /// </summary>
+        public static bool LiquidIsNotAllowed(LiquidType liquidId) => (_selectedLiquids.Count > 0 || AnyFilterActive) && !_selectedLiquids.Contains(liquidId);
+
+        /// <summary>
+        /// Returns true if no wire‐filter is active and the wire is not in the set.
+        /// </summary>
+        public static bool WireIsNotAllowed(WireType wire) => (_selectedWires.Count > 0 || AnyFilterActive) && !_selectedWires.Contains(wire);
+
+        /// <summary>
+        /// Returns true if the wire is in the set.
+        /// </summary>
+        public static bool WireIsAllowed(WireType wire) => _selectedWires.Contains(wire);
+
+        /// <summary>
+        /// Clears everything – both tile, wall, liquid, and wire filters – and resets the modes to hide & normal.
+        /// </summary>
+        public static void ClearAll()
+        {
+            // _selectedTileIDs.Clear();
+            // _selectedWallIDs.Clear();
+            // _selectedLiquids.Clear();
+            // _selectedWires.Clear();
+
+            // Clear all filters.
+            // Also clear the "names" lists to prevent UI resync issues.
+            FilterManager.SelectedTileNames.Clear();
+            FilterManager.SelectedWallNames.Clear();
+            FilterManager.SelectedLiquidNames.Clear();
+            FilterManager.SelectedWireNames.Clear();
+
+            FilterManager.ClearWallFilters();
+            FilterManager.ClearTileFilters();
+            FilterManager.ClearLiquidFilters();
+            FilterManager.ClearWireFilters();
+
+            // Reset the filter modes.
+            CurrentFilterMode = FilterManager.FilterMode.Hide;
+            CurrentBackgroundMode = FilterManager.BackgroundMode.Normal;
+        }
+
+        #region Tile Filter Methods
+
+        /// <summary>
+        /// Add a tile ID to the filter (i.e. show this ID).
+        /// Air has an id of -1, so tiles have an >= -1 rule.
+        /// </summary>
+        public static void AddTileFilter(int tileId)
+        {
+            if (tileId >= -1 && _selectedTileIDs.Add(tileId))
+            {
+                // no direct UI work here—UI binds to SelectedTileNames
+            }
+        }
+
+        /// <summary>
+        /// Remove a tile ID from the filter (i.e. stop showing this ID).
+        /// </summary>
+        public static void RemoveTileFilter(int tileId) => _selectedTileIDs.Remove(tileId);
+
+        /// <summary>
+        /// Clear all tile filters (i.e. show every tile).
+        /// </summary>
+        public static void ClearTileFilters() => _selectedTileIDs.Clear();
+
+        #endregion
+
+        #region Wall Filter Methods
+
+        /// <summary>
+        /// Add a wall ID to the filter.
+        /// </summary>
+        public static void AddWallFilter(int wallId)
+        {
+            if (wallId >= 0 && _selectedWallIDs.Add(wallId))
+            {
+                // no direct UI work here—UI binds to SelectedWallNames
+            }
+        }
+
+        /// <summary>
+        /// Remove a wall ID from the filter.
+        /// </summary>
+        public static void RemoveWallFilter(int wallId) => _selectedWallIDs.Remove(wallId);
+
+        /// <summary>
+        /// Clear all wall filters.
+        /// </summary>
+        public static void ClearWallFilters() => _selectedWallIDs.Clear();
+
+        #endregion
+
+        #region Liquid Filter Methods
+
+        // --- Liquid filter methods ---
+        /// <summary>
+        /// Add a liquid ID to the filter.
+        /// </summary>
+        public static void AddLiquidFilter(LiquidType liq)
+        {
+            if (_selectedLiquids.Add(liq)) { }
+        }
+
+        /// <summary>
+        /// Remove a liquid ID from the filter.
+        /// </summary>
+        public static void RemoveLiquidFilter(LiquidType liq) => _selectedLiquids.Remove(liq);
+
+        /// <summary>
+        /// Clear all liquid filters.
+        /// </summary>
+        public static void ClearLiquidFilters() => _selectedLiquids.Clear();
+
+        #endregion
+
+        #region Wire Filter Methods
+
+        // ------- Wire filter (new) -------
+        [Flags]
+        public enum WireType : byte
+        {
+            Red = 1 << 0,
+            Blue = 1 << 1,
+            Green = 1 << 2,
+            Yellow = 1 << 3,
+        }
+        public static void AddWireFilter(WireType wire) { _selectedWires.Add(wire); }
+        public static void RemoveWireFilter(WireType wire) { _selectedWires.Remove(wire); }
+        public static void ClearWireFilters()
+        {
+            _selectedWires.Clear();
+            SelectedWireNames.Clear();
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Represents an item (such as a tile, wall, liquid, or wire) that can be filtered
+    /// in the TEdit filter popup window. Each item has an ID, a display name, and a
+    /// check state indicating whether it is included in the filter. Implements
+    /// INotifyPropertyChanged so that WPF data binding reflects changes in checkboxes
+    /// in the UI.
+    /// 
+    /// Example usage:
+    /// - Used as the data model for each checkbox row in the filter lists.
+    /// - Supports binding to the IsChecked property to track filter selections.
+    /// </summary>
+    public class FilterCheckItem : INotifyPropertyChanged
+    {
+        public string Name { get; }
+        public int Id { get; }
+        private bool _isChecked;
+
+        public bool IsChecked
+        {
+            get => _isChecked;
+            set { _isChecked = value; OnPropertyChanged(nameof(IsChecked)); }
+        }
+
+        public FilterCheckItem(int id, string name, bool isChecked = false)
+        {
+            Id = id;
+            Name = name;
+            IsChecked = isChecked;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        protected void OnPropertyChanged(string prop)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+    }
+
+    /// <summary>
+    /// Converts between an enum value and a boolean for use with RadioButton bindings in WPF.
+    /// When bound to a RadioButton, it returns true if the enum's value matches the button's ConverterParameter,
+    /// allowing for simple two-way binding between a group of RadioButtons and an enum property.
+    /// </summary>
+    public class EnumToBooleanConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => value?.ToString() == parameter?.ToString();
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => (value is bool b && b) ? Enum.Parse(targetType, parameter.ToString()) : Binding.DoNothing;
+    }
+}

--- a/src/TEdit/ViewModel/FilterManager.cs
+++ b/src/TEdit/ViewModel/FilterManager.cs
@@ -42,7 +42,7 @@ namespace TEdit.ViewModel
         /// <summary>
         /// Returns true if any tile‐filter is active.
         /// </summary>
-        public static bool AnyFilterActive => SelectedTileIDs.Count > 0 || SelectedWallIDs.Count > 0 || SelectedLiquidNames.Count > 0 || SelectedWireNames.Count > 0;
+        public static bool AnyFilterActive => SelectedTileNames.Count > 0 || SelectedWallNames.Count > 0 || SelectedLiquidNames.Count > 0 || SelectedWireNames.Count > 0;
 
         /// <summary>
         /// Returns true if tile‐filter is active and the tileId is not in the set.

--- a/src/TEdit/ViewModel/FilterManager.cs
+++ b/src/TEdit/ViewModel/FilterManager.cs
@@ -40,7 +40,7 @@ namespace TEdit.ViewModel
         /// <summary>
         /// Returns true if any tile‐filter is active.
         /// </summary>
-        public static bool AnyFilterActive => SelectedTileIDs.Count > 0 || SelectedWallIDs.Count > 0 || SelectedLiquidNames.Count > 0 || _selectedWires.Count > 0;
+        public static bool AnyFilterActive => SelectedTileIDs.Count > 0 || SelectedWallIDs.Count > 0 || SelectedLiquidNames.Count > 0 || SelectedWireNames.Count > 0;
 
         /// <summary>
         /// Returns true if tile‐filter is active and the tileId is not in the set.
@@ -72,12 +72,12 @@ namespace TEdit.ViewModel
         /// </summary>
         public static void ClearAll()
         {
-            // _selectedTileIDs.Clear();
-            // _selectedWallIDs.Clear();
-            // _selectedLiquids.Clear();
-            // _selectedWires.Clear();
-
             // Clear all filters.
+            _selectedTileIDs.Clear();
+            _selectedWallIDs.Clear();
+            _selectedLiquids.Clear();
+            _selectedWires.Clear();
+
             // Also clear the "names" lists to prevent UI resync issues.
             FilterManager.SelectedTileNames.Clear();
             FilterManager.SelectedWallNames.Clear();

--- a/src/TEdit/ViewModel/GrayscaleManager.cs
+++ b/src/TEdit/ViewModel/GrayscaleManager.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+
+namespace TEdit.ViewModel
+{
+    public static class GrayscaleManager
+    {
+        /// <summary>
+        /// Creates a Texture2D filled with a single color (including transparent).
+        /// </summary>
+        public static Texture2D CreateSolidTexture(GraphicsDevice device, int width, int height, Color color)
+        {
+            var tex = new Texture2D(device, width, height);
+            Color[] data = new Color[width * height];
+            for (int i = 0; i < data.Length; i++) data[i] = color;
+            tex.SetData(data);
+            return tex;
+        }
+
+        public static Microsoft.Xna.Framework.Color ToGrayscale(Microsoft.Xna.Framework.Color c)
+        {
+            // Calculate luminance
+            byte gray = (byte)(c.R * 0.299 + c.G * 0.587 + c.B * 0.114);
+            return new Microsoft.Xna.Framework.Color(gray, gray, gray, c.A);
+        }
+
+        public static class GrayscaleCache
+        {
+            // Key: (Texture2D, Rectangle)
+            private static readonly Dictionary<(Texture2D, Rectangle), Texture2D> _cache = [];
+
+            public static Texture2D GetOrCreate(GraphicsDevice device, Texture2D source, Rectangle sourceRect)
+            {
+                var key = (source, sourceRect);
+                if (_cache.TryGetValue(key, out var grayTex))
+                    return grayTex;
+                // Create grayscale
+                grayTex = ToGrayscale(device, source, sourceRect);
+                _cache[key] = grayTex;
+                return grayTex;
+            }
+
+            public static void Clear()
+            {
+                foreach (var tex in _cache.Values)
+                    tex.Dispose();
+                _cache.Clear();
+            }
+
+            private static Texture2D ToGrayscale(GraphicsDevice device, Texture2D source, Rectangle sourceRect)
+            {
+                Color[] data = new Color[sourceRect.Width * sourceRect.Height];
+                source.GetData(0, sourceRect, data, 0, data.Length);
+                for (int i = 0; i < data.Length; i++)
+                {
+                    byte gray = (byte)(data[i].R * 0.299 + data[i].G * 0.587 + data[i].B * 0.114);
+                    data[i] = new Color(gray, gray, gray, data[i].A);
+                }
+                Texture2D grayTex = new(device, sourceRect.Width, sourceRect.Height);
+                grayTex.SetData(data);
+                return grayTex;
+            }
+        }
+    }
+}

--- a/src/TEdit/ViewModel/WorldViewModel.Commands.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Commands.cs
@@ -307,12 +307,12 @@ public partial class WorldViewModel
     }
     public ICommand RedoCommand
     {
-        get { return _redoCommand ??= new RelayCommand(() => UndoManager.Redo()); }
+        get { return _redoCommand ??= new RelayCommand(() => UndoManager?.Redo()); }
     }
 
     public ICommand UndoCommand
     {
-        get { return _undoCommand ??= new RelayCommand(() => UndoManager.Undo()); }
+        get { return _undoCommand ??= new RelayCommand(() => UndoManager?.Undo()); }
     }
 
     public ICommand CopyCommand
@@ -340,7 +340,7 @@ public partial class WorldViewModel
     }
     private bool CanPaste()
     {
-        return _clipboard.Buffer != null;
+        return Clipboard != null && _clipboard.Buffer != null;
     }
     public ICommand DeleteCommand
     {

--- a/src/TEdit/ViewModel/WorldViewModel.Editor.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Editor.cs
@@ -62,6 +62,7 @@ public partial class WorldViewModel
             return;
 
         _clipboard.CopySelection(CurrentWorld, Selection.SelectionArea);
+        this.SelectedTabIndex = 3; // Open the clipboard tab.
     }
 
     public async void CropWorld()
@@ -372,6 +373,7 @@ public partial class WorldViewModel
         if (!CanPaste())
             return;
 
+        this.SelectedTabIndex = 3; // Open the clipboard tab.
         var pasteTool = Tools.FirstOrDefault(t => t.Name == "Paste");
         if (pasteTool != null)
         {

--- a/src/TEdit/ViewModel/WorldViewModel.Editor.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Editor.cs
@@ -399,7 +399,7 @@ public partial class WorldViewModel
         UpdateRenderPixel(x, y);
     }
 
-    private void UpdateRenderWorld()
+    public void UpdateRenderWorld()
     {
         Task.Factory.StartNew(
             () =>
@@ -419,7 +419,93 @@ public partial class WorldViewModel
                 OnProgressChanged(this, new ProgressChangedEventArgs(100, "Render Complete"));
             });
     }
+    // OPTION: This can simply be combined with 'UpdateRenderWorld'.
+    public void UpdateRenderWorldUsingFilter()
+    {
+        Task.Factory.StartNew(
+            () =>
+            {
+                if (CurrentWorld != null)
+                {
+                    for (int y = 0; y < CurrentWorld.TilesHigh; y++)
+                    {
+                        Color curBgColor = new Color(GetBackgroundColor(y).PackedValue);
+                        OnProgressChanged(this, new ProgressChangedEventArgs(y.ProgressPercentage(CurrentWorld.TilesHigh), "Calculating Colors..."));
+                        for (int x = 0; x < CurrentWorld.TilesWide; x++)
+                        {
+                            // Define defualt bools.
+                            bool showWalls      = _showWalls;
+                            bool showTiles      = _showTiles;
+                            bool showLiquids    = _showLiquid;
+                            bool showRedWire    = _showRedWires;
+                            bool showBlueWire   = _showBlueWires;
+                            bool showGreenWire  = _showGreenWires;
+                            bool showYellowWire = _showYellowWires;
 
+                            bool wallGrayscale       = false;
+                            bool tileGrayscale       = false;
+                            bool liquidGrayscale     = false;
+                            bool redWireGrayscale    = false;
+                            bool blueWireGrayscale   = false;
+                            bool greenWireGrayscale  = false;
+                            bool yellowWireGrayscale = false;
+
+                            // Test the the filter for walls, tiles, liquids, and wires. 
+                            if (FilterManager.WallIsNotAllowed(CurrentWorld.Tiles[x, y].Wall))                                                      // Check if this wall is not in the list.
+                                if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)               showWalls = false;              // Hide walls not in list.
+                                else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale)     wallGrayscale = true;           // Grayscale walls not in list.
+
+                            if (FilterManager.TileIsNotAllowed(CurrentWorld.Tiles[x, y].Type))                                                      // Check if this block is not in the list.
+                                if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)               showTiles = false;              // Hide blocks not in list.
+                                else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale)     tileGrayscale = true;           // Grayscale blocks not in list.
+
+                            if (FilterManager.LiquidIsNotAllowed(CurrentWorld.Tiles[x, y].LiquidType))                                              // Check if this liquid is not in the list.
+                                if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)               showLiquids = false;            // Hide liquids not in list.
+                                else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale)     liquidGrayscale = true;         // Grayscale liquids not in list.
+
+                            // Use the HasWire bool to save on processing speed.
+                            if (CurrentWorld.Tiles[x, y].HasWire)
+                            {
+                                if (CurrentWorld.Tiles[x, y].WireRed)                                                                               // Check if this tile contains a red wire.
+                                    if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Red))                                                 // Check if this wire is not in the list.
+                                        if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           showRedWire = false;        // Hide wires not in list.
+                                        else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) redWireGrayscale = true;    // Grayscale wires not in list.
+
+                                if (CurrentWorld.Tiles[x, y].WireBlue)                                                                              // Check if this tile contains a red wire.
+                                    if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Blue))                                                // Check if this wire is not in the list.
+                                        if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           showBlueWire = false;       // Hide wires not in list.
+                                        else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) blueWireGrayscale = true;   // Grayscale wires not in list.
+
+                                if (CurrentWorld.Tiles[x, y].WireGreen)                                                                             // Check if this tile contains a red wire.
+                                    if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Green))                                               // Check if this wire is not in the list.
+                                        if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           showGreenWire = false;      // Hide wires not in list.
+                                        else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) greenWireGrayscale = true;  // Grayscale wires not in list.
+
+                                if (CurrentWorld.Tiles[x, y].WireYellow)                                                                            // Check if this tile contains a red wire.
+                                    if (FilterManager.WireIsNotAllowed(FilterManager.WireType.Yellow))                                              // Check if this wire is not in the list.
+                                        if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)           showYellowWire = false;     // Hide wires not in list.
+                                        else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) yellowWireGrayscale = true; // Grayscale wires not in list.
+                            }
+
+                            // Test the the filter for custom background (solid color) mode.
+                            if (FilterManager.CurrentBackgroundMode == FilterManager.BackgroundMode.Transparent)
+                                curBgColor = Color.Transparent;
+                            else if (FilterManager.CurrentBackgroundMode == FilterManager.BackgroundMode.Custom)
+                                curBgColor = FilterManager.BackgroundModeCustomColor;
+
+                            // Define the color based on the filter results.
+                            Color color = Render.PixelMap.GetTileColor(CurrentWorld.Tiles[x, y], curBgColor, showWalls, showTiles, showLiquids, showRedWire, showBlueWire, showGreenWire, showYellowWire,
+                                    wallGrayscale: wallGrayscale, tileGrayscale: tileGrayscale, liquidGrayscale: liquidGrayscale,
+                                    redWireGrayscale: redWireGrayscale, blueWireGrayscale: blueWireGrayscale, greenWireGrayscale: greenWireGrayscale, yellowWireGrayscale: yellowWireGrayscale);
+
+                            // Set the pixel data.
+                            PixelMap.SetPixelColor(x, y, color);
+                        }
+                    }
+                }
+                OnProgressChanged(this, new ProgressChangedEventArgs(100, "Render Complete"));
+            });
+    }
     public void UpdateRenderPixel(Vector2Int32 p)
     {
         UpdateRenderPixel(p.X, p.Y);


### PR DESCRIPTION
# Added an Advanced Filter Feature.
This tool allows you to filter what tiles, walls, liquids, and wires are displayed on TEdits world view.
- Advanced Filter includes full **HIDE** / **GRAYSCALE** support as well as **TRANSPARENT** / **CUSTOM** backgrounds.

<p align="center">
  <img src="https://github.com/user-attachments/assets/ded7fba7-1dfa-457e-817b-5f3ba8e27fc9" width="400" />
  <img src="https://github.com/user-attachments/assets/7addc854-9b1a-4d23-a469-527cd60747c6" width="400" />
</p>


**NOTE:** Activating the filter **DOES NOT** allow the selection to only select filtered entrees by _default_.
-  The _Filter Clipboard_ checkbox allows this feature.

<p align="center">
  <img src="https://github.com/user-attachments/assets/b2ffcbbc-f8b0-4d26-9578-bc19c1410dd2" width="600" />
</p>


**Controls:**
- "Tiles/Walls/Liquids/Wires" tabs navigate to list views of their categorical entrees.
- "Check All" button simply checks all entrees checkboxes within the sections list view.
- "Uncheck All" button simply unchecks all entrees checkboxes within the sections list view.
- "Name: + Textbox" - Sorts the list view based on the users input .
- "Filter Mode" - How the none-selected entrees should be handled.
  - "Hide" checkbox hides all non-filtered entrees from view.
  - "Grayscale" checkbox converts all non-filtered entrees to grayscale.
- "Background Mode" - How the world view background should be handled.
  - "Normal" checkbox will have the map render the default color grading.
  - "Transparent" checkbox will have the map renderer use no background whatsoever.
    - The background will depend on the control color.
  - "Custom" checkbox will have the map renderer use a custom background color.
    - "..." button will allow you to change the custom background color.
- "Set Values" button sets all the tiles UV manually to any value in the the "U" or "V" textbox's.
- "Filter Clipboard" checkbox allows selections copied to only add filtered items to the clipboard.
- "Cancel" button simply cancels all operations.
- "Disable" button will disable filtering and restore default map textures.
- "Apply" button will accept the current changes.

<img src="https://github.com/user-attachments/assets/e86238b4-af47-44ea-8394-c04752674c0c" width="600" />

_- GUI visual as-of posting date._

# BONUS:
## Added Frame Editor Language Support.
As a bonus, I decided to go back and add full language support to the [Live Frame Editor #1947](https://github.com/TEdit/Terraria-Map-Editor/pull/1947). This addition came from the _LFE_ being designed to be more of a TEdit main window feature, and not a plugin. This means it needed more delicate attention when it came to different languages.

<p align="center">
  <img src="https://github.com/user-attachments/assets/99741218-fb5e-49e5-be82-501d77078efa" width="300" />
</p>

![LanguageSupport](https://github.com/user-attachments/assets/7cbc7d5f-8342-4859-a33d-0a43bcf12918)

## Fixed Main Toolbar Button Crashes.
The following toolbar buttons would cause hard crashes when no world was loaded, or no redo data existed.
- Undo
- Redo
- Copy
- Paste

Furthermore, using the _copy_ and _paste_ buttons now switch to the `Clipboard` tab.

## Fixed HouseGenPlugin Crashing Upon Load.
This is a simple null reference fix to the _HouseGenPlugin_ where `GeneratredSchematic` is **null** the first time this property is accessed.