### PR TITLE
Added "Sprites" to The Advanced Filter. Fixed World Upgrading.

### DIFF
--- a/src/TEdit.Terraria/World.FileV2.cs
+++ b/src/TEdit.Terraria/World.FileV2.cs
@@ -728,7 +728,7 @@ public partial class World
             {
                 // Use TryParse encase the world is being upgraded from v0 or v1.
                 int.TryParse(world.Seed, out var seed);
-                bw.Write(seed);
+                bw.Write(seed.ToString());
             }
 
             bw.Write(world.WorldGenVersion);

--- a/src/TEdit.Terraria/World.FileV2.cs
+++ b/src/TEdit.Terraria/World.FileV2.cs
@@ -552,7 +552,10 @@ public partial class World
                 bw.Write(WorldConfiguration.NpcNames[npc.SpriteId]);
             }
 
-            bw.Write(npc.DisplayName);
+            // Check displayName for a null value encase the world is being upgraded from v0 or v1.
+            string displayName = npc.DisplayName ?? npc.Name;
+
+            bw.Write(displayName);
             bw.Write(npc.Position.X);
             bw.Write(npc.Position.Y);
             bw.Write(npc.IsHomeless);
@@ -723,7 +726,9 @@ public partial class World
             }
             else
             {
-                bw.Write(world.Seed);
+                // Use TryParse encase the world is being upgraded from v0 or v1.
+                int.TryParse(world.Seed, out var seed);
+                bw.Write(seed);
             }
 
             bw.Write(world.WorldGenVersion);

