### PR TITLE
Fixed AltC Path Issue.

### DIFF
--- a/src/TEdit/App.xaml.cs
+++ b/src/TEdit/App.xaml.cs
@@ -66,6 +66,9 @@ public partial class App : Application
 
     protected override void OnStartup(StartupEventArgs e)
     {
+        // Read settings immediately.
+        LoadAppSettings();
+
         Version = SemVersion.Parse(Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion, SemVersionStyles.Any);
         ErrorLogging.Initialize();
         AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
@@ -169,8 +172,6 @@ public partial class App : Application
         DispatcherHelper.Initialize();
         TaskFactoryHelper.Initialize();
 
-        LoadAppSettings();
-
         base.OnStartup(e);
     }
 
@@ -212,7 +213,7 @@ public partial class App : Application
 
         ClipboardBufferRenderer.ClipboardRenderSize = clipboardSize;
         ToolDefaultData.LoadSettings(xmlSettings.Elements("Tools"));
-        AltC = (string)xmlSettings.Element("AltC");
+        AltC = (string)(xmlSettings.Element("AltC") ?? xmlSettings.Element("App")?.Element("AltC")); // Handles either nesting.
         SteamUserId = (int?)xmlSettings.Element("SteamUserId") ?? null;
     }
 }

--- a/src/TEdit/DependencyChecker.cs
+++ b/src/TEdit/DependencyChecker.cs
@@ -225,13 +225,9 @@ public static class DependencyChecker
         return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), @"My Games\Terraria\Worlds");
     }
 
+    // Updated function restores user prompting.
     public static bool DirectoryHasContentFolder(string path)
-    {
-        if (!Directory.Exists(Path.Combine(path, "Content")))
-            return false;
-
-        return true;
-    }
+        => Directory.Exists(path);
 
     private static string BrowseForTerraria()
     {


### PR DESCRIPTION
Within Tedit5.X+, the `AltC` tag is never defined before its value is read, thus breaking alt content locations.