### PR TITLE
Fix git-cliff --ignore-tags breaking with v2.11.0

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -68,9 +68,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: >-
-            --verbose --latest --strip header
-            ${{ !contains(github.ref_name, '-') && '--ignore-tags "-(alpha|beta|rc)"' || '' }}
+          args: --verbose --latest --strip header
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -57,6 +57,7 @@ commit_parsers = [
     # Catch-all
     { message = ".*", group = "<!-- 9 -->📦 Other Changes" },
 ]
+ignore_tags = "-(alpha|beta|rc)"
 filter_commits = false
 topo_order = false
 sort_commits = "oldest"


### PR DESCRIPTION
## Summary
- Move `ignore_tags` regex into `cliff.toml` instead of passing via CLI `--ignore-tags` arg
- git-cliff v2.11.0 changed argument parsing — the shell word-splits `"-(alpha|beta|rc)"` causing `unexpected argument '-('` error

## Test plan
- [ ] Tag a test pre-release and verify the workflow completes successfully