--- a/src/TEdit/Properties/Language.Designer.cs
+++ b/src/TEdit/Properties/Language.Designer.cs
@@ -791,6 +791,15 @@ namespace TEdit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sprites.
+        /// </summary>
+        public static string menu_filter_header_sprites {
+            get {
+                return ResourceManager.GetString("menu_filter_header_sprites", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Tiles.
         /// </summary>
         public static string menu_filter_header_tiles {

--- a/src/TEdit/Properties/Language.ar-BH.resx
+++ b/src/TEdit/Properties/Language.ar-BH.resx
@@ -1449,4 +1449,7 @@
   <data name="menu_filter_filterclipboard" xml:space="preserve">
     <value>تصفية الحافظة</value>
   </data>
+  <data name="menu_filter_header_sprites" xml:space="preserve">
+    <value>العفاريت</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.de-DE.resx
+++ b/src/TEdit/Properties/Language.de-DE.resx
@@ -1449,4 +1449,7 @@ Klicke auf „Wiederholen“, um einen neuen Ordner auszuwählen, oder auf „Ab
   <data name="menu_filter_filterclipboard" xml:space="preserve">
     <value>Zwischenablage filtern</value>
   </data>
+  <data name="menu_filter_header_sprites" xml:space="preserve">
+    <value>Sprites</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.en.resx
+++ b/src/TEdit/Properties/Language.en.resx
@@ -1449,4 +1449,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_filter_filterclipboard" xml:space="preserve">
     <value>Filter Clipboard</value>
   </data>
+  <data name="menu_filter_header_sprites" xml:space="preserve">
+    <value>Sprites</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.es-ES.resx
+++ b/src/TEdit/Properties/Language.es-ES.resx
@@ -1449,4 +1449,7 @@ Presione reintentar para elegir una nueva carpeta o cancelar para usar {0} como 
   <data name="menu_filter_filterclipboard" xml:space="preserve">
     <value>Filtrar portapapeles</value>
   </data>
+  <data name="menu_filter_header_sprites" xml:space="preserve">
+    <value>duendes</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pl-PL.resx
+++ b/src/TEdit/Properties/Language.pl-PL.resx
@@ -1449,4 +1449,7 @@ Naciśnij spróbuj ponownie aby wybrać nowy folder lub anuluj aby użyć {0} ja
   <data name="menu_filter_filterclipboard" xml:space="preserve">
     <value>Filtruj schowek</value>
   </data>
+  <data name="menu_filter_header_sprites" xml:space="preserve">
+    <value>Duszki</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.pt-BR.resx
+++ b/src/TEdit/Properties/Language.pt-BR.resx
@@ -1449,4 +1449,7 @@ Clique em tentar novamente para escolher uma nova pasta ou cancelar para usar {0
   <data name="menu_filter_filterclipboard" xml:space="preserve">
     <value>Filtrar área de transferência</value>
   </data>
+  <data name="menu_filter_header_sprites" xml:space="preserve">
+    <value>Sprites</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.resx
+++ b/src/TEdit/Properties/Language.resx
@@ -1452,4 +1452,7 @@ Press retry to pick a new folder or cancel to use {0} as your terraria path.</va
   <data name="menu_filter_filterclipboard" xml:space="preserve">
     <value>Filter Clipboard</value>
   </data>
+  <data name="menu_filter_header_sprites" xml:space="preserve">
+    <value>Sprites</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.ru-RU.resx
+++ b/src/TEdit/Properties/Language.ru-RU.resx
@@ -1449,4 +1449,7 @@
   <data name="menu_filter_filterclipboard" xml:space="preserve">
     <value>Фильтровать буфер обмена</value>
   </data>
+  <data name="menu_filter_header_sprites" xml:space="preserve">
+    <value>Спрайты</value>
+  </data>
 </root>

--- a/src/TEdit/Properties/Language.zh-CN.resx
+++ b/src/TEdit/Properties/Language.zh-CN.resx
@@ -1449,4 +1449,7 @@
   <data name="menu_filter_filterclipboard" xml:space="preserve">
     <value>过滤剪贴板</value>
   </data>
+  <data name="menu_filter_header_sprites" xml:space="preserve">
+    <value>精灵</value>
+  </data>
 </root>

--- a/src/TEdit/Render/PixelMap.cs
+++ b/src/TEdit/Render/PixelMap.cs
@@ -230,6 +230,7 @@ public static class PixelMap
 
         if (tile.IsActive && showTile)
         {
+            // TODO: Allow the minimap to show sprites.
             if (WorldConfiguration.TileProperties.Count > tile.Type)
                 c = c.AlphaBlend(WorldConfiguration.TileProperties[tile.Type].Color);
             else

--- a/src/TEdit/Render/PixelMap.cs
+++ b/src/TEdit/Render/PixelMap.cs
@@ -230,7 +230,6 @@ public static class PixelMap
 
         if (tile.IsActive && showTile)
         {
-            // TODO: Allow the minimap to show sprites.
             if (WorldConfiguration.TileProperties.Count > tile.Type)
                 c = c.AlphaBlend(WorldConfiguration.TileProperties[tile.Type].Color);
             else

--- a/src/TEdit/Render/RenderMiniMap.cs
+++ b/src/TEdit/Render/RenderMiniMap.cs
@@ -95,7 +95,7 @@ public class RenderMiniMap
                     else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) wallGrayscale = true;               // Grayscale walls not in list.
 
                 if (FilterManager.TileIsNotAllowed(w.Tiles[worldX, worldY].Type)                                                        // Since sprites are under the tile denomination, we combine them.
-                    && FilterManager.SpriteIsNotAllowed(w.Tiles[x, y].Type))                                                            // Check if this block / sprite is not in the list.
+                    && FilterManager.SpriteIsNotAllowed(w.Tiles[worldX, worldY].Type))                                                  // Check if this block / sprite is not in the list.
                     if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showTiles = false;                            // Hide blocks not in list.
                     else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) tileGrayscale = true;               // Grayscale blocks not in list.
 

--- a/src/TEdit/Render/RenderMiniMap.cs
+++ b/src/TEdit/Render/RenderMiniMap.cs
@@ -94,7 +94,8 @@ public class RenderMiniMap
                     if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showWalls = false;                            // Hide walls not in list.
                     else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) wallGrayscale = true;               // Grayscale walls not in list.
 
-                if (FilterManager.TileIsNotAllowed(w.Tiles[worldX, worldY].Type))                                                       // Check if this block is not in the list.
+                if (FilterManager.TileIsNotAllowed(w.Tiles[worldX, worldY].Type)                                                        // Since sprites are under the tile denomination, we combine them.
+                    && FilterManager.SpriteIsNotAllowed(w.Tiles[x, y].Type))                                                            // Check if this block / sprite is not in the list.
                     if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) showTiles = false;                            // Hide blocks not in list.
                     else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) tileGrayscale = true;               // Grayscale blocks not in list.
 

--- a/src/TEdit/View/Popups/FilterWindow.xaml
+++ b/src/TEdit/View/Popups/FilterWindow.xaml
@@ -106,6 +106,26 @@
                     </ListBox>
                 </StackPanel>
             </TabItem>
+            <!-- SPRITES -->
+            <TabItem Header="{x:Static p:Language.menu_filter_header_sprites}">
+                <StackPanel Margin="10,0,10,0" Height="365">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5" VerticalAlignment="Center">
+                        <TextBlock Foreground="Snow" VerticalAlignment="Center" Margin="0,0,5,0">
+                            <TextBlock.Text><MultiBinding StringFormat="{}{0}:"><Binding Path="(p:Language.menu_filter_tab_searchname)" /></MultiBinding></TextBlock.Text>
+                        </TextBlock>
+                        <TextBox Width="320" Margin="0,0,10,0" VerticalAlignment="Center" Text="{Binding SpriteSearchText, UpdateSourceTrigger=PropertyChanged}"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_check_all}" Width="80" Margin="0,0,5,0" Click="SpriteCheckAll_Click"/>
+                        <Button Content="{x:Static p:Language.menu_filter_tab_uncheck_all}" Width="90" Click="SpriteUncheckAll_Click"/>
+                    </StackPanel>
+                    <ListBox ItemsSource="{Binding FilteredSpriteItems}" Height="335">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}" Content="{Binding Name}"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+            </TabItem>
         </TabControl>
       
         <!-- Bottom Buttons & Modes -->

--- a/src/TEdit/View/WorldRenderXna.xaml.cs
+++ b/src/TEdit/View/WorldRenderXna.xaml.cs
@@ -2536,9 +2536,9 @@ public partial class WorldRenderXna : UserControl
                     if (curtile.Type >= WorldConfiguration.TileProperties.Count) { continue; }
                     var tileprop = WorldConfiguration.GetTileProperties(curtile.Type);
 
-                    // Hide all tiles not within a filter when enabled.
+                    // Hide all tiles & sprites not within a filter when enabled.
                     bool forceGrayscale = false;
-                    if (FilterManager.TileIsNotAllowed(curtile.Type))
+                    if (FilterManager.TileIsNotAllowed(curtile.Type) && FilterManager.SpriteIsNotAllowed(curtile.Type))
                         if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide) continue;
                         else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale) forceGrayscale = true;
 

--- a/src/TEdit/ViewModel/FilterManager.cs
+++ b/src/TEdit/ViewModel/FilterManager.cs
@@ -25,12 +25,15 @@ namespace TEdit.ViewModel
         private static readonly HashSet<int> _selectedWallIDs = [];
         private static readonly HashSet<LiquidType> _selectedLiquids = [];
         private static readonly HashSet<WireType> _selectedWires = [];
+        private static readonly HashSet<int> _selectedSpriteIDs = [];
         public static ObservableCollection<string> SelectedTileNames { get; } = [];
         public static ObservableCollection<string> SelectedWallNames { get; } = [];
         public static ObservableCollection<string> SelectedLiquidNames { get; } = [];
         public static ObservableCollection<string> SelectedWireNames { get; } = [];
+        public static ObservableCollection<string> SelectedSpriteNames { get; } = [];
         public static IReadOnlyCollection<int> SelectedTileIDs => _selectedTileIDs;
         public static IReadOnlyCollection<int> SelectedWallIDs => _selectedWallIDs;
+        public static IReadOnlyCollection<int> SelectedSpriteIDs => _selectedSpriteIDs;
 
         public static FilterMode CurrentFilterMode { get; set; }         = FilterMode.Hide;
         public static Color FilterModeCustomColor { get; set; }          = Color.Transparent;
@@ -42,7 +45,7 @@ namespace TEdit.ViewModel
         /// <summary>
         /// Returns true if any tile‐filter is active.
         /// </summary>
-        public static bool AnyFilterActive => SelectedTileNames.Count > 0 || SelectedWallNames.Count > 0 || SelectedLiquidNames.Count > 0 || SelectedWireNames.Count > 0;
+        public static bool AnyFilterActive => SelectedTileNames.Count > 0 || SelectedWallNames.Count > 0 || SelectedLiquidNames.Count > 0 || SelectedWireNames.Count > 0 || SelectedSpriteNames.Count > 0;
 
         /// <summary>
         /// Returns true if tile‐filter is active and the tileId is not in the set.
@@ -70,6 +73,11 @@ namespace TEdit.ViewModel
         public static bool WireIsAllowed(WireType wire) => _selectedWires.Contains(wire);
 
         /// <summary>
+        /// Returns true if sprite‐filter is active and the spriteId is not in the set.
+        /// </summary>
+        public static bool SpriteIsNotAllowed(int spriteId) => (_selectedSpriteIDs.Count > 0 || AnyFilterActive) && !_selectedSpriteIDs.Contains(spriteId);
+
+        /// <summary>
         /// Clears everything – both tile, wall, liquid, and wire filters – and resets the modes to hide & normal.
         /// </summary>
         public static void ClearAll()
@@ -79,17 +87,20 @@ namespace TEdit.ViewModel
             _selectedWallIDs.Clear();
             _selectedLiquids.Clear();
             _selectedWires.Clear();
+            _selectedSpriteIDs.Clear();
 
             // Also clear the "names" lists to prevent UI resync issues.
             FilterManager.SelectedTileNames.Clear();
             FilterManager.SelectedWallNames.Clear();
             FilterManager.SelectedLiquidNames.Clear();
             FilterManager.SelectedWireNames.Clear();
+            FilterManager.SelectedSpriteNames.Clear();
 
             FilterManager.ClearWallFilters();
             FilterManager.ClearTileFilters();
             FilterManager.ClearLiquidFilters();
             FilterManager.ClearWireFilters();
+            FilterManager.ClearSpriteFilters();
 
             // Reset the filter modes.
             CurrentFilterMode = FilterManager.FilterMode.Hide;
@@ -191,6 +202,31 @@ namespace TEdit.ViewModel
             _selectedWires.Clear();
             SelectedWireNames.Clear();
         }
+
+        #endregion
+
+        #region Sprite Filter Methods
+
+        /// <summary>
+        /// Add a sprite ID to the filter.
+        /// </summary>
+        public static void AddSpriteFilter(int spriteId)
+        {
+            if (spriteId >= -1 && _selectedSpriteIDs.Add(spriteId))
+            {
+                // no direct UI work here—UI binds to SelectedSpriteNames
+            }
+        }
+
+        /// <summary>
+        /// Remove a sprite ID from the filter (i.e. stop showing this ID).
+        /// </summary>
+        public static void RemoveSpriteFilter(int spriteId) => _selectedSpriteIDs.Remove(spriteId);
+
+        /// <summary>
+        /// Clear all sprite filters (i.e. show every sprite).
+        /// </summary>
+        public static void ClearSpriteFilters() => _selectedSpriteIDs.Clear();
 
         #endregion
     }

--- a/src/TEdit/ViewModel/WorldViewModel.Editor.cs
+++ b/src/TEdit/ViewModel/WorldViewModel.Editor.cs
@@ -452,12 +452,13 @@ public partial class WorldViewModel
                             bool greenWireGrayscale  = false;
                             bool yellowWireGrayscale = false;
 
-                            // Test the the filter for walls, tiles, liquids, and wires. 
+                            // Test the the filter for walls, tiles, liquids, wires, and sprites. 
                             if (FilterManager.WallIsNotAllowed(CurrentWorld.Tiles[x, y].Wall))                                                      // Check if this wall is not in the list.
                                 if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)               showWalls = false;              // Hide walls not in list.
                                 else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale)     wallGrayscale = true;           // Grayscale walls not in list.
 
-                            if (FilterManager.TileIsNotAllowed(CurrentWorld.Tiles[x, y].Type))                                                      // Check if this block is not in the list.
+                            if (FilterManager.TileIsNotAllowed(CurrentWorld.Tiles[x, y].Type)                                                       // Since sprites are under the tile denomination, we combine them.
+                                && FilterManager.SpriteIsNotAllowed(CurrentWorld.Tiles[x, y].Type))                                                 // Check if this block / sprite is not in the list.
                                 if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Hide)               showTiles = false;              // Hide blocks not in list.
                                 else if (FilterManager.CurrentFilterMode == FilterManager.FilterMode.Grayscale)     tileGrayscale = true;           // Grayscale blocks not in list.
 


### PR DESCRIPTION
## Added "Sprites" to The Advanced Filter.

![TE-AdvFilter-Sprites](https://github.com/user-attachments/assets/d88cf126-b943-4f07-bb3f-484a83663856)

## Fixed World Upgrading.

When upgrading worlds from `V0` or `V1` to `V2`, some world properties such as *World Seed* and *NPC Name* are null. This PR includes added checks and fixes to this issue restoring the ability to upgrade "old" worlds via TEdit.
  - Tested with a world file from `world v67`. Future checks may be needed for even older files